### PR TITLE
Add SHA cipher alias for SHA-1 to wolfJCE

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -42,6 +42,8 @@ public final class WolfCryptProvider extends Provider {
                     "com.wolfssl.provider.jce.WolfCryptMessageDigestMd5");
         }
         if (FeatureDetect.ShaEnabled()) {
+            put("MessageDigest.SHA",
+                    "com.wolfssl.provider.jce.WolfCryptMessageDigestSha");
             put("MessageDigest.SHA-1",
                     "com.wolfssl.provider.jce.WolfCryptMessageDigestSha");
         }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
@@ -49,8 +49,12 @@ public class WolfCryptMessageDigestShaTest {
         assertNotNull(p);
 
         try {
-            MessageDigest sha = MessageDigest.getInstance("SHA-1",
+            /* Try "SHA" cipher string, for SUN interop */
+            MessageDigest sha = MessageDigest.getInstance("SHA",
                                                           "wolfJCE");
+
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1",
+                                                           "wolfJCE");
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.ShaEnabled() == false) {


### PR DESCRIPTION
This PR updated wolfJCE to support the "SHA" algorithm string.  Maps to the same functionality as the "SHA-1" algorithm.  The SUN provider offers "SHA", and some applications expect that to be available.

This also adds a simple test to make sure "SHA" is able to be used via MessageDigest.getInstance().