### PR TITLE
Fixed wrong hash codes and spelling. Updated error codes.

### DIFF
--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -34,37 +34,37 @@
 /* copy from cyassl/hmac.c */
 static INLINE int GetHashSizeByType(int type)
 {
-    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
-                      || type == SHA512 || type == BLAKE2B_ID))
+    if (!(type == WC_MD5 || type == WC_SHA    || type == WC_SHA256 || type == WC_SHA384
+                      || type == WC_SHA512 || type == BLAKE2B_ID))
         return BAD_FUNC_ARG;
 
     switch (type) {
         #ifndef NO_MD5
-        case MD5:
+        case WC_MD5:
             return MD5_DIGEST_SIZE;
         break;
         #endif
 
         #ifndef NO_SHA
-        case SHA:
+        case WC_SHA:
             return SHA_DIGEST_SIZE;
         break;
         #endif
         
         #ifndef NO_SHA256
-        case SHA256:
+        case WC_SHA256:
             return SHA256_DIGEST_SIZE;
         break;
         #endif
         
         #if defined(CYASSL_SHA384) || defined(WOLFSSL_SHA384)
-        case SHA384:
+        case WC_SHA384:
             return SHA384_DIGEST_SIZE;
         break;
         #endif
         
         #if defined(CYASSL_SHA512) || defined(WOLFSSL_SHA512)
-        case SHA512:
+        case WC_SHA512:
             return SHA512_DIGEST_SIZE;
         break;
         #endif

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -35,8 +35,8 @@ public class Hmac extends NativeStruct {
 	public static final int SHA = 4;
 	public static final int SHA224 = 5;
 	public static final int SHA256 = 6;
-	public static final int SHA384 = 12;
-	public static final int SHA512 = 13;
+	public static final int SHA384 = 7;
+	public static final int SHA512 = 8;
 	public static final int BLAKE2b = 14;
 
 	private WolfCryptState state = WolfCryptState.UNINITIALIZED;

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -31,13 +31,13 @@ import java.nio.ByteBuffer;
  */
 public class Hmac extends NativeStruct {
 
-	public static final int MD5 = 0;
-	public static final int SHA = 1;
-	public static final int SHA224 = 8;
-	public static final int SHA256 = 2;
-	public static final int SHA384 = 5;
-	public static final int SHA512 = 4;
-	public static final int BLAKE2b = 7;
+	public static final int MD5 = 3;
+	public static final int SHA = 4;
+	public static final int SHA224 = 5;
+	public static final int SHA256 = 6;
+	public static final int SHA384 = 12;
+	public static final int SHA512 = 13;
+	public static final int BLAKE2b = 14;
 
 	private WolfCryptState state = WolfCryptState.UNINITIALIZED;
 	private int type = -1;

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
@@ -28,117 +28,176 @@ public enum WolfCryptError {
     NO_ERROR_FOUND      (-1),
 
     /* error codes match <wolfssl>/wolfssl/wolfcrypt/error-crypt.h */
-    MAX_CODE_E          (-100),
-    OPEN_RAN_E          (-101),
-    READ_RAN_E          (-102),
-    WINCRYPT_E          (-103),
-    CRYPTGEN_E          (-104),
-    RAN_BLOCK_E         (-105),
-    BAD_MUTEX_E         (-106),
+    MAX_CODE_E          (-100),  /* errors -101 - -299 */
+    OPEN_RAN_E          (-101),  /* opening random device error */
+    READ_RAN_E          (-102),  /* reading random device error */
+    WINCRYPT_E          (-103),  /* windows crypt init error */
+    CRYPTGEN_E          (-104),  /* windows crypt generation error */
+    RAN_BLOCK_E         (-105),  /* reading random device would block */
+    BAD_MUTEX_E         (-106),  /* Bad mutex operation */
+    WC_TIMEOUT_E        (-107),  /* timeout error */
+    WC_PENDING_E        (-108),  /* wolfCrypt operation pending (would block) */
+    WC_NOT_PENDING_E    (-109),  /* wolfCrypt operation not pending */
 
-    MP_INIT_E           (-110),
-    MP_READ_E           (-111),
-    MP_EXPTMOD_E        (-112),
-    MP_TO_E             (-113),
-    MP_SUB_E            (-114),
-    MP_ADD_E            (-115),
-    MP_MUL_E            (-116),
-    MP_MULMOD_E         (-117),
-    MP_MOD_E            (-118),
-    MP_INVMOD_E         (-119),
-    MP_CMP_E            (-120),
-    MP_ZERO_E           (-121),
+    MP_INIT_E           (-110),  /* mp_init error state */
+    MP_READ_E           (-111),  /* mp_read error state */
+    MP_EXPTMOD_E        (-112),  /* mp_exptmod error state */
+    MP_TO_E             (-113),  /* mp_to_xxx error state, can't convert */
+    MP_SUB_E            (-114),  /* mp_sub error state, can't subtract */
+    MP_ADD_E            (-115),  /* mp_add error state, can't add */
+    MP_MUL_E            (-116),  /* mp_mul error state, can't multiply */
+    MP_MULMOD_E         (-117),  /* mp_mulmod error state, can't multiply mod */
+    MP_MOD_E            (-118),  /* mp_mod error state, can't mod */
+    MP_INVMOD_E         (-119),  /* mp_invmod error state, can't inv mod */
+    MP_CMP_E            (-120),  /* mp_cmp error state */
+    MP_ZERO_E           (-121),  /* got a mp zero result, not expected */
 
-    MEMORY_E            (-125),
+    MEMORY_E            (-125),  /* out of memory error */
+    VAR_STATE_CHANGE_E  (-126),  /* var state modified by different thread */
 
-    RSA_WRONG_TYPE_E    (-130),
-    RSA_BUFFER_E        (-131),
+    RSA_WRONG_TYPE_E    (-130),  /* RSA wrong block type for RSA function */
+    RSA_BUFFER_E        (-131),  /* RSA buffer error, output too small or
+                                  input too large */
+    BUFFER_E            (-132),  /* output buffer too small or input too large */
+    ALGO_ID_E           (-133),  /* setting algo id error */
+    PUBLIC_KEY_E        (-134),  /* setting public key error */
+    DATE_E              (-135),  /* setting date validity error */
+    SUBJECT_E           (-136),  /* setting subject name error */
+    ISSUER_E            (-137),  /* setting issuer  name error */
+    CA_TRUE_E           (-138),  /* setting CA basic constraint true error */
+    EXTENSIONS_E        (-139),  /* setting extensions error */
 
-    BUFFER_E            (-132),
-    ALGO_ID_E           (-133),
-    PUBLIC_KEY_E        (-134),
-    DATE_E              (-135),
-    SUBJECT_E           (-136),
-    ISSUER_E            (-137),
-    CA_TRUE_E           (-138),
-    EXTENSIONS_E        (-139),
+    ASN_PARSE_E         (-140),  /* ASN parsing error, invalid input */
+    ASN_VERSION_E       (-141),  /* ASN version error, invalid number */
+    ASN_GETINT_E        (-142),  /* ASN get big int error, invalid data */
+    ASN_RSA_KEY_E       (-143),  /* ASN key init error, invalid input */
+    ASN_OBJECT_ID_E     (-144),  /* ASN object id error, invalid id */
+    ASN_TAG_NULL_E      (-145),  /* ASN tag error, not null */
+    ASN_EXPECT_0_E      (-146),  /* ASN expect error, not zero */
+    ASN_BITSTR_E        (-147),  /* ASN bit string error, wrong id */
+    ASN_UNKNOWN_OID_E   (-148),  /* ASN oid error, unknown sum id */
+    ASN_DATE_SZ_E       (-149),  /* ASN date error, bad size */
+    ASN_BEFORE_DATE_E   (-150),  /* ASN date error, current date before */
+    ASN_AFTER_DATE_E    (-151),  /* ASN date error, current date after */
+    ASN_SIG_OID_E       (-152),  /* ASN signature error, mismatched oid */
+    ASN_TIME_E          (-153),  /* ASN time error, unknown time type */
+    ASN_INPUT_E         (-154),  /* ASN input error, not enough data */
+    ASN_SIG_CONFIRM_E   (-155),  /* ASN sig error, confirm failure */
+    ASN_SIG_HASH_E      (-156),  /* ASN sig error, unsupported hash type */
+    ASN_SIG_KEY_E       (-157),  /* ASN sig error, unsupported key type */
+    ASN_DH_KEY_E        (-158),  /* ASN key init error, invalid input */
+    ASN_NTRU_KEY_E      (-159),  /* ASN ntru key decode error, invalid input */
+    ASN_CRIT_EXT_E      (-160),  /* ASN unsupported critical extension */
+    ASN_ALT_NAME_E      (-161),  /* ASN alternate name error */
+    ASN_NO_PEM_HEADER   (-162),  /* ASN no PEM header found */
 
-    ASN_PARSE_E         (-140),
-    ASN_VERSION_E       (-141),
-    ASN_GETINT_E        (-142),
-    ASN_RSA_KEY_E       (-143),
-    ASN_OBJECT_ID_E     (-144),
-    ASN_TAG_NULL_E      (-145),
-    ASN_EXPECT_0_E      (-146),
-    ASN_BITSTR_E        (-147),
-    ASN_UNKNOWN_OID_E   (-148),
-    ASN_DATE_SZ_E       (-149),
-    ASN_BEFORE_DATE_E   (-150),
-    ASN_AFTER_DATE_E    (-151),
-    ASN_SIG_OID_E       (-152),
-    ASN_TIME_E          (-153),
-    ASN_INPUT_E         (-154),
-    ASN_SIG_CONFIRM_E   (-155),
-    ASN_SIG_HASH_E      (-156),
-    ASN_SIG_KEY_E       (-157),
-    ASN_DH_KEY_E        (-158),
-    ASN_NTRU_KEY_E      (-159),
-    ASN_CRIT_EXT_E      (-160),
+    ECC_BAD_ARG_E       (-170),  /* ECC input argument of wrong type */
+    ASN_ECC_KEY_E       (-171),  /* ASN ECC bad input */
+    ECC_CURVE_OID_E     (-172),  /* Unsupported ECC OID curve type */
+    BAD_FUNC_ARG        (-173),  /* Bad function argument provided */
+    NOT_COMPILED_IN     (-174),  /* Feature not compiled in */
+    UNICODE_SIZE_E      (-175),  /* Unicode password too big */
+    NO_PASSWORD         (-176),  /* no password provided by user */
+    ALT_NAME_E          (-177),  /* alt name size problem, too big */
+    BAD_OCSP_RESPONDER  (-178),  /* missing key usage extensions */
 
-    ECC_BAD_ARG_E       (-170),
-    ASN_ECC_KEY_E       (-171),
-    ECC_CURVE_OID_E     (-172),
-    BAD_FUNC_ARG        (-173),
-    NOT_COMPILED_IN     (-174),
-    UNICODE_SIZE_E      (-175),
-    NO_PASSWORD         (-176),
-    ALT_NAME_E          (-177),
+    AES_GCM_AUTH_E      (-180),  /* AES-GCM Authentication check failure */
+    AES_CCM_AUTH_E      (-181),  /* AES-CCM Authentication check failure */
 
-    AES_GCM_AUTH_E      (-180),
-    AES_CCM_AUTH_E      (-181),
+    ASYNC_INIT_E        (-182),  /* Async Init type error */
 
-    CAVIUM_INIT_E       (-182),
+    COMPRESS_INIT_E     (-183),  /* Compress init error */
+    COMPRESS_E          (-184),  /* Compress error */
+    DECOMPRESS_INIT_E   (-185),  /* DeCompress init error */
+    DECOMPRESS_E        (-186),  /* DeCompress error */
 
-    COMPRESS_INIT_E     (-183),
-    COMPRESS_E          (-184),
-    DECOMPRESS_INIT_E   (-185),
-    DECOMPRESS_E        (-186),
+    BAD_ALIGN_E          (-187),  /* Bad alignment for operation, no alloc */
+    ASN_NO_SIGNER_E      (-188),  /* ASN no signer to confirm failure */
+    ASN_CRL_CONFIRM_E    (-189),  /* ASN CRL signature confirm failure */
+    ASN_CRL_NO_SIGNER_E  (-190),  /* ASN CRL no signer to confirm failure */
+    ASN_OCSP_CONFIRM_E   (-191),  /* ASN OCSP signature confirm failure */
 
-    BAD_ALIGN_E         (-187),
-    ASN_NO_SIGNER_E     (-188),
-    ASN_CRL_CONFIRM_E   (-189),
-    ASN_CRL_NO_SIGNER_E (-190),
-    ASN_OCSP_CONFIRM_E  (-191),
+    BAD_STATE_E          (-192),  /* Bad state operation */
+    BAD_PADDING_E        (-193),  /* Bad padding, msg not correct length  */
 
-    BAD_ENC_STATE_E     (-192),
-    BAD_PADDING_E       (-193),
+    REQ_ATTRIBUTE_E      (-194),  /* setting cert request attributes error */
 
-    REQ_ATTRIBUTE_E     (-194),
+    PKCS7_OID_E          (-195),  /* PKCS#7, mismatched OID error */
+    PKCS7_RECIP_E        (-196),  /* PKCS#7, recipient error */
+    FIPS_NOT_ALLOWED_E   (-197),  /* FIPS not allowed error */
+    ASN_NAME_INVALID_E   (-198),  /* ASN name constraint error */
 
-    PKCS7_OID_E         (-195),
-    PKCS7_RECIP_E       (-196),
-    FIPS_NOT_ALLOWED_E  (-197),
-    ASN_NAME_INVALID_E  (-198),
+    RNG_FAILURE_E        (-199),  /* RNG Failed, Reinitialize */
+    HMAC_MIN_KEYLEN_E    (-200),  /* FIPS Mode HMAC Minimum Key Length error */
+    RSA_PAD_E            (-201),  /* RSA Padding Error */
+    LENGTH_ONLY_E        (-202),  /* Returning output length only */
 
-    RNG_FAILURE_E       (-199),
-    HMAC_MIN_KEYLEN_E   (-200),
-    RSA_PAD_E           (-201),
-    LENGTH_ONLY_E       (-202),
+    IN_CORE_FIPS_E       (-203),  /* In Core Integrity check failure */
+    AES_KAT_FIPS_E       (-204),  /* AES KAT failure */
+    DES3_KAT_FIPS_E      (-205),  /* DES3 KAT failure */
+    HMAC_KAT_FIPS_E      (-206),  /* HMAC KAT failure */
+    RSA_KAT_FIPS_E       (-207),  /* RSA KAT failure */
+    DRBG_KAT_FIPS_E      (-208),  /* HASH DRBG KAT failure */
+    DRBG_CONT_FIPS_E     (-209),  /* HASH DRBG Continuous test failure */
+    AESGCM_KAT_FIPS_E    (-210),  /* AESGCM KAT failure */
+    THREAD_STORE_KEY_E   (-211),  /* Thread local storage key create failure */
+    THREAD_STORE_SET_E   (-212),  /* Thread local storage key set failure */
 
-    IN_CORE_FIPS_E      (-203),
-    AES_KAT_FIPS_E      (-204),
-    DES3_KAT_FIPS_E     (-205),
-    HMAC_KAT_FIPS_E     (-206),
-    RSA_KAT_FIPS_E      (-207),
-    DRBG_KAT_FIPS_E     (-208),
-    DRBG_CONT_FIPS_E    (-209),
-    AESGCM_KAT_FIPS_E   (-210),
-    THREAD_STORE_KEY_E  (-211),
-    THREAD_STORE_SET_E  (-212),
+    MAC_CMP_FAILED_E     (-213),  /* MAC comparison failed */
+    IS_POINT_E           (-214),  /* ECC is point on curve failed */
+    ECC_INF_E            (-215),  /* ECC point infinity error */
+    ECC_PRIV_KEY_E       (-216),  /* ECC private key not valid error */
+    ECC_OUT_OF_RANGE_E   (-217),  /* ECC key component out of range */
 
-    MAC_CMP_FAILED_E    (-213),
+    SRP_CALL_ORDER_E     (-218),  /* SRP function called in the wrong order. */
+    SRP_VERIFY_E         (-219),  /* SRP proof verification failed. */
+    SRP_BAD_KEY_E        (-220),  /* SRP bad ephemeral values. */
 
-    MIN_CODE_E          (-300);
+    ASN_NO_SKID          (-221),  /* ASN no Subject Key Identifier found */
+    ASN_NO_AKID          (-222),  /* ASN no Authority Key Identifier found */
+    ASN_NO_KEYUSAGE      (-223),  /* ASN no Key Usage found */
+    SKID_E               (-224),  /* setting Subject Key Identifier error */
+    AKID_E               (-225),  /* setting Authority Key Identifier error */
+    KEYUSAGE_E           (-226),  /* Bad Key Usage value */
+    CERTPOLICIES_E       (-227),  /* setting Certificate Policies error */
+
+    WC_INIT_E            (-228),  /* wolfcrypt failed to initialize */
+    SIG_VERIFY_E         (-229),  /* wolfcrypt signature verify error */
+    BAD_COND_E           (-230),  /* Bad condition variable operation */
+    SIG_TYPE_E           (-231),  /* Signature Type not enabled/available */
+    HASH_TYPE_E          (-232),  /* Hash Type not enabled/available */
+
+    WC_KEY_SIZE_E        (-234),  /* Key size error, either too small or large */
+    ASN_COUNTRY_SIZE_E   (-235),  /* ASN Cert Gen, invalid country code size */
+    MISSING_RNG_E        (-236),  /* RNG required but not provided */
+    ASN_PATHLEN_SIZE_E   (-237),  /* ASN CA path length too large error */
+    ASN_PATHLEN_INV_E    (-238),  /* ASN CA path length inversion error */
+
+    BAD_KEYWRAP_ALG_E    (-239),
+    BAD_KEYWRAP_IV_E     (-240),  /* Decrypted AES key wrap IV incorrect */
+    WC_CLEANUP_E         (-241),  /* wolfcrypt cleanup failed */
+    ECC_CDH_KAT_FIPS_E   (-242),  /* ECC CDH Known Answer Test failure */
+    DH_CHECK_PUB_E       (-243),  /* DH Check Pub Key error */
+    BAD_PATH_ERROR       (-244),  /* Bad path for opendir */
+
+    ASYNC_OP_E           (-245),  /* Async operation error */
+
+    ECC_PRIVATEONLY_E    (-246),  /* Invalid use of private only ECC key*/
+    EXTKEYUSAGE_E        (-247),  /* Bad Extended Key Usage value */
+    WC_HW_E              (-248),  /* Error with hardware crypto use */
+    WC_HW_WAIT_E         (-249),  /* Hardware waiting on resource */
+
+    PSS_SALTLEN_E        (-250),  /* PSS length of salt is to long for hash */
+    PRIME_GEN_E          (-251),  /* Failure finding a prime. */
+    BER_INDEF_E          (-252),  /* Cannot decode indefinite length BER. */
+    RSA_OUT_OF_RANGE_E   (-253),  /* Ciphertext to decrypt out of range. */
+    RSAPSS_PAT_FIPS_E    (-254),  /* RSA-PSS PAT failure */
+    ECDSA_PAT_FIPS_E     (-255),  /* ECDSA PAT failure */
+    DH_KAT_FIPS_E        (-256),  /* DH KAT failure */
+
+    WC_LAST_E            (-256),  /* Update this to indicate last error */
+
+    MIN_CODE_E           (-300);   /* errors -101 - -299 */
 
     private final int code;
 


### PR DESCRIPTION
 **jni/jni_hmac.c**
The changes to jni_hmac.c fixed compile time errors where the hash types without WC prefix were not found.

 **src/main/java/com/wolfssl/wolfcrypt/Hmac.java**
The changes made to Hmac.java fixed 1 failure and 2 errors during the "ant test" unit tests for wolfcrypt-jni.
The hash codes in the java code mismatched those expected in the C code.  

Tests such as testMacSha512SingleUpdate() would fail because the code sent in for SHA512 was really the one for SHA256 and caused an expected array length error.

Steps to reproduce the unit test failure:

- configure wolfssl proper with at least --enable-keygen
- run "make" inside wolfcrypt-jni base directory
- run "ant build-jce-debug"
- run "ant test"
- read "wolfcrypt-jni/build/reports/TEST-com.wolfssl.provider.jce.test.WolfJCETestSuite.txt"

**src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java**
These changes update error codes to match those in <wolfssl>/wolfssl/wolfcrypt/error-crypt.h.  This was the first step taken to fix the rest of the ant test errors that stated "No error code found in JNI WolfCryptError enum". Although this error still persisted.
