### PR TITLE
Dynamic hash codes hmac

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Hmac.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Hmac.h
@@ -9,20 +9,6 @@ extern "C" {
 #endif
 #undef com_wolfssl_wolfcrypt_Hmac_NULL
 #define com_wolfssl_wolfcrypt_Hmac_NULL 0LL
-#undef com_wolfssl_wolfcrypt_Hmac_MD5
-#define com_wolfssl_wolfcrypt_Hmac_MD5 0L
-#undef com_wolfssl_wolfcrypt_Hmac_SHA
-#define com_wolfssl_wolfcrypt_Hmac_SHA 1L
-#undef com_wolfssl_wolfcrypt_Hmac_SHA224
-#define com_wolfssl_wolfcrypt_Hmac_SHA224 8L
-#undef com_wolfssl_wolfcrypt_Hmac_SHA256
-#define com_wolfssl_wolfcrypt_Hmac_SHA256 2L
-#undef com_wolfssl_wolfcrypt_Hmac_SHA384
-#define com_wolfssl_wolfcrypt_Hmac_SHA384 5L
-#undef com_wolfssl_wolfcrypt_Hmac_SHA512
-#define com_wolfssl_wolfcrypt_Hmac_SHA512 4L
-#undef com_wolfssl_wolfcrypt_Hmac_BLAKE2b
-#define com_wolfssl_wolfcrypt_Hmac_BLAKE2b 7L
 /*
  * Class:     com_wolfssl_wolfcrypt_Hmac
  * Method:    wc_HmacSetKey
@@ -70,6 +56,54 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacFinal
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSizeByType
   (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeMd5
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeMd5
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeSha
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeSha256
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha256
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeSha384
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha384
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeSha512
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha512
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    getCodeBlake2b
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeBlake2b
+  (JNIEnv *, jclass);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Hmac

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -299,3 +299,57 @@ Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSizeByType(
 
     return result;
 }
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeMd5(
+        JNIEnv* env, jobject this)
+{
+    jint result = WC_MD5;
+    LogStr("WC_MD5 = %d\n", result);
+    return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha(
+        JNIEnv* env, jobject this)
+{
+    jint result = WC_SHA;
+    LogStr("WC_SHA = %d\n", result);
+    return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha256(
+        JNIEnv* env, jobject this)
+{
+    jint result = WC_SHA256;
+    LogStr("WC_SHA256 = %d\n", result);
+    return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha384(
+        JNIEnv* env, jobject this)
+{
+    jint result = WC_SHA384;
+    LogStr("WC_SHA384 = %d\n", result);
+    return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha512(
+        JNIEnv* env, jobject this)
+{
+    jint result = WC_SHA512;
+    LogStr("WC_SHA512 = %d\n", result);
+    return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_wolfssl_wolfcrypt_Hmac_getCodeBlake2b(
+        JNIEnv* env, jobject this)
+{
+    jint result = BLAKE2B_ID;
+    LogStr("BLAKE2B_ID = %d", result);
+    return result;
+}

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -34,37 +34,37 @@
 /* copy from cyassl/hmac.c */
 static WC_INLINE int GetHashSizeByType(int type)
 {
-    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
-                      || type == SHA512 || type == BLAKE2B_ID))
+    if (!(type == WC_MD5 || type == WC_SHA    || type == WC_SHA256 || type == WC_SHA384
+                      || type == WC_SHA512 || type == BLAKE2B_ID))
         return BAD_FUNC_ARG;
 
     switch (type) {
         #ifndef NO_MD5
-        case MD5:
+        case WC_MD5:
             return MD5_DIGEST_SIZE;
         break;
         #endif
 
         #ifndef NO_SHA
-        case SHA:
+        case WC_SHA:
             return SHA_DIGEST_SIZE;
         break;
         #endif
         
         #ifndef NO_SHA256
-        case SHA256:
+        case WC_SHA256:
             return SHA256_DIGEST_SIZE;
         break;
         #endif
         
         #if defined(CYASSL_SHA384) || defined(WOLFSSL_SHA384)
-        case SHA384:
+        case WC_SHA384:
             return SHA384_DIGEST_SIZE;
         break;
         #endif
         
         #if defined(CYASSL_SHA512) || defined(WOLFSSL_SHA512)
-        case SHA512:
+        case WC_SHA512:
             return SHA512_DIGEST_SIZE;
         break;
         #endif

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -32,7 +32,7 @@
 #include <wolfcrypt_jni_debug.h>
 
 /* copy from cyassl/hmac.c */
-static INLINE int GetHashSizeByType(int type)
+static WC_INLINE int GetHashSizeByType(int type)
 {
     if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
                       || type == SHA512 || type == BLAKE2B_ID))

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -31,11 +31,15 @@
 /* #define WOLFCRYPT_JNI_DEBUG_ON */
 #include <wolfcrypt_jni_debug.h>
 
