### PR TITLE
Add initial example framework with one ProviderTest JCE example

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,9 @@
     <property name="test.dir" value="src/test/java/" />
     <property name="test.build.dir" value="build/test" />
     <property name="reports.dir" value="build/reports" />
+    <property name="examples.build.dir" value="examples/build" />
+    <property name="examples.provider.dir" value="examples/provider" />
+    <property name="examples.provider.build.dir" value="examples/build/provider" />
 
     <property name="junit4" value="junit-4.13.2.jar" />
     <property name="hamcrest-core" value="hamcrest-all-1.3.jar" />
@@ -68,6 +71,7 @@
     <target name="clean">
         <delete dir="${test.build.dir}" />
         <delete dir="${build.dir}" />
+        <delete dir="${examples.provider.build.dir}" />
         <delete dir="${examples.build.dir}" />
         <delete dir="${reports.dir}" />
         <delete failonerror="false">
@@ -100,6 +104,7 @@
         <mkdir dir="${lib.dir}" />
         <mkdir dir="${test.build.dir}" />
         <mkdir dir="${reports.dir}" />
+        <mkdir dir="${examples.provider.build.dir}" />
     </target>
 
     <!-- compile all JNI and JCE source files -->
@@ -235,6 +240,22 @@
         <javadoc sourcepath="${src.dir}" destdir="${doc.dir}" />
     </target>
 
+    <target name="examples-jce" description="Build JCE Examples">
+        <javac
+            srcdir="${examples.provider.dir}"
+            destdir="${examples.provider.build.dir}"
+            debug="${java.debug}"
+            debuglevel="${java.debuglevel}"
+            deprecation="${java.deprecation}"
+            optimize="${java.optimize}"
+            source="${java.source}"
+            target="${java.target}"
+            classpathref="classpath"
+            includeantruntime="false">
+            <compilerarg value="-Xlint:-options"/>
+        </javac>
+    </target>
+
     <!-- compile JNI/JCE test classes, depending on how 'ant build' was run -->
     <target name="build-test" depends="set-build-debug, debug-javac-flags">
 
@@ -346,11 +367,11 @@
         description="Build library JAR (JNI classes ONLY)">
     </target>
 
-    <target name="build-jce-debug" depends="set-build-debug, jar-jce, sign, sign-alt, javah, javadoc"
+    <target name="build-jce-debug" depends="set-build-debug, jar-jce, sign, sign-alt, javah, javadoc, examples-jce"
         description="Build library JAR (JNI + JCE classes)">
     </target>
 
-    <target name="build-jce-release" depends="set-build-release, jar-jce, sign, sign-alt, javah, javadoc"
+    <target name="build-jce-release" depends="set-build-release, jar-jce, sign, sign-alt, javah, javadoc, examples-jce"
         description="Build library JAR (JNI + JCE classes)">
     </target>
 

--- a/examples/provider/ProviderTest.java
+++ b/examples/provider/ProviderTest.java
@@ -1,0 +1,89 @@
+/* ProviderTest.java
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+
+import com.wolfssl.provider.jce.WolfCryptProvider;
+
+/**
+ * This class tests the wolfSSL provider installation.  It lists all providers
+ * installed on the system, tries to look up the wolfSSL provider, and if
+ * found, prints out the information about the wolfSSL provider.
+ *
+ * This app can be useful for testing if wolfJCE has been installed
+ * correctly at the system level.
+ */
+public class ProviderTest {
+
+    /* Print out info about registered Security providers. Does not
+     * install wolfJCE. If wolfJCE has been installed at the system
+     * level, or application has installed wolfJCE at runtime, it will
+     * show up. Otherwise will not. main() below calls this once without
+     * installing wolfJCE explicitly, then calls again after installing
+     * wolfJCE at runtime as the highest-level provider. */
+    public static void pollProviders()
+    {
+        /* Get all providers */
+        Provider [] providers = Security.getProviders();
+
+        System.out.println("\nAll Installed Java Security Providers:");
+        System.out.println("---------------------------------------");
+        for(Provider prov:providers)
+        {
+            System.out.println("\t" + prov);
+        }
+
+        Provider p = Security.getProvider("wolfJCE");
+        if (p == null) {
+            System.out.println("No wolfJCE provider registered in system");
+        } else {
+            /* Test if wolfSSL is a Provider */
+            System.out.println("\nInfo about wolfSSL Provider (wolfJCE):");
+            System.out.println("----------------------------------------");
+            System.out.println("Provider: " + p);
+            System.out.println("Info: " + p.getInfo());
+            System.out.println("Services:");
+            System.out.println(p.getServices());
+        }
+    }
+
+    public static void main(String args [])
+    {
+        /* Print system providers before explicit wolfJCE install */
+        System.out.println("=================================================");
+        System.out.println("| Before installing wolfJCE at runtime          |");
+        System.out.println("=================================================");
+        pollProviders();
+
+        /* Install wolfJCE */
+        Security.insertProviderAt(new WolfCryptProvider(), 1);
+
+        /* Print system provider, after installing wolfJCE */
+        System.out.println("");
+        System.out.println("=================================================");
+        System.out.println("| After installing wolfJCE at runtime           |");
+        System.out.println("=================================================");
+        pollProviders();
+    }
+}
+

--- a/examples/provider/ProviderTest.sh
+++ b/examples/provider/ProviderTest.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd ./examples/build/provider
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
+java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ -Dwolfjce.debug=true ProviderTest $@
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -34,7 +34,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.0, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.3, "wolfCrypt JCE Provider");
 
         /* MessageDigest */
         if (FeatureDetect.Md5Enabled()) {


### PR DESCRIPTION
This PR:
- Adds an initial directory structure for JCE examples and adds support to `build.xml` to build them when either `ant build-jce-debug` or `ant build-jce-release` is used.
- Increments the wolfJCE version number in `WolfCryptProvider.java` to match the recent 1.3 release (oversight during last release).