### PR TITLE
nativeheaderdir, wc_ecc_set_rng, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ This package provides a Java, JNI-based interface to the native wolfCrypt
 (and wolfCrypt FIPS API, if using with a FIPS version of wolfCrypt). It also
 includes a JCE provider for wolfCrypt.
 
-For instructions and notes on the JNI wrapper, please referene this README,
-or online documentation.
+For instructions and notes on the JNI wrapper, please reference this README.md,
+or the wolfSSL online documentation.
 
 For instructinos and notes on the JCE provider, please reference the
-README_JCE file, or online instructions.
+README_JCE.md file, or online instructions.
 
 ### Compiling
 ---------
 
 To compile the wolfCrypt JNI wrapper:
 
-1) Compile and install a wolfSSL (wolfssl-x.x.x) or wolfSSL FIPS
-release (wolfssl-x.x.x-commercial-fips):
+1) Compile and install a wolfSSL (wolfssl-x.x.x), wolfSSL FIPS
+release (wolfssl-x.x.x-commercial-fips), or wolfSSL FIPS Ready release:
 
-In either case, you will need the "--enable-keygen" ./configure option.
+In any of these cases, you will need the "--enable-keygen" ./configure option.
 
 wolfSSL Standard Build:
 ```
@@ -29,11 +29,29 @@ $ make check
 $ sudo make install
 ```
 
-wolfSSL FIPS Build:
+wolfSSL FIPSv1 Build:
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
 $ ./configure --enable-fips --enable-keygen