+#ifdef HAVE_FIPS
+#define WC_INLINE INLINE
+#endif
+
 /* copy from cyassl/hmac.c */
 static WC_INLINE int GetHashSizeByType(int type)
 {
-    if (!(type == WC_MD5 || type == WC_SHA    || type == WC_SHA256 || type == WC_SHA384
-                      || type == WC_SHA512 || type == BLAKE2B_ID))
+    if (!(type == WC_MD5 || type == WC_SHA || type == WC_SHA256
+            || type == WC_SHA384 || type == WC_SHA512 || type == BLAKE2B_ID))
         return BAD_FUNC_ARG;
 
     switch (type) {

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -31,147 +31,198 @@ import java.nio.ByteBuffer;
  */
 public class Hmac extends NativeStruct {
 
-	public static final int MD5 = 0;
-	public static final int SHA = 1;
-	public static final int SHA224 = 8;
-	public static final int SHA256 = 2;
-	public static final int SHA384 = 5;
-	public static final int SHA512 = 4;
-	public static final int BLAKE2b = 7;
+    private enum hashType {
+        MD5, SHA, SHA256, SHA384, SHA512, BLAKE2b;
+    }
 
-	private WolfCryptState state = WolfCryptState.UNINITIALIZED;
-	private int type = -1;
-	private byte[] key;
+    public static final int MD5     = getHashCode(hashType.MD5);
+    public static final int SHA     = getHashCode(hashType.SHA);
+    public static final int SHA256  = getHashCode(hashType.SHA256);
+    public static final int SHA384  = getHashCode(hashType.SHA384);
+    public static final int SHA512  = getHashCode(hashType.SHA512);
+    public static final int BLAKE2b = getHashCode(hashType.BLAKE2b);
 
-	public Hmac() {
-	}
+    private WolfCryptState state = WolfCryptState.UNINITIALIZED;
+    private int type = -1;
+    private byte[] key;
 
-	public Hmac(int type, byte[] key) {
-		setKey(type, key);
-	}
+    public Hmac() {
+    }
 
-	private native void wc_HmacSetKey(int type, byte[] key);
+    public Hmac(int type, byte[] key) {
+        setKey(type, key);
+    }
 
-	private native void wc_HmacUpdate(byte data);
+    private native void wc_HmacSetKey(int type, byte[] key);
 
-	private native void wc_HmacUpdate(byte[] data, int offset, int length);
+    private native void wc_HmacUpdate(byte data);
 
-	private native void wc_HmacUpdate(ByteBuffer data, int offset, int length);
+    private native void wc_HmacUpdate(byte[] data, int offset, int length);
 
-	private native byte[] wc_HmacFinal();
+    private native void wc_HmacUpdate(ByteBuffer data, int offset, int length);
 
-	private native int wc_HmacSizeByType(int type);
+    private native byte[] wc_HmacFinal();
 
-	protected native long mallocNativeStruct() throws OutOfMemoryError;
+    private native int wc_HmacSizeByType(int type);
 
-	public void setKey(int type, byte[] key) {
-		wc_HmacSetKey(type, key);
+    private native static int getCodeMd5();
 
-		this.type = type;
-		this.key = key;
+    private native static int getCodeSha();
 
-		state = WolfCryptState.READY;
-	}
+    private native static int getCodeSha256();
 
-	public void reset() {
-		if (state == WolfCryptState.READY) {
-			setKey(type, key);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    private native static int getCodeSha384();
 
-	public void update(byte data) {
-		if (state == WolfCryptState.READY) {
-			wc_HmacUpdate(data);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    private native static int getCodeSha512();
 
-	public void update(byte[] data) {
-		if (state == WolfCryptState.READY) {
-			wc_HmacUpdate(data, 0, data.length);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    private native static int getCodeBlake2b();
 
-	public void update(byte[] data, int offset, int length) {
-		if (state == WolfCryptState.READY) {
-			wc_HmacUpdate(data, offset, length);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    protected native long mallocNativeStruct() throws OutOfMemoryError;
 
-	public void update(ByteBuffer data) {
-		if (state == WolfCryptState.READY) {
-			int offset = data.position();
-			int length = data.remaining();
+    public void setKey(int type, byte[] key) {
+        wc_HmacSetKey(type, key);
+        this.type = type;
+        this.key = key;
 
-			wc_HmacUpdate(data, offset, length);
+        state = WolfCryptState.READY;
+    }
 
-			data.position(offset + length);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    public void reset() {
+        if (state == WolfCryptState.READY) {
+            setKey(type, key);
+        } else {
+            throw new IllegalStateException(
+                "No available key to perform the opperation.");
+        }
+    }
 
-	public byte[] doFinal() {
-		if (state == WolfCryptState.READY) {
-			return wc_HmacFinal();
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    public void update(byte data) {
+        if (state == WolfCryptState.READY) {
+            wc_HmacUpdate(data);
+        } else {
+            throw new IllegalStateException(
+                "No available key to perform the opperation.");
+        }
+    }
 
-	public byte[] doFinal(byte[] data) {
-		if (state == WolfCryptState.READY) {
-			update(data);
-			return wc_HmacFinal();
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+    public void update(byte[] data) {
+        if (state == WolfCryptState.READY) {
+            wc_HmacUpdate(data, 0, data.length);
+        } else {
+            throw new IllegalStateException(
+                "No available key to perform the opperation.");
+        }
+    }
 
-	public String getAlgorithm() {
-		if (state == WolfCryptState.READY) {
-			switch (type) {
-				case MD5:
-					return "HmacMD5";
-				case SHA224:
-					return "HmacSHA224";
-				case SHA256:
-					return "HmacSHA256";
-				case SHA384:
-					return "HmacSHA384";
-				case SHA512:
-					return "HmacSHA512";
-				case BLAKE2b:
-					return "HmacBLAKE2b";
-			}
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
+    public void update(byte[] data, int offset, int length) {
+        if (state == WolfCryptState.READY) {
+            wc_HmacUpdate(data, offset, length);
+        } else {
+            throw new IllegalStateException(
+                    "No available key to perform the opperation.");
+        }
+    }
 
-		return "";
-	}
+    public void update(ByteBuffer data) {
+        if (state == WolfCryptState.READY) {
+            int offset = data.position();
+            int length = data.remaining();
 
-	public int getMacLength() {
-		if (state == WolfCryptState.READY) {
-			return wc_HmacSizeByType(type);
-		} else {
-			throw new IllegalStateException(
-					"No available key to perform the opperation.");
-		}
-	}
+            wc_HmacUpdate(data, offset, length);
+
+            data.position(offset + length);
+        } else {
+            throw new IllegalStateException(
+                    "No available key to perform the opperation.");
+        }
+    }
+
+    public byte[] doFinal() {
+        if (state == WolfCryptState.READY) {
+            return wc_HmacFinal();
+        } else {
+            throw new IllegalStateException(
+                    "No available key to perform the opperation.");
+        }
+    }
+
+    public byte[] doFinal(byte[] data) {
+        if (state == WolfCryptState.READY) {
+            update(data);
+            return wc_HmacFinal();
+        } else {
+            throw new IllegalStateException(
+                    "No available key to perform the opperation.");
+        }
+    }
+
+    public String getAlgorithm() {
+        if (state == WolfCryptState.READY) {
+
+            if (type == MD5) {
+                return "HmacMD5";
+            } 
+            else if (type == SHA256) {
+                return "HmacSHA256";
+            }
+            else if (type == SHA384) {
+                return "HmacSHA384";
+            }
+            else if (type == SHA512) {
+                return "HmacSHA512";
+            }
+            else if (type == BLAKE2b) {
+                return "HmacBLAKE2b";
+            } else {
+                return "";
+            }
+
+        } else {
+            throw new IllegalStateException(
+                "No available key to perform the opperation.");
+        }
+    }
+
+    public int getMacLength() {
+        if (state == WolfCryptState.READY) {
+            return wc_HmacSizeByType(type);
+        } else {
+            throw new IllegalStateException(
+                "No available key to perform the opperation.");
+        }
+    }
+
+    private static int getHashCode(hashType hash) {
+        int ret = -1;
+        switch (hash) {
+            case MD5:
+                ret = getCodeMd5();
+                break;
+            case SHA:
+                ret = getCodeSha();
+                break;
+            case SHA256:
+                ret = getCodeSha256();
+                break;
+            case SHA384:
+                ret = getCodeSha384();
+                break;
+            case SHA512:
+                ret = getCodeSha512();
+                break;
+            case BLAKE2b:
+                ret = getCodeBlake2b();
+                break;
+            default:
+                throw new IllegalStateException(
+                        "Invalid hash type.");
+        }
+
+        if (ret < 0) {
+            throw new IllegalStateException(
+                    "Hash code not found.");
+        }
+
+        return ret;
+    }
 }

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -21,6 +21,7 @@
 
 package com.wolfssl.wolfcrypt;
 
+import com.wolfssl.wolfcrypt.WolfCrypt;
 import java.nio.ByteBuffer;
 
 /**
@@ -32,15 +33,15 @@ import java.nio.ByteBuffer;
 public class Hmac extends NativeStruct {
 
     private enum hashType {
-        MD5, SHA, SHA256, SHA384, SHA512, BLAKE2b;
+        typeMD5, typeSHA, typeSHA256, typeSHA384, typeSHA512, typeBLAKE2b;
     }
 
-    public static final int MD5     = getHashCode(hashType.MD5);
-    public static final int SHA     = getHashCode(hashType.SHA);
-    public static final int SHA256  = getHashCode(hashType.SHA256);
-    public static final int SHA384  = getHashCode(hashType.SHA384);
-    public static final int SHA512  = getHashCode(hashType.SHA512);
-    public static final int BLAKE2b = getHashCode(hashType.BLAKE2b);
+    public static final int MD5     = getHashCode(hashType.typeMD5);
+    public static final int SHA     = getHashCode(hashType.typeSHA);
+    public static final int SHA256  = getHashCode(hashType.typeSHA256);
+    public static final int SHA384  = getHashCode(hashType.typeSHA384);
+    public static final int SHA512  = getHashCode(hashType.typeSHA512);
+    public static final int BLAKE2b = getHashCode(hashType.typeBLAKE2b);
 
     private WolfCryptState state = WolfCryptState.UNINITIALIZED;
     private int type = -1;
@@ -193,36 +194,21 @@ public class Hmac extends NativeStruct {
     }
 
     private static int getHashCode(hashType hash) {
-        int ret = -1;
         switch (hash) {
-            case MD5:
-                ret = getCodeMd5();
-                break;
-            case SHA:
-                ret = getCodeSha();
-                break;
-            case SHA256:
-                ret = getCodeSha256();
-                break;
-            case SHA384:
-                ret = getCodeSha384();
-                break;
-            case SHA512:
-                ret = getCodeSha512();
-                break;
-            case BLAKE2b:
-                ret = getCodeBlake2b();
-                break;
+            case typeMD5:
+                return getCodeMd5();
+            case typeSHA:
+                return getCodeSha();
+            case typeSHA256:
+                return getCodeSha256();
+            case typeSHA384:
+                return getCodeSha384();
+            case typeSHA512:
+                return getCodeSha512();
+            case typeBLAKE2b:
+                return getCodeBlake2b();
             default:
-                throw new IllegalStateException(
-                        "Invalid hash type.");
+                return WolfCrypt.FAILURE;
         }
-
-        if (ret < 0) {
-            throw new IllegalStateException(
-                    "Hash code not found.");
-        }
-
-        return ret;
     }
 }

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCrypt.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCrypt.java
@@ -30,6 +30,7 @@ package com.wolfssl.wolfcrypt;
 public class WolfCrypt extends WolfObject {
 
 	public static final int SUCCESS = 0;
+    public static final int FAILURE = -1;
 
 	public static final int SIZE_OF_128_BITS = 16;
 	public static final int SIZE_OF_160_BITS = 20;

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCrypt.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCrypt.java
@@ -29,18 +29,18 @@ package com.wolfssl.wolfcrypt;
  */
 public class WolfCrypt extends WolfObject {
 
-	public static final int SUCCESS = 0;
+    public static final int SUCCESS = 0;
     public static final int FAILURE = -1;
 
-	public static final int SIZE_OF_128_BITS = 16;
-	public static final int SIZE_OF_160_BITS = 20;
-	public static final int SIZE_OF_192_BITS = 24;
-	public static final int SIZE_OF_256_BITS = 32;
-	public static final int SIZE_OF_384_BITS = 48;
-	public static final int SIZE_OF_512_BITS = 64;
-	public static final int SIZE_OF_1024_BITS = 128;
-	public static final int SIZE_OF_2048_BITS = 256;
+    public static final int SIZE_OF_128_BITS = 16;
+    public static final int SIZE_OF_160_BITS = 20;
+    public static final int SIZE_OF_192_BITS = 24;
+    public static final int SIZE_OF_256_BITS = 32;
+    public static final int SIZE_OF_384_BITS = 48;
+    public static final int SIZE_OF_512_BITS = 64;
+    public static final int SIZE_OF_1024_BITS = 128;
+    public static final int SIZE_OF_2048_BITS = 256;
 
-	private WolfCrypt() {
-	}
+    private WolfCrypt() {
+    }
 }


### PR DESCRIPTION
**02e8e3e** 
INLINE changed to WC_INLINE to match that of wolfssl.  Fixes compile time error.

**64b8e3a** 
6 JNI methods were created:  getCodeSHA, getCodeMd5, etc.
1 java method was created: getHashCode(hashType hash)

The getHashCode accepts an enum argument of hashType such as SHA or MD5.  Depending on the passed in enum; getHashCode will call the respective JNI method such as getCodeSHA.

The JNI method than returns the hash code defined by wolfssl header files.

This allows for different versions of wolfssl to be used without having to manually change hard coded enum values in the Java code.
