### PR TITLE
Prep for wolfCrypt JNI 1.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+
+# Build directories
+build/
+lib/
+
+# Generated Javadocs
+docs/
+
+# Code signing key/alias info file
+codeSigning.properties
+

--- a/README.md
+++ b/README.md
@@ -114,3 +114,42 @@ Signing the JAR is important especially if using the JCE Provider with a JDK
 that requires JCE provider JAR's to be authenticated.  Please see
 README_JCE for more details.
 
+### Revision History
+---------
+
+********* wolfCrypt JNI Release 1.0.0 (7/10/2017)
+
+Release 1.0.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Bug fixes to JCE classes: Cipher, KeyAgreement (DH), Signature
+- JCE debug logging with wolfjce.debug system property
+- Additional unit tests for JCE provider
+- Conditional ant build for JNI and/or JCE
+- New ant targets with choice of debug or release builds
+
+********* wolfCrypt JNI Release 0.3 BETA
+
+Release 0.3 BETA of wolfCrypt JNI includes:
+
+- Support for ECC and DH key generation
+- Bug fixes regarding key import/export
+- Better argument sanitization at JNI level
+
+********* wolfCrypt JNI Release 0.2 BETA
+
+Release 0.2 BETA of wolfCrypt JNI includes:
+
+- Support for Android
+- Support for Oracle JDK/JVM
+- Support for code signing wolfcrypt-jni.jar file
+- Compatibility with non-FIPS wolfSSL and wolfCrypt builds
+- Bug fixes regarding releasing native resources
+- Test package changed to (com.wolfssl.provider.jce.test)
+
+********* wolfCrypt JNI Release 0.1 BETA
+
+Release 0.1 BETA of wolfCrypt JNI includes:
+
+- Initial JCE package
+- Support for OpenJDK
+

--- a/README_JCE.md
+++ b/README_JCE.md
@@ -115,26 +115,3 @@ Please email support@wolfssl.com with any questions or feedback.
 The wolfJCE User Manual (PDF), available from the wolfSSL website contains
 additional details on using the wolfCrypt JCE provider.
 
-### Revision History
----------
-
-0.1 BETA
-
-- Initial JCE package
-- Support for OpenJDK
-
-0.2 BETA
-
-- Support for Android
-- Support for Oracle JDK/JVM
-- Support for code signing wolfcrypt-jni.jar file
-- Compatibility with non-FIPS wolfSSL and wolfCrypt builds
-- Bug fixes regarding releasing native resources
-- Test package changed to (com.wolfssl.provider.jce.test)
-
-0.3 BETA
-
-- Support for ECC and DH key generation
-- Bug fixes regarding key import/export
-- Better argument sanitization at JNI level
-

--- a/build.xml
+++ b/build.xml
@@ -16,6 +16,11 @@
         $JUNIT_HOME/junit.jar
     </description>
 
+    <!-- versioning/manifest properties -->
+    <property name="implementation.vendor"  value="wolfSSL Inc." />
+    <property name="implementation.title"   value="wolfCrypt JNI" />
+    <property name="implementation.version" value="1.0" />
+
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />
     <property name="jni.dir" value="jni/include/" />
@@ -103,6 +108,14 @@
     <!-- create JAR with ONLY JNI classes, not to be used with JCE -->
     <target name="jar-jni" depends="compile">
         <jar jarfile="${lib.dir}/wolfcrypt-jni.jar">
+            <manifest>
+                <attribute name="Implementation-Title"
+                           value="${implementation.title}" />
+                <attribute name="Implementation-Version"
+                           value="${implementation.version}" />
+                <attribute name="Implementation-Vendor"
+                           value="${implementation.vendor}" />
+            </manifest>
             <fileset dir="${build.dir}">
                 <include name="com/wolfssl/wolfcrypt/*.class"/>
             </fileset>
@@ -112,6 +125,14 @@
     <!-- create JAR with JNI and JCE classes, use this when wanting JCE -->
     <target name="jar-jce" depends="compile">
         <jar jarfile="${lib.dir}/wolfcrypt-jni.jar" basedir="${build.dir}">
+            <manifest>
+                <attribute name="Implementation-Title"
+                           value="${implementation.title}" />
+                <attribute name="Implementation-Version"
+                           value="${implementation.version}" />
+                <attribute name="Implementation-Vendor"
+                           value="${implementation.vendor}" />
+            </manifest>
         </jar>
         <echo unless:set="sign.alias">WARNING: Skipping JAR signing, codeSigning.properties not found</echo>
     </target>


### PR DESCRIPTION
This PR is in prep for the wolfcrypt-jni-1.0.0 release and includes:

1. Adds several items to .gitignore

2. Adds title/vendor/version to build.xml, used to stamp JAR when created

3. Updates README with 1.0.0 notes