### PR TITLE
Fixes for chacha/Curve25519

### DIFF
--- a/jni/jni_chacha.c
+++ b/jni/jni_chacha.c
@@ -105,7 +105,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
     int ret = 0;
     ChaCha* chacha = NULL;
     byte* iv   = NULL;
-    word32 ivSz = 0;
 
     chacha = (ChaCha*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
@@ -113,12 +112,11 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
         return;
     }
     iv   = getByteArray(env, iv_object);
-    ivSz = getByteArrayLength(env, iv_object);
 
     if (!chacha || !iv) {
         ret = BAD_FUNC_ARG;
     } else {
-        ret = wc_Chacha_SetIV(chacha, iv, ivSz);
+        ret = wc_Chacha_SetIV(chacha, iv, 0);
     }
 
     if (ret != 0)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.0</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
 

--- a/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
@@ -152,7 +152,7 @@ public class Curve25519 extends NativeStruct {
 	
     public byte[] exportPublic() {
 		if (state == WolfCryptState.READY) {
-			return wc_curve25519_export_private();
+			return wc_curve25519_export_public();
 		} else {
 			throw new IllegalStateException(
 					"No available key to perform the operation.");


### PR DESCRIPTION
- Fixed maven version
- Fixed typo in Curve25519 API
- Fixed invocation of wc_Chacha_SetIV (last parameter was used as length instead of offset)