### PR TITLE
override allows for CC/LD flags to be given as command line arguement…

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,9 +10,9 @@ TARGET    = $(OUT_PATH)/libwolfcryptjni.jnilib
 
 JAVA_HOME = $(shell /usr/libexec/java_home)
 CC        = gcc
-CCFLAGS   = -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
+override CCFLAGS   += -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
 			-I$(INC_PATH)
-LDFLAGS   = -dynamiclib -framework JavaVM -lwolfssl
+override LDFLAGS   += -dynamiclib -framework JavaVM -lwolfssl
 
 all: $(TARGET)
 

--- a/makefile.linux
+++ b/makefile.linux
@@ -10,9 +10,9 @@ TARGET    = $(OUT_PATH)/libwolfcryptjni.so
 
 JAVA_HOME = $(shell readlink -f /usr/bin/javac | sed "s:/bin/javac::")
 CC        = gcc
-CCFLAGS   = -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux \
+override CCFLAGS   += -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux \
 			-I$(INC_PATH) -fPIC
-LDFLAGS   = -Wl,--no-as-needed -lwolfssl -shared
+override LDFLAGS   += -Wl,--no-as-needed -lwolfssl -shared
 
 all: $(TARGET)
 

--- a/makefile.macosx
+++ b/makefile.macosx
@@ -10,9 +10,9 @@ TARGET    = $(OUT_PATH)/libwolfcryptjni.jnilib
 
 JAVA_HOME = $(shell /usr/libexec/java_home)
 CC        = gcc
-CCFLAGS   = -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
+override CCFLAGS   += -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
 			-I$(INC_PATH)
-LDFLAGS   = -dynamiclib -framework JavaVM -lwolfssl
+override LDFLAGS   += -dynamiclib -framework JavaVM -lwolfssl
 
 all: $(TARGET)
 


### PR DESCRIPTION
This was needed for Jenkins environment and to keep portability of makefile.