### PR TITLE
1.1.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ README_JCE.md for more details.
 ### Revision History
 ---------
 
-********* wolfCrypt JNI Release X.X.X (TBD)
+********* wolfCrypt JNI Release 1.1.0 (08/26/2020)
 
-Release X.X.X of wolfCrypt JNI has bug fixes and new features including:
+Release 1.1.0 of wolfCrypt JNI has bug fixes and new features including:
 
 - New JNI-level wrappers for ChaCha, Curve25519, and Ed25519
 - Maven pom.xml build file

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -641,6 +641,8 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1shared_1secret(
         XFREE(output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         throwWolfCryptExceptionFromError(env, ret);
     }
+#else
+    (void)rng;
 #endif
 
     ret = (!ecc || !pub)


### PR DESCRIPTION
This PR preps for the 1.6.0 release and includes:

- README update for version and release date
- Minor warning fix in jni/jni_ecc.c