+$ make check
+$ sudo make install
+```
+
+wolfSSL FIPSv2 Build:
+
+```
+$ cd wolfssl-x.x.x-commercial-fips
+$ ./configure --enable-fips=v2 --enable-keygen
+$ make check
+$ sudo make install
+```
+
+wolfSSL FIPS Ready Build:
+
+```
+$ cd wolfssl-x.x.x-commercial-fips
+$ ./configure --enable-fips=ready --enable-keygen
 $ make check
 $ sudo make install
 ```
@@ -62,7 +80,7 @@ files to be on your JUNIT_HOME path.
 
 To install and set up JUnit:
 
-a) Download "junit-4.12.jar" and "hamcrest-core-1.3.jar" from junit.org
+a) Download "junit-4.12.jar" and "hamcrest-all-1.3.jar" from junit.org
 
 b) Place these JAR files on your system and set JUNIT_HOME to point to
    that location:
@@ -112,7 +130,7 @@ sign.tsaurl=<timestamp server url>
 
 Signing the JAR is important especially if using the JCE Provider with a JDK
 that requires JCE provider JAR's to be authenticated.  Please see
-README_JCE for more details.
+README_JCE.md for more details.
 
 ### Revision History
 ---------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ includes a JCE provider for wolfCrypt.
 For instructions and notes on the JNI wrapper, please reference this README.md,
 or the wolfSSL online documentation.
 
-For instructinos and notes on the JCE provider, please reference the
+For instructions and notes on the JCE provider, please reference the
 README_JCE.md file, or online instructions.
 
 ### Compiling
@@ -134,6 +134,23 @@ README_JCE.md for more details.
 
 ### Revision History
 ---------
+
+********* wolfCrypt JNI Release X.X.X (TBD)
+
+Release X.X.X of wolfCrypt JNI has bug fixes and new features including:
+
+- New JNI-level wrappers for ChaCha, Curve25519, and Ed25519
+- Maven pom.xml build file
+- Runtime detection of hash type enum values for broader wolfSSL support
+- Updated wolfSSL error codes to match native wolfSSL updates
+- Native HMAC wrapper fixes for building with wolfCrypt FIPSv2
+- Native wrapper to return HAVE_FIPS_VERSION value to Java
+- Remove Blake2b from HMAC types, to match native wolfSSL changes
+- Better native wolfSSL feature detection
+- Increase Junit version to 4.13
+- Use nativeheaderdir on supported platforms instead of javah
+- Use hamcrest-all-1.3.jar in build.xml
+- Add call to wc_ecc_set_rng() when needed
 
 ********* wolfCrypt JNI Release 1.0.0 (7/10/2017)
 

--- a/README_JCE.md
+++ b/README_JCE.md
@@ -4,7 +4,7 @@
 The wolfCrypt JCE Provider is currently set up to be compiled together into
 the same JAR file as the normal wolfcrypt-jni classes.
 
-The wolfCrypt JCE Provider is located in the following class:
+The wolfCrypt JCE Provider is located in the following package:
 
     com.wolfssl.wolfcrypt.jce.provider
 

--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,20 @@
 
     <property environment="env" />
 
+    <!-- check if javac nativeheaderdir is available -->
+    <condition property="have-nativeheaderdir">
+        <and>
+            <antversion atleast="1.9.8"/>
+            <not>
+                <or>
+                    <equals arg1="${ant.java.version}" arg2="1.5"/>
+                    <equals arg1="${ant.java.version}" arg2="1.6"/>
+                    <equals arg1="${ant.java.version}" arg2="1.7"/>
+                </or>
+            </not>
+        </and>
+    </condition>
+
     <!-- classpath to compiled wolfcrypt-jni.jar, for running tests -->
     <path id="classpath">
         <fileset dir="${lib.dir}" includes="*.jar">
@@ -89,7 +103,23 @@
     </target>
 
     <!-- compile all JNI and JCE source files -->
-    <target name="compile" depends="init">
+    <target name="compile-nativeheaderdir" if="have-nativeheaderdir" depends="init">
+        <javac
+            srcdir="${src.dir}"
+            destdir="${build.dir}"
+            nativeheaderdir="${jni.dir}"
+            debug="${java.debug}"
+            debuglevel="${java.debuglevel}"
+            deprecation="${java.deprecation}"
+            optimize="${java.optimize}"
+            source="${java.source}"
+            target="${java.target}"
+            classpathref="classpath"
+            includeantruntime="false">
+            <compilerarg value="-Xlint:-options" />
+        </javac>
+    </target>
+    <target name="compile-javah" unless="have-nativeheaderdir" depends="init">
         <javac
             srcdir="${src.dir}"
             destdir="${build.dir}"
@@ -106,7 +136,7 @@
     </target>
 
     <!-- create JAR with ONLY JNI classes, not to be used with JCE -->
-    <target name="jar-jni" depends="compile">
+    <target name="jar-jni" depends="compile-nativeheaderdir, compile-javah">
         <jar jarfile="${lib.dir}/wolfcrypt-jni.jar">
             <manifest>
                 <attribute name="Implementation-Title"
@@ -123,7 +153,7 @@
     </target>
 
     <!-- create JAR with JNI and JCE classes, use this when wanting JCE -->
-    <target name="jar-jce" depends="compile">
+    <target name="jar-jce" depends="compile-nativeheaderdir, compile-javah">
         <jar jarfile="${lib.dir}/wolfcrypt-jni.jar" basedir="${build.dir}">
             <manifest>
                 <attribute name="Implementation-Title"
@@ -172,7 +202,8 @@
     </target>
 
     <!-- NOTE: depends on either jar-jni or jar-jce targets -->
-    <target name="javah" if="jni.classes.present" depends="jni-class-detect"
+    <target name="javah" if="jni.classes.present" unless="have-nativeheaderdir"
+        depends="jni-class-detect"
         description="Generate javah headers">
         <javah destdir="${jni.dir}" force="yes" classpathref="classpath">
             <class name="com.wolfssl.wolfcrypt.WolfCrypt" />

--- a/build.xml
+++ b/build.xml
@@ -32,7 +32,7 @@
     <property name="reports.dir" value="build/reports" />
 
     <property name="junit4" value="junit-4.13.jar" />
-    <property name="hamcrest-core" value="hamcrest-core-1.3.jar" />
+    <property name="hamcrest-core" value="hamcrest-all-1.3.jar" />
     <property name="ant-junit4" value="ant/ant-junit4.jar" />
     <property name="jce.debug" value="false" />
 

--- a/jni/include/com_wolfssl_wolfcrypt_Ecc.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Ecc.h
@@ -60,10 +60,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1check_1key
 /*
  * Class:     com_wolfssl_wolfcrypt_Ecc
  * Method:    wc_ecc_shared_secret
- * Signature: (Lcom/wolfssl/wolfcrypt/Ecc;)[B
+ * Signature: (Lcom/wolfssl/wolfcrypt/Ecc;Lcom/wolfssl/wolfcrypt/Rng;)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1shared_1secret
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Ecc

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -752,6 +752,7 @@ public class WolfCryptCipher extends CipherSpi {
         debug.print("[Cipher, " + algString + "-" + algMode + "] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -541,6 +541,7 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
         debug.print("[KeyAgreement, " + algString + "] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -304,6 +304,7 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
         debug.print("[KeyPairGenerator, " + algString + "] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
@@ -192,6 +192,7 @@ public class WolfCryptMac extends MacSpi {
         debug.print("[Mac, " + algString + "] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -101,6 +101,7 @@ public final class WolfCryptMessageDigestMd5 extends MessageDigestSpi {
         debug.print("[MessageDigest, MD5] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -101,6 +101,7 @@ public final class WolfCryptMessageDigestSha extends MessageDigestSpi {
         debug.print("[MessageDigest, SHA] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -101,6 +101,7 @@ public final class WolfCryptMessageDigestSha256 extends MessageDigestSpi {
         debug.print("[MessageDigest, SHA256] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -101,6 +101,7 @@ public final class WolfCryptMessageDigestSha384 extends MessageDigestSpi {
         debug.print("[MessageDigest, SHA384] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -101,6 +101,7 @@ public final class WolfCryptMessageDigestSha512 extends MessageDigestSpi {
         debug.print("[MessageDigest, SHA512] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
@@ -71,6 +71,7 @@ public final class WolfCryptRandom extends SecureRandomSpi {
         debug.print("[Random] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -618,6 +618,7 @@ public class WolfCryptSignature extends SignatureSpi {
                     digestString + "] " + msg);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
@@ -65,6 +65,7 @@ public abstract class NativeStruct extends WolfObject {
 
 	private native void xfree(long pointer);
 
+    @SuppressWarnings("deprecation")
 	@Override
 	protected void finalize() throws Throwable {
 		releaseNativeStruct();


### PR DESCRIPTION
This PR includes fixes and cleanup:

- Uses nativeheaderdir in build.xml on supported platforms, otherwise falls back to javah (allows wolfcrypt-jni to compile on newer JDK versions)
- Switches JUnit to use hamcrest-all-1.3.jar, consistent with wolfssljni
- Adds call to wc_ecc_set_rng() to work with recent wolfSSL releases
- README updates

This has been tested against wolfSSL, FIPSv1, FIPSv2, and FIPS Ready on Linux and OS X.