### PR TITLE
add support for MessageDigestSpi.engineGetDigestLength()

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -101,6 +101,11 @@ public final class WolfCryptMessageDigestMd5 extends MessageDigestSpi {
         debug.print("[MessageDigest, MD5] " + msg);
     }
 
+    @Override
+    protected int engineGetDigestLength() {
+        return this.md5.digestSize();
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -101,6 +101,11 @@ public final class WolfCryptMessageDigestSha extends MessageDigestSpi {
         debug.print("[MessageDigest, SHA] " + msg);
     }
 
+    @Override
+    protected int engineGetDigestLength() {
+        return this.sha.digestSize();
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -97,6 +97,11 @@ public final class WolfCryptMessageDigestSha256 extends MessageDigestSpi {
             log("update, offset: " + offset + ", len: " + len);
     }
 
+    @Override
+    protected int engineGetDigestLength() {
+        return this.sha.digestSize();
+    }
+
     private void log(String msg) {
         debug.print("[MessageDigest, SHA256] " + msg);
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -97,6 +97,11 @@ public final class WolfCryptMessageDigestSha384 extends MessageDigestSpi {
             log("update, offset: " + offset + ", len: " + len);
     }
 
+    @Override
+    protected int engineGetDigestLength() {
+        return this.sha.digestSize();
+    }
+
     private void log(String msg) {
         debug.print("[MessageDigest, SHA384] " + msg);
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -97,6 +97,11 @@ public final class WolfCryptMessageDigestSha512 extends MessageDigestSpi {
             log("update, offset: " + offset + ", len: " + len);
     }
 
+    @Override
+    protected int engineGetDigestLength() {
+        return this.sha.digestSize();
+    }
+
     private void log(String msg) {
         debug.print("[MessageDigest, SHA512] " + msg);
     }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 
+import com.wolfssl.wolfcrypt.Md5;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 
@@ -227,6 +228,14 @@ public class WolfCryptMessageDigestMd5Test {
 
             assertArrayEquals(wolfOutput, interopOutput);
         }
+    }
+
+    @Test
+    public void testMd5GetDigestLength()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        MessageDigest md5 = MessageDigest.getInstance("MD5", "wolfJCE");
+        assertEquals(Md5.DIGEST_SIZE, md5.getDigestLength());
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 
+import com.wolfssl.wolfcrypt.Sha256;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 
@@ -212,6 +213,14 @@ public class WolfCryptMessageDigestSha256Test {
 
             assertArrayEquals(wolfOutput, interopOutput);
         }
+    }
+
+    @Test
+    public void testSha256GetDigestLength()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256", "wolfJCE");
+        assertEquals(Sha256.DIGEST_SIZE, sha256.getDigestLength());
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 
+import com.wolfssl.wolfcrypt.Sha384;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 
@@ -226,6 +227,14 @@ public class WolfCryptMessageDigestSha384Test {
             assertArrayEquals(wolfOutput, interopOutput);
         }
 
+    }
+
+    @Test
+    public void testSha384GetDigestLength()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        MessageDigest sha384 = MessageDigest.getInstance("SHA-384", "wolfJCE");
+        assertEquals(Sha384.DIGEST_SIZE, sha384.getDigestLength());
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 
+import com.wolfssl.wolfcrypt.Sha512;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 
@@ -289,6 +290,14 @@ public class WolfCryptMessageDigestSha512Test {
             assertArrayEquals(wolfOutput, interopOutput);
         }
 
+    }
+
+    @Test
+    public void testSha512GetDigestLength()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        MessageDigest sha512 = MessageDigest.getInstance("SHA-512", "wolfJCE");
+        assertEquals(Sha512.DIGEST_SIZE, sha512.getDigestLength());
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 
+import com.wolfssl.wolfcrypt.Sha;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 
@@ -224,6 +225,14 @@ public class WolfCryptMessageDigestShaTest {
 
             assertArrayEquals(wolfOutput, interopOutput);
         }
+    }
+
+    @Test
+    public void testShaGetDigestLength()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        MessageDigest sha = MessageDigest.getInstance("SHA-1", "wolfJCE");
+        assertEquals(Sha.DIGEST_SIZE, sha.getDigestLength());
     }
 }
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/Des3FipsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/Des3FipsTest.java
@@ -47,6 +47,11 @@ public class Des3FipsTest extends FipsTest {
 
     @BeforeClass
     public static void checkAvailability() {
+
+        /* Most test classes pick this up from FipsTest checkAvailability(),
+         * but not when method is overridden here */
+        Assume.assumeTrue(Fips.enabled);
+
         try {
             new Des3();
         } catch (WolfCryptException e) {


### PR DESCRIPTION
This PR adds methods to wolfJCE's `WolfCryptMessageDigestXXX` classes to override the `MessageDigestSpi.engineGetDigestLength()` API.