### PR TITLE
Prep for 1.4.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ that requires JCE provider JAR's to be authenticated.  Please see
 ### Revision History
 ---------
 
+#### wolfCrypt JNI Release 1.4.0 (08/11/2022)
+
+Release 1.4.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Add example directory with one simple ProviderTest example (PR 32)
+- Fix double free of ChaCha pointer (PR 34)
+- Add test cases for ChaCha.java (PR 34)
+- Skip WolfCryptMacTest for HMAC-MD5 when using wolfCrypt FIPS 140-3 (PR 35)
+- Use new hash struct names (wc\_Md5/wc\_Sha/etc) in native code (PR 35)
+- Fix potential build error with non-ASCII apostrophes in Fips.java (PR 36)
+
 #### wolfCrypt JNI Release 1.3.0 (05/13/2022)
 
 Release 1.3.0 of wolfCrypt JNI has bug fixes and new features including:

--- a/build.xml
+++ b/build.xml
@@ -320,8 +320,8 @@
 
             <sysproperty key="sun.boot.library.path" value="$JAVA_HOME/bin:${lib.dir}" />
             <sysproperty key="wolfjce.debug" value="${jce.debug}" />
-            <env key="LD_LIBRARY_PATH" path="$LD_LIBRARY_PATH:{lib.dir}:/usr/local/lib" />
-            <env key="CLASSPATH" path="$LD_LIBRARY_PATH:${env.JUNIT_HOME}/${junit4}" />
+            <env key="LD_LIBRARY_PATH" path="${env.LD_LIBRARY_PATH}:{lib.dir}:/usr/local/lib" />
+            <env key="CLASSPATH" path="${env.LD_LIBRARY_PATH}:${env.JUNIT_HOME}/${junit4}" />
 
             <batchtest fork="yes" todir="${reports.dir}">
                 <fileset dir="${test.dir}">

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.3" />
+    <property name="implementation.version" value="1.4" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -34,7 +34,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.3, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.4, "wolfCrypt JCE Provider");
 
         /* MessageDigest */
         if (FeatureDetect.Md5Enabled()) {


### PR DESCRIPTION
This PR includes fixes from v1.4 release cycle and version bumps:

- Bumps version in WolfCryptProvider.java to 1.4
- Bumps version in build.xml to 1.4
- Updates README.md with v1.4 ChangeLog info
- Adjusts build.xml to use correct `${env.LD_LIBRARY_PATH}` instead of just `$LD_LIBRARY_PATH`