### PR TITLE
Replace non-ASCII apostrophes in Fips.java/README_JCE.md

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -112,7 +112,7 @@ ant build system, please see the main README.md included in this package.
 
 ### Using a Pre-Signed JAR File
 
-wolfSSL (company) has it’s own set of code signing certificates from Oracle
+wolfSSL (company) has it's own set of code signing certificates from Oracle
 that allow wolfJCE to be authenticated in the Oracle JDK.  With each release
 of wolfJCE, wolfSSL ships a couple pre-signed versions of the
 ‘wolfcrypt-jni.jar”, located at:

--- a/src/main/java/com/wolfssl/wolfcrypt/Fips.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Fips.java
@@ -1462,7 +1462,7 @@ public class Fips extends WolfObject {
 
     /**
      * Creates the agreement agree of size agreeSz using Dh key private priv of
-     * size privSz and peer’s public key otherPub of size pubSz.
+     * size privSz and peer's public key otherPub of size pubSz.
      *
      * @param key
      *            the Dh object.
@@ -1486,7 +1486,7 @@ public class Fips extends WolfObject {
 
     /**
      * Creates the agreement agree of size agreeSz using Dh key private priv of
-     * size privSz and peer’s public key otherPub of size pubSz.
+     * size privSz and peer's public key otherPub of size pubSz.
      *
      * @param key
      *            the Dh object.
@@ -1661,7 +1661,7 @@ public class Fips extends WolfObject {
 
     /**
      * Creates the shared secret out of size outlen using ecc private_key and
-     * the peer’s ecc public_key.
+     * the peer's ecc public_key.
      *
      * @param private_key
      *            the Ecc object for the private key.
@@ -1679,7 +1679,7 @@ public class Fips extends WolfObject {
 
     /**
      * Creates the shared secret out of size outlen using ecc private_key and
-     * the peer’s ecc public_key.
+     * the peer's ecc public_key.
      *
      * @param private_key
      *            the Ecc object for the private key.


### PR DESCRIPTION
We had a few non-ASCII apostrophes in Fips.java which were causing a build error on a customer platform.