### PR TITLE
Prep for 1.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ that requires JCE provider JAR's to be authenticated.  Please see
 ### Revision History
 ---------
 
+#### wolfCrypt JNI Release 1.3.0 (05/13/2022)
+
+Release 1.3.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Run FIPS tests on `ant test` when linked against a wolfCrypt FIPS library (PR 24)
+- Wrap native AesGcmSetExtIV\_fips() API (PR 24)
+- Fix releaseByteArray() usage in Fips.RsaSSL\_Sign() (PR 24)
+- Fix AES-GCM FIPS test cases (PR 24)
+- Keep existing JAVA\_HOME in makefiles if already set (PR 25)
+- Add JCE support for MessageDigestSpi.engineGetDigestLength() (PR 27)
+- Update junit to 4.13.2 (PR 28)
+- Update missing Javadocs, fixes warnings on newer Java versions (PR 29)
+
 #### wolfCrypt JNI Release 1.2.0 (11/16/2021)
 
 Release 1.2.0 of wolfCrypt JNI has bug fixes and new features including:

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.2" />
+    <property name="implementation.version" value="1.3" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/src/main/java/com/wolfssl/wolfcrypt/Asn.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Asn.java
@@ -33,6 +33,9 @@ public class Asn extends WolfObject {
     /** Maximum encoded signature size */
     public static final int MAX_ENCODED_SIG_SIZE = 512;
 
+    /** Default Asn constructor */
+    public Asn() { }
+
     /** ASN.1 encode message digest, before it is signed
      *
      * @param encoded output buffer to place encoded data

--- a/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
@@ -34,6 +34,9 @@ public abstract class BlockCipher extends NativeStruct {
 
     private int opmode;
 
+    /** Default BlockCipher constructor */
+    public BlockCipher() { }
+
     /**
      * Set block cipher key, IV, and mode
      *

--- a/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
@@ -65,5 +65,8 @@ public class FeatureDetect {
     static {
         System.loadLibrary("wolfcryptjni");
     }
+
+    /** Default FeatureDetect constructor */
+    public FeatureDetect() { }
 }
 

--- a/src/main/java/com/wolfssl/wolfcrypt/Fips.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Fips.java
@@ -1224,9 +1224,10 @@ public class Fips extends WolfObject {
      */
 
     /**
-     * @return The current status of the module. A return code of 0 means the
-     *         module is in a state without errors. Any other return code is the
-     *         specific error state of the module.
+     * Returns the current status of the wolfCrypt FIPS module.
+     * @return A return code of 0 means the module is in a state without
+     *         errors. Any other return code is the specific error state of
+     *         the module.
      */
     public static native int wolfCrypt_GetStatus_fips();
 

--- a/src/main/java/com/wolfssl/wolfcrypt/Logging.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Logging.java
@@ -37,5 +37,8 @@ public class Logging extends WolfObject {
      * Turn off native wolfSSL debug logging
      */
     public static native void wolfSSL_Debugging_OFF();
+
+    /** Default Logging constructor */
+    public Logging() { }
 }
 

--- a/src/main/java/com/wolfssl/wolfcrypt/MessageDigest.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/MessageDigest.java
@@ -32,6 +32,9 @@ public abstract class MessageDigest extends NativeStruct {
 
     private WolfCryptState state = WolfCryptState.UNINITIALIZED;
 
+    /** Default MessageDigest constructor */
+    public MessageDigest() { }
+
     /**
      * Initialize native structure
      */

--- a/src/main/java/com/wolfssl/wolfcrypt/Rng.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Rng.java
@@ -46,6 +46,9 @@ public class Rng extends NativeStruct {
             int length);
     private native void rngGenerateBlock(byte[] buffer, int offset, int length);
 
+    /** Default Rng constructor */
+    public Rng() { }
+
     @Override
     public void releaseNativeStruct() {
         free();

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -135,8 +135,8 @@ public class WolfCryptKeyPairGeneratorTest {
             if (size > 0) {
                 enabledCurves.add(supportedCurves[i]);
 
-                if (!enabledKeySizes.contains(new Integer(size))) {
-                    enabledKeySizes.add(new Integer(size));
+                if (!enabledKeySizes.contains(Integer.valueOf(size))) {
+                    enabledKeySizes.add(Integer.valueOf(size));
                 }
             }
         }


### PR DESCRIPTION
This PR preps for the 1.3.0 release and includes:

- Fixes Javadoc warnings and missing default constructors that show up in newer Java versions
- Fixes deprecation warning for Integer(int) in WolfCryptKeyPairGeneratorTest.java
- Updates README.md and build.xml for 1.3.0