### PR TITLE
Resolve WolfCryptCipherTest failure, fix OSX build

### DIFF
--- a/makefile.macosx
+++ b/makefile.macosx
@@ -13,7 +13,7 @@ JAVA_HOME ?= $(shell /usr/libexec/java_home)
 CC        = gcc
 override CCFLAGS   += -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
 			-I$(INC_PATH)
-override LDFLAGS   += -dynamiclib -framework JavaVM -lwolfssl
+override LDFLAGS   += -dynamiclib -lwolfssl
 
 all: $(TARGET)
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -1129,7 +1129,9 @@ public class WolfCryptCipherTest {
             fail("Cipher.doFinal should throw exception when data is larger " +
                  "than RSA key size");
         } catch (WolfCryptException e) {
-            assertEquals("Rsa Padding error", e.getMessage());
+            /* will throw exception with either "Rsa Padding error" or
+             * "Bad function argument" depending on wolfSSL version. But, in
+             * any case, we expect to get an exception here. */
         }
 
         /* PUBLIC ENCRYPT */


### PR DESCRIPTION
This PR fixes a JCE test case failure, which will fix the nightly test as well:

```
Testcase: testRSAECBPKCS1PaddingWithTooBigData took 0.086 sec
expected:<[Rsa Padding error]> but was:<[Bad function argument]>
junit.framework.AssertionFailedError: expected:<[Rsa Padding error]> but was:<[Bad function argument]>
	at com.wolfssl.provider.jce.test.WolfCryptCipherTest.testRSAECBPKCS1PaddingWithTooBigData(WolfCryptCipherTest.java:1132)
```

The following commit to wolfSSL proper added a new BAD_FUNC_ARG return code that changed the string description of the exception returned at this point in the WolfCryptCipherTest case.  Specific code addition is around the message `Expected that inLen be no longer RSA key length`.

https://github.com/wolfSSL/wolfssl/commit/e9187f5f00

This PR change loosens the check on the specific exception error string, and instead just makes sure that a WolfCryptException is thrown when expected.

This also fixes the OSX build for newer versions of XCode by removing the unnecessary `-framework JavaVM` from `makefile.macosx`. Regression tested on older version of OSX.