### PR TITLE
Add wolfJCE MessageDigest.clone() support

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Md5.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Md5.h
@@ -31,6 +31,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1init
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
+ * Method:    native_copy
+ * Signature: (Lcom/wolfssl/wolfcrypt/Md5;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Md5
  * Method:    native_update
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */

--- a/jni/include/com_wolfssl_wolfcrypt_Sha.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha.h
@@ -31,6 +31,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1init
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
+ * Method:    native_copy
+ * Signature: (Lcom/wolfssl/wolfcrypt/Sha;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Sha
  * Method:    native_update
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */

--- a/jni/include/com_wolfssl_wolfcrypt_Sha256.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha256.h
@@ -31,6 +31,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1init
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
+ * Method:    native_copy
+ * Signature: (Lcom/wolfssl/wolfcrypt/Sha256;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Sha256
  * Method:    native_update
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */

--- a/jni/include/com_wolfssl_wolfcrypt_Sha384.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha384.h
@@ -31,6 +31,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1init
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
+ * Method:    native_copy
+ * Signature: (Lcom/wolfssl/wolfcrypt/Sha384;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Sha384
  * Method:    native_update
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */

--- a/jni/include/com_wolfssl_wolfcrypt_Sha512.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha512.h
@@ -31,6 +31,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1init
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
+ * Method:    native_copy
+ * Signature: (Lcom/wolfssl/wolfcrypt/Sha512;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Sha512
  * Method:    native_update
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -68,6 +68,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1init(
     JNIEnv* env, jobject this)
 {
 #ifndef NO_MD5
+    int ret = 0;
     Md5* md5 = (Md5*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
         /* getNativeStruct may throw exception, prevent throwing another */
@@ -77,7 +78,43 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1init(
     if (!md5) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
     } else {
-        wc_InitMd5(md5);
+        ret = wc_InitMd5(md5);
+        if (ret != 0) {
+            throwWolfCryptExceptionFromError(env, ret);
+        }
+    }
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy
+  (JNIEnv* env, jobject this, jobject toBeCopied)
+{
+#ifndef NO_MD5
+    int ret = 0;
+    Md5* md5 = NULL;
+    Md5* tbc = NULL; /* tbc = to be copied */
+
+    if (this == NULL || toBeCopied == NULL) {
+        throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
+    }
+
+    md5 = (Md5*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    tbc = (Md5*) getNativeStruct(env, toBeCopied);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    ret = wc_Md5Copy(tbc, md5);
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
     }
 #else
     throwNotCompiledInException(env);
@@ -89,6 +126,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifndef NO_MD5
+    int ret = 0;
     Md5*  md5  = NULL;
     byte* data = NULL;
 
@@ -103,7 +141,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update__Ljava_nio_ByteBuffer_2II(
     if (!md5 || !data) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
     } else {
-        wc_Md5Update(md5, data + position, len);
+        ret = wc_Md5Update(md5, data + position, len);
+        if (ret != 0) {
+            throwWolfCryptExceptionFromError(env, ret);
+        }
     }
 
     LogStr("wc_Md5Update(md5=%p, data, len)\n", md5);
@@ -119,9 +160,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update___3BII(
     JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset, jint len)
 {
 #ifndef NO_MD5
+    int ret = 0;
     Md5*   md5   = NULL;
     byte*  data  = NULL;
-    jsize  bufSz = (*env)->GetArrayLength(env, data_buffer);
+    word32 dataSz = 0;
 
     md5 = (Md5*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
@@ -129,12 +171,16 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update___3BII(
         return;
     }
 
-    data = getByteArray(env, data_buffer);
+    data   = getByteArray(env, data_buffer);
+    dataSz = getByteArrayLength(env, data_buffer);
 
-    if (!md5 || !data || (offset > bufSz)) {
+    if (!md5 || !data || (offset + len > dataSz)) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
     } else {
-        wc_Md5Update(md5, data + offset, len);
+        ret = wc_Md5Update(md5, data + offset, len);
+        if (ret != 0) {
+            throwWolfCryptExceptionFromError(env, ret);
+        }
     }
 
     LogStr("wc_Md5Update(md5=%p, data, len)\n", md5);
@@ -152,6 +198,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifndef NO_MD5
+    int ret = 0;
     Md5*  md5  = NULL;
     byte* hash = NULL;
 
@@ -166,7 +213,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final__Ljava_nio_ByteBuffer_2I(
     if (!md5 || !hash) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
     } else {
-        wc_Md5Final(md5, hash + position);
+        ret = wc_Md5Final(md5, hash + position);
+        if (ret != 0) {
+            throwWolfCryptExceptionFromError(env, ret);
+        }
     }
 
     LogStr("wc_Md5Final(md5=%p, hash)\n", md5);
@@ -182,6 +232,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifndef NO_MD5
+    int ret = 0;
     Md5*  md5  = NULL;
     byte* hash = NULL;
 
@@ -196,7 +247,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final___3B(
     if (!md5 || !hash) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
     } else {
-        wc_Md5Final(md5, hash);
+        ret = wc_Md5Final(md5, hash);
+        if (ret != 0) {
+            throwWolfCryptExceptionFromError(env, ret);
+        }
     }
 
     LogStr("wc_Md5Final(md5=%p, hash)\n", md5);

--- a/jni/jni_sha.c
+++ b/jni/jni_sha.c
@@ -164,6 +164,39 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1init(
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy
+  (JNIEnv* env, jobject this, jobject toBeCopied)
+{
+#ifndef NO_SHA
+    int ret = 0;
+    Sha* sha = NULL;
+    Sha* tbc = NULL; /* tbc = to be copied */
+
+    if (this == NULL || toBeCopied == NULL) {
+        throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
+    }
+
+    sha = (Sha*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    tbc = (Sha*) getNativeStruct(env, toBeCopied);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    ret = wc_ShaCopy(tbc, sha);
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
+    }
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
 JNIEXPORT void JNICALL
 Java_com_wolfssl_wolfcrypt_Sha_native_1update__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
@@ -224,7 +257,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1update___3BII(
 
     LogStr("wc_ShaUpdate_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
-    LogHex(data, 0, len);
+    LogHex(data, offset, len);
 
     releaseByteArray(env, data_buffer, data, JNI_ABORT);
 #else
@@ -316,6 +349,39 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1init(
 
     if (ret != 0)
         throwWolfCryptExceptionFromError(env, ret);
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy
+  (JNIEnv* env, jobject this, jobject toBeCopied)
+{
+#ifndef NO_SHA256
+    int ret = 0;
+    Sha256* sha = NULL;
+    Sha256* tbc = NULL; /* tbc = to be copied */
+
+    if (this == NULL || toBeCopied == NULL) {
+        throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
+    }
+
+    sha = (Sha256*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    tbc = (Sha256*) getNativeStruct(env, toBeCopied);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    ret = wc_Sha256Copy(tbc, sha);
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -479,6 +545,39 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1init(
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy
+  (JNIEnv* env, jobject this, jobject toBeCopied)
+{
+#ifdef WOLFSSL_SHA384
+    int ret = 0;
+    Sha384* sha = NULL;
+    Sha384* tbc = NULL; /* tbc = to be copied */
+
+    if (this == NULL || toBeCopied == NULL) {
+        throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
+    }
+
+    sha = (Sha384*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    tbc = (Sha384*) getNativeStruct(env, toBeCopied);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    ret = wc_Sha384Copy(tbc, sha);
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
+    }
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
 JNIEXPORT void JNICALL
 Java_com_wolfssl_wolfcrypt_Sha384_native_1update__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
@@ -632,6 +731,39 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1init(
 
     if (ret != 0)
         throwWolfCryptExceptionFromError(env, ret);
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy
+  (JNIEnv* env, jobject this, jobject toBeCopied)
+{
+#ifdef WOLFSSL_SHA512
+    int ret = 0;
+    Sha512* sha = NULL;
+    Sha512* tbc = NULL; /* tbc = to be copied */
+
+    if (this == NULL || toBeCopied == NULL) {
+        throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
+    }
+
+    sha = (Sha512*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    tbc = (Sha512*) getNativeStruct(env, toBeCopied);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    ret = wc_Sha512Copy(tbc, sha);
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -31,7 +31,8 @@ import com.wolfssl.provider.jce.WolfCryptDebug;
 /**
  * wolfCrypt JCE MD5 MessageDigest wrapper
  */
-public final class WolfCryptMessageDigestMd5 extends MessageDigestSpi {
+public final class WolfCryptMessageDigestMd5
+    extends MessageDigestSpi implements Cloneable {
 
     /* internal reference to wolfCrypt JNI Md5 object */
     private Md5 md5;
@@ -46,6 +47,16 @@ public final class WolfCryptMessageDigestMd5 extends MessageDigestSpi {
 
         md5 = new Md5();
         md5.init();
+    }
+
+    /**
+     * Create new WolfCryptMessageDigestMd5 based on existing Md5 object.
+     * Existing object should already be initialized.
+     *
+     * @param md5 initialized Md5 object to be used with this MessageDigest
+     */
+    private WolfCryptMessageDigestMd5(Md5 md5) {
+        this.md5 = md5;
     }
 
     @Override
@@ -104,6 +115,12 @@ public final class WolfCryptMessageDigestMd5 extends MessageDigestSpi {
     @Override
     protected int engineGetDigestLength() {
         return this.md5.digestSize();
+    }
+
+    @Override
+    public Object clone() {
+        Md5 md5Copy = new Md5(this.md5);
+        return new WolfCryptMessageDigestMd5(md5Copy);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -31,7 +31,8 @@ import com.wolfssl.provider.jce.WolfCryptDebug;
 /**
  * wolfCrypt JCE SHA-1 MessageDigest wrapper
  */
-public final class WolfCryptMessageDigestSha extends MessageDigestSpi {
+public final class WolfCryptMessageDigestSha
+    extends MessageDigestSpi implements Cloneable {
 
     /* internal reference to wolfCrypt JNI Sha object */
     private Sha sha;
@@ -46,6 +47,16 @@ public final class WolfCryptMessageDigestSha extends MessageDigestSpi {
 
         sha = new Sha();
         sha.init();
+    }
+
+    /**
+     * Create new WolfCryptMessageDigestSha based on existing Sha object.
+     * Existing object should already be initialized.
+     *
+     * @param sha initialized Sha object to be used with this MessageDigest
+     */
+    private WolfCryptMessageDigestSha(Sha sha) {
+        this.sha = sha;
     }
 
     @Override
@@ -104,6 +115,12 @@ public final class WolfCryptMessageDigestSha extends MessageDigestSpi {
     @Override
     protected int engineGetDigestLength() {
         return this.sha.digestSize();
+    }
+
+    @Override
+    public Object clone() {
+        Sha shaCopy = new Sha(this.sha);
+        return new WolfCryptMessageDigestSha(shaCopy);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -31,7 +31,8 @@ import com.wolfssl.provider.jce.WolfCryptDebug;
 /**
  * wolfCrypt JCE SHA2-256 MessageDigest wrapper
  */
-public final class WolfCryptMessageDigestSha256 extends MessageDigestSpi {
+public final class WolfCryptMessageDigestSha256
+    extends MessageDigestSpi implements Cloneable {
 
     /* internal reference to wolfCrypt JNI Sha object */
     private Sha256 sha;
@@ -46,6 +47,16 @@ public final class WolfCryptMessageDigestSha256 extends MessageDigestSpi {
 
         sha = new Sha256();
         sha.init();
+    }
+
+    /**
+     * Create new WolfCryptMessageDigestSha256 based on existing Sha256 object.
+     * Existing object should already be initialized.
+     *
+     * @param sha initialized Sha256 object to be used with this MessageDigest
+     */
+    private WolfCryptMessageDigestSha256(Sha256 sha) {
+        this.sha = sha;
     }
 
     @Override
@@ -104,6 +115,12 @@ public final class WolfCryptMessageDigestSha256 extends MessageDigestSpi {
 
     private void log(String msg) {
         debug.print("[MessageDigest, SHA256] " + msg);
+    }
+
+    @Override
+    public Object clone() {
+        Sha256 shaCopy = new Sha256(this.sha);
+        return new WolfCryptMessageDigestSha256(shaCopy);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -31,7 +31,8 @@ import com.wolfssl.provider.jce.WolfCryptDebug;
 /**
  * wolfCrypt JCE SHA2-384 MessageDigest wrapper
  */
-public final class WolfCryptMessageDigestSha384 extends MessageDigestSpi {
+public final class WolfCryptMessageDigestSha384
+    extends MessageDigestSpi implements Cloneable {
 
     /* internal reference to wolfCrypt JNI Sha object */
     private Sha384 sha;
@@ -46,6 +47,16 @@ public final class WolfCryptMessageDigestSha384 extends MessageDigestSpi {
 
         sha = new Sha384();
         sha.init();
+    }
+
+    /**
+     * Create new WolfCryptMessageDigestSha384 based on existing Sha384 object.
+     * Existing object should already be initialized.
+     *
+     * @param sha initialized Sha384 object to be used with this MessageDigest
+     */
+    private WolfCryptMessageDigestSha384(Sha384 sha) {
+        this.sha = sha;
     }
 
     @Override
@@ -104,6 +115,12 @@ public final class WolfCryptMessageDigestSha384 extends MessageDigestSpi {
 
     private void log(String msg) {
         debug.print("[MessageDigest, SHA384] " + msg);
+    }
+
+    @Override
+    public Object clone() {
+        Sha384 shaCopy = new Sha384(this.sha);
+        return new WolfCryptMessageDigestSha384(shaCopy);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -31,7 +31,8 @@ import com.wolfssl.provider.jce.WolfCryptDebug;
 /**
  * wolfCrypt JCE SHA2-512 MessageDigest wrapper
  */
-public final class WolfCryptMessageDigestSha512 extends MessageDigestSpi {
+public final class WolfCryptMessageDigestSha512
+    extends MessageDigestSpi implements Cloneable {
 
     /* internal reference to wolfCrypt JNI Sha object */
     private Sha512 sha;
@@ -46,6 +47,16 @@ public final class WolfCryptMessageDigestSha512 extends MessageDigestSpi {
 
         sha = new Sha512();
         sha.init();
+    }
+
+    /**
+     * Create new WolfCryptMessageDigestSha512 based on existing Sha512 object.
+     * Existing object should already be initialized.
+     *
+     * @param sha initialized Sha512 object to be used with this MessageDigest
+     */
+    private WolfCryptMessageDigestSha512(Sha512 sha) {
+        this.sha = sha;
     }
 
     @Override
@@ -104,6 +115,12 @@ public final class WolfCryptMessageDigestSha512 extends MessageDigestSpi {
 
     private void log(String msg) {
         debug.print("[MessageDigest, SHA512] " + msg);
+    }
+
+    @Override
+    public Object clone() {
+        Sha512 shaCopy = new Sha512(this.sha);
+        return new WolfCryptMessageDigestSha512(shaCopy);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/wolfcrypt/Md5.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Md5.java
@@ -48,6 +48,16 @@ public class Md5 extends MessageDigest {
     protected native void native_init();
 
     /**
+     * Copy existing native WC_MD5 struct (Md5 object) into this one.
+     * Copies structure state using wc_Md5Copy().
+     *
+     * @param toBeCopied initialized Md5 object to be copied.
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    protected native void native_copy(Md5 toBeCopied);
+
+    /**
      * Native Md5 update
      *
      * @param data input data
@@ -93,6 +103,18 @@ public class Md5 extends MessageDigest {
      */
     public Md5() {
         init();
+    }
+
+    /**
+     * Create new Md5 object by making a copy of the one given.
+     *
+     * @param md5 Initialized/created Md5 object to be copied
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    public Md5(Md5 md5) {
+        init();
+        native_copy(md5);
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha.java
@@ -48,6 +48,16 @@ public class Sha extends MessageDigest {
     protected native void native_init();
 
     /**
+     * Copy existing native WC_SHA struct (Sha object) into this one.
+     * Copies structure state using wc_ShaCopy().
+     *
+     * @param toBeCopied initialized Sha object to be copied.
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    protected native void native_copy(Sha toBeCopied);
+
+    /**
      * Native SHA-1 update
      *
      * @param data input data
@@ -93,6 +103,18 @@ public class Sha extends MessageDigest {
      */
     public Sha() {
         init();
+    }
+
+    /**
+     * Create new SHA-1 object by making a copy of the one given.
+     *
+     * @param sha Initialized/created Sha object to be copied
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    public Sha(Sha sha) {
+        init();
+        native_copy(sha);
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha256.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha256.java
@@ -48,6 +48,16 @@ public class Sha256 extends MessageDigest {
     protected native void native_init();
 
     /**
+     * Copy existing native WC_SHA256 struct (Sha256 object) into this one.
+     * Copies structure state using wc_Sha256Copy().
+     *
+     * @param toBeCopied initialized Sha256 object to be copied.
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    protected native void native_copy(Sha256 toBeCopied);
+
+    /**
      * Native SHA2-256 update
      *
      * @param data input data
@@ -93,6 +103,18 @@ public class Sha256 extends MessageDigest {
      */
     public Sha256() {
         init();
+    }
+
+    /**
+     * Create new SHA2-256 object by making a copy of the one given.
+     *
+     * @param sha256 Initialized/created Sha256 object to be copied
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    public Sha256(Sha256 sha256) {
+        init();
+        native_copy(sha256);
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha384.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha384.java
@@ -48,6 +48,16 @@ public class Sha384 extends MessageDigest {
     protected native void native_init();
 
     /**
+     * Copy existing native WC_SHA384 struct (Sha384 object) into this one.
+     * Copies structure state using wc_Sha384Copy().
+     *
+     * @param toBeCopied initialized Sha384 object to be copied.
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    protected native void native_copy(Sha384 toBeCopied);
+
+    /**
      * Native SHA2-384 update
      *
      * @param data input data
@@ -93,6 +103,18 @@ public class Sha384 extends MessageDigest {
      */
     public Sha384() {
         init();
+    }
+
+    /**
+     * Create new SHA2-384 object by making a copy of the one given.
+     *
+     * @param sha384 Initialized/created Sha384 object to be copied
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    public Sha384(Sha384 sha384) {
+        init();
+        native_copy(sha384);
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha512.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha512.java
@@ -48,6 +48,16 @@ public class Sha512 extends MessageDigest {
     protected native void native_init();
 
     /**
+     * Copy existing native WC_SHA512 struct (Sha512 object) into this one.
+     * Copies structure state using wc_Sha512Copy().
+     *
+     * @param toBeCopied initialized Sha512 object to be copied.
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    protected native void native_copy(Sha512 toBeCopied);
+
+    /**
      * Native SHA2-512 update
      *
      * @param data input data
@@ -93,6 +103,18 @@ public class Sha512 extends MessageDigest {
      */
     public Sha512() {
         init();
+    }
+
+    /**
+     * Create new SHA2-512 object by making a copy of the one given.
+     *
+     * @param sha512 Initialized/created Sha512 object to be copied
+     *
+     * @throws WolfCryptException if native operation fails
+     */
+    public Sha512(Sha512 sha512) {
+        init();
+        native_copy(sha512);
     }
 
     /**

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
@@ -186,6 +186,42 @@ public class WolfCryptMessageDigestMd5Test {
     }
 
     @Test
+    public void testMd5Clone()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               CloneNotSupportedException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0xb1, (byte)0x0a, (byte)0x8d, (byte)0xb1,
+            (byte)0x64, (byte)0xe0, (byte)0x75, (byte)0x41,
+            (byte)0x05, (byte)0xb7, (byte)0xa9, (byte)0x9b,
+            (byte)0xe7, (byte)0x2e, (byte)0x3f, (byte)0xe5
+        };
+
+        byte[] output;
+        byte[] output2;
+
+        MessageDigest md5 = MessageDigest.getInstance("MD5", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            md5.update(inArray[i]);
+        }
+
+        /* Try to clone existing MessageDigest, should copy over same state */
+        MessageDigest md5Copy = (MessageDigest)md5.clone();
+
+        output = md5.digest();
+        output2 = md5Copy.digest();
+
+        assertEquals(expected.length, output.length);
+        assertEquals(expected.length, output2.length);
+
+        assertArrayEquals(expected, output);
+        assertArrayEquals(expected, output2);
+    }
+
+    @Test
     public void testMd5Interop()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
@@ -171,6 +171,46 @@ public class WolfCryptMessageDigestSha256Test {
     }
 
     @Test
+    public void testSha256Clone()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               CloneNotSupportedException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0xa5, (byte)0x91, (byte)0xa6, (byte)0xd4,
+            (byte)0x0b, (byte)0xf4, (byte)0x20, (byte)0x40,
+            (byte)0x4a, (byte)0x01, (byte)0x17, (byte)0x33,
+            (byte)0xcf, (byte)0xb7, (byte)0xb1, (byte)0x90,
+            (byte)0xd6, (byte)0x2c, (byte)0x65, (byte)0xbf,
+            (byte)0x0B, (byte)0xcd, (byte)0xa3, (byte)0x2b,
+            (byte)0x57, (byte)0xb2, (byte)0x77, (byte)0xd9,
+            (byte)0xad, (byte)0x9f, (byte)0x14, (byte)0x6e
+        };
+
+        byte[] output;
+        byte[] output2;
+
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha256.update(inArray[i]);
+        }
+
+        /* Try to clone existing MessageDigest, should copy over same state */
+        MessageDigest sha256Copy = (MessageDigest)sha256.clone();
+
+        output = sha256.digest();
+        output2 = sha256Copy.digest();
+
+        assertEquals(expected.length, output.length);
+        assertEquals(expected.length, output2.length);
+
+        assertArrayEquals(expected, output);
+        assertArrayEquals(expected, output2);
+    }
+
+    @Test
     public void testSha256Interop()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
@@ -184,6 +184,89 @@ public class WolfCryptMessageDigestSha384Test {
     }
 
     @Test
+    public void testSha384Reset()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0x99, (byte)0x51, (byte)0x43, (byte)0x29,
+            (byte)0x18, (byte)0x6b, (byte)0x2f, (byte)0x6a,
+            (byte)0xe4, (byte)0xa1, (byte)0x32, (byte)0x9e,
+            (byte)0x7e, (byte)0xe6, (byte)0xc6, (byte)0x10,
+            (byte)0xa7, (byte)0x29, (byte)0x63, (byte)0x63,
+            (byte)0x35, (byte)0x17, (byte)0x4a, (byte)0xc6,
+            (byte)0xb7, (byte)0x40, (byte)0xf9, (byte)0x02,
+            (byte)0x83, (byte)0x96, (byte)0xfc, (byte)0xc8,
+            (byte)0x03, (byte)0xd0, (byte)0xe9, (byte)0x38,
+            (byte)0x63, (byte)0xa7, (byte)0xc3, (byte)0xd9,
+            (byte)0x0f, (byte)0x86, (byte)0xbe, (byte)0xee,
+            (byte)0x78, (byte)0x2f, (byte)0x4f, (byte)0x3f
+        };
+
+        byte[] output;
+
+        MessageDigest sha384 = MessageDigest.getInstance("SHA-384", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha384.update(inArray[i]);
+        }
+
+        sha384.reset();
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha384.update(inArray[i]);
+        }
+        output = sha384.digest();
+        assertEquals(expected.length, output.length);
+        assertArrayEquals(expected, output);
+    }
+
+    @Test
+    public void testSha384Clone()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               CloneNotSupportedException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0x99, (byte)0x51, (byte)0x43, (byte)0x29,
+            (byte)0x18, (byte)0x6b, (byte)0x2f, (byte)0x6a,
+            (byte)0xe4, (byte)0xa1, (byte)0x32, (byte)0x9e,
+            (byte)0x7e, (byte)0xe6, (byte)0xc6, (byte)0x10,
+            (byte)0xa7, (byte)0x29, (byte)0x63, (byte)0x63,
+            (byte)0x35, (byte)0x17, (byte)0x4a, (byte)0xc6,
+            (byte)0xb7, (byte)0x40, (byte)0xf9, (byte)0x02,
+            (byte)0x83, (byte)0x96, (byte)0xfc, (byte)0xc8,
+            (byte)0x03, (byte)0xd0, (byte)0xe9, (byte)0x38,
+            (byte)0x63, (byte)0xa7, (byte)0xc3, (byte)0xd9,
+            (byte)0x0f, (byte)0x86, (byte)0xbe, (byte)0xee,
+            (byte)0x78, (byte)0x2f, (byte)0x4f, (byte)0x3f
+        };
+
+        byte[] output;
+        byte[] output2;
+
+        MessageDigest sha384 = MessageDigest.getInstance("SHA-384", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha384.update(inArray[i]);
+        }
+
+        /* Try to clone existing MessageDigest, should copy over same state */
+        MessageDigest sha384Copy = (MessageDigest)sha384.clone();
+
+        output = sha384.digest();
+        output2 = sha384Copy.digest();
+
+        assertEquals(expected.length, output.length);
+        assertEquals(expected.length, output2.length);
+
+        assertArrayEquals(expected, output);
+        assertArrayEquals(expected, output2);
+    }
+
+    @Test
     public void testSha384Interop()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
@@ -247,6 +247,54 @@ public class WolfCryptMessageDigestSha512Test {
     }
 
     @Test
+    public void testSha512Clone()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               CloneNotSupportedException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0x2c, (byte)0x74, (byte)0xfd, (byte)0x17,
+            (byte)0xed, (byte)0xaf, (byte)0xd8, (byte)0x0e,
+            (byte)0x84, (byte)0x47, (byte)0xb0, (byte)0xd4,
+            (byte)0x67, (byte)0x41, (byte)0xee, (byte)0x24,
+            (byte)0x3b, (byte)0x7e, (byte)0xb7, (byte)0x4d,
+            (byte)0xd2, (byte)0x14, (byte)0x9a, (byte)0x0a,
+            (byte)0xb1, (byte)0xb9, (byte)0x24, (byte)0x6f,
+            (byte)0xb3, (byte)0x03, (byte)0x82, (byte)0xf2,
+            (byte)0x7e, (byte)0x85, (byte)0x3d, (byte)0x85,
+            (byte)0x85, (byte)0x71, (byte)0x9e, (byte)0x0e,
+            (byte)0x67, (byte)0xcb, (byte)0xda, (byte)0x0d,
+            (byte)0xaa, (byte)0x8f, (byte)0x51, (byte)0x67,
+            (byte)0x10, (byte)0x64, (byte)0x61, (byte)0x5d,
+            (byte)0x64, (byte)0x5a, (byte)0xe2, (byte)0x7a,
+            (byte)0xcb, (byte)0x15, (byte)0xbf, (byte)0xb1,
+            (byte)0x44, (byte)0x7f, (byte)0x45, (byte)0x9b
+        };
+
+        byte[] output;
+        byte[] output2;
+
+        MessageDigest sha512 = MessageDigest.getInstance("SHA-512", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha512.update(inArray[i]);
+        }
+
+        /* Try to clone existing MessageDigest, should copy over same state */
+        MessageDigest sha512Copy = (MessageDigest)sha512.clone();
+
+        output = sha512.digest();
+        output2 = sha512Copy.digest();
+
+        assertEquals(expected.length, output.length);
+        assertEquals(expected.length, output2.length);
+
+        assertArrayEquals(expected, output);
+        assertArrayEquals(expected, output2);
+    }
+
+    @Test
     public void testSha512Interop()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
@@ -31,6 +31,7 @@ import java.security.Provider;
 import java.security.MessageDigest;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
+import java.lang.CloneNotSupportedException;
 
 import com.wolfssl.wolfcrypt.Sha;
 import com.wolfssl.provider.jce.WolfCryptProvider;
@@ -184,6 +185,43 @@ public class WolfCryptMessageDigestShaTest {
         output = sha.digest();
         assertEquals(expected.length, output.length);
         assertArrayEquals(expected, output);
+    }
+
+    @Test
+    public void testShaClone()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               CloneNotSupportedException {
+
+        String input = "Hello World";
+        byte[] inArray = input.getBytes();
+        final byte expected[] = new byte[] {
+            (byte)0x0a, (byte)0x4d, (byte)0x55, (byte)0xa8,
+            (byte)0xd7, (byte)0x78, (byte)0xe5, (byte)0x02,
+            (byte)0x2f, (byte)0xab, (byte)0x70, (byte)0x19,
+            (byte)0x77, (byte)0xc5, (byte)0xd8, (byte)0x40,
+            (byte)0xbb, (byte)0xc4, (byte)0x86, (byte)0xd0
+        };
+
+        byte[] output;
+        byte[] output2;
+
+        MessageDigest sha = MessageDigest.getInstance("SHA-1", "wolfJCE");
+
+        for (int i = 0; i < inArray.length; i++) {
+            sha.update(inArray[i]);
+        }
+
+        /* Try to clone existing MessageDigest, should copy over same state */
+        MessageDigest shaCopy = (MessageDigest)sha.clone();
+
+        output = sha.digest();
+        output2 = shaCopy.digest();
+
+        assertEquals(expected.length, output.length);
+        assertEquals(expected.length, output2.length);
+
+        assertArrayEquals(expected, output);
+        assertArrayEquals(expected, output2);
     }
 
     @Test

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
@@ -23,6 +23,9 @@ package com.wolfssl.wolfcrypt.test;
 
 import static org.junit.Assert.*;
 
+import java.nio.ByteBuffer;
+import javax.crypto.ShortBufferException;
+
 import org.junit.Test;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -33,6 +36,9 @@ import com.wolfssl.wolfcrypt.WolfCryptError;
 import com.wolfssl.wolfcrypt.WolfCryptException;
 
 public class Md5Test {
+    private ByteBuffer data = ByteBuffer.allocateDirect(128);
+    private ByteBuffer result = ByteBuffer.allocateDirect(Md5.DIGEST_SIZE);
+    private ByteBuffer expected = ByteBuffer.allocateDirect(Md5.DIGEST_SIZE);
 
     @BeforeClass
     public static void checkMd5IsAvailable() {
@@ -51,4 +57,150 @@ public class Md5Test {
         assertNotEquals(NativeStruct.NULL, new Md5().getNativeStruct());
     }
 
+    @Test
+    public void hashShouldMatchUsingByteBuffer() throws ShortBufferException {
+        String[] dataVector = new String[] {
+            "",
+            "616263",
+            "6D65737361676520646967657374",
+            "6162636465666768696A6B6C6D6E6F707172737475767778797A",
+            "4142434445464748494A4B4C4D4E4F505152535455565758595A" +
+                "6162636465666768696A6B6C6D6E6F707172737475767778" +
+                "797A30313233343536373839",
+            "3132333435363738393031323334353637383930313233343536" +
+                "373839303132333435363738393031323334353637383930" +
+                "313233343536373839303132333435363738393031323334" +
+                "353637383930"
+        };
+        String[] hashVector = new String[] {
+            "d41d8cd98f00b204e9800998ecf8427e",
+            "900150983cd24fb0d6963f7d28e17f72",
+            "f96b697d7cb7938d525a2f31aaf161d0",
+            "c3fcd3d76192e4007dfb496cca67e13b",
+            "d174ab98d277d9f5a5611c2c9f419d9f",
+            "57edf4a22be3c955ac49da2e2107b67a"
+        };
+
+        for (int i = 0; i < dataVector.length; i++) {
+            Md5 md5 = new Md5();
+
+            data.put(Util.h2b(dataVector[i])).rewind();
+            expected.put(Util.h2b(hashVector[i])).rewind();
+
+            md5.update(data, dataVector[i].length() / 2);
+            md5.digest(result);
+            data.rewind();
+            result.rewind();
+
+            assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    public void hashShouldMatchUsingByteArray() {
+        String[] dataVector = new String[] {
+            "",
+            "616263",
+            "6D65737361676520646967657374",
+            "6162636465666768696A6B6C6D6E6F707172737475767778797A",
+            "4142434445464748494A4B4C4D4E4F505152535455565758595A" +
+                "6162636465666768696A6B6C6D6E6F707172737475767778" +
+                "797A30313233343536373839",
+            "3132333435363738393031323334353637383930313233343536" +
+                "373839303132333435363738393031323334353637383930" +
+                "313233343536373839303132333435363738393031323334" +
+                "353637383930"
+        };
+        String[] hashVector = new String[] {
+            "d41d8cd98f00b204e9800998ecf8427e",
+            "900150983cd24fb0d6963f7d28e17f72",
+            "f96b697d7cb7938d525a2f31aaf161d0",
+            "c3fcd3d76192e4007dfb496cca67e13b",
+            "d174ab98d277d9f5a5611c2c9f419d9f",
+            "57edf4a22be3c955ac49da2e2107b67a"
+        };
+
+        for (int i = 0; i < dataVector.length; i++) {
+            Md5 md5 = new Md5();
+
+            byte[] data = Util.h2b(dataVector[i]);
+            byte[] expected = Util.h2b(hashVector[i]);
+
+            md5.update(data);
+            byte[] result = md5.digest();
+
+            assertArrayEquals(expected, result);
+        }
+    }
+
+    @Test
+    public void releaseAndReInitObject() {
+
+        Md5 md5 = new Md5();
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("D05374DC381D9B52806446A71C8E79B1");
+        byte[] result = null;
+
+        md5.update(data);
+        result = md5.digest();
+        assertArrayEquals(expected, result);
+        md5.releaseNativeStruct();
+
+        /* test re-initializing object */
+        md5 = new Md5();
+        result = null;
+        md5.update(data);
+        result = md5.digest();
+        md5.releaseNativeStruct();
+    }
+
+    @Test
+    public void reuseObject() {
+
+        Md5 md5 = new Md5();
+        byte[] data  = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] data2 = new byte[] { 0x05, 0x06, 0x07, 0x08, 0x09 };
+        byte[] expected = Util.h2b("D05374DC381D9B52806446A71C8E79B1");
+        byte[] expected2 = Util.h2b("AAB3A52AB69EC2B75102EF3A7059EAC2");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        md5.update(data);
+        result = md5.digest();
+        assertArrayEquals(expected, result);
+
+        /* test reusing existing object after a call to digest() */
+        md5.update(data2);
+        result2 = md5.digest();
+        assertArrayEquals(expected2, result2);
+
+        md5.releaseNativeStruct();
+    }
+
+    @Test
+    public void copyObject() {
+
+        Md5 md5 = null;
+        Md5 md5Copy = null;
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("D05374DC381D9B52806446A71C8E79B1");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        md5 = new Md5();
+        md5.update(data);
+
+        /* test making copy of Md5, should retain same state */
+        md5Copy = new Md5(md5);
+
+        result = md5.digest();
+        result2 = md5Copy.digest();
+
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, result2);
+
+        md5.releaseNativeStruct();
+        md5Copy.releaseNativeStruct();
+    }
 }
+

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
@@ -160,4 +160,31 @@ public class Sha256Test {
 
         sha.releaseNativeStruct();
     }
+
+    @Test
+    public void copyObject() {
+
+        Sha256 sha = null;
+        Sha256 shaCopy = null;
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("08BB5E5D6EAAC1049EDE0893D30ED022" +
+                                   "B1A4D9B5B48DB414871F51C9CB35283D");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        sha = new Sha256();
+        sha.update(data);
+
+        /* test making copy of Sha256, should retain same state */
+        shaCopy = new Sha256(sha);
+
+        result = sha.digest();
+        result2 = shaCopy.digest();
+
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, result2);
+
+        sha.releaseNativeStruct();
+        shaCopy.releaseNativeStruct();
+    }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
@@ -171,4 +171,32 @@ public class Sha384Test {
 
         sha.releaseNativeStruct();
     }
+
+    @Test
+    public void copyObject() {
+
+        Sha384 sha = null;
+        Sha384 shaCopy = null;
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("561C16404A1B592406301780C0C2DF6A" +
+                                   "A0555F504F35BFBEAC810AE36A343B77" +
+                                   "6858C5E0DE56BB79607A34D2F67108F2");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        sha = new Sha384();
+        sha.update(data);
+
+        /* test making copy of Sha384, should retain same state */
+        shaCopy = new Sha384(sha);
+
+        result = sha.digest();
+        result2 = shaCopy.digest();
+
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, result2);
+
+        sha.releaseNativeStruct();
+        shaCopy.releaseNativeStruct();
+    }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
@@ -174,4 +174,33 @@ public class Sha512Test {
 
         sha.releaseNativeStruct();
     }
+
+    @Test
+    public void copyObject() {
+
+        Sha512 sha = null;
+        Sha512 shaCopy = null;
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("B7B70A0B14D7FA213C6CCD3CBFFC8BB8" +
+                                   "F8E11A85F1113B0EB26A00208F2B9B3A" +
+                                   "1DD4AAF39962861E16AB062274342A1C" +
+                                   "E1F9DBA3654F36FC338245589F296C28");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        sha = new Sha512();
+        sha.update(data);
+
+        /* test making copy of Sha512, should retain same state */
+        shaCopy = new Sha512(sha);
+
+        result = sha.digest();
+        result2 = shaCopy.digest();
+
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, result2);
+
+        sha.releaseNativeStruct();
+        shaCopy.releaseNativeStruct();
+    }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
@@ -24,7 +24,6 @@ package com.wolfssl.wolfcrypt.test;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-
 import javax.crypto.ShortBufferException;
 
 import org.junit.Test;
@@ -158,6 +157,32 @@ public class ShaTest {
         assertArrayEquals(expected2, result2);
 
         sha.releaseNativeStruct();
+    }
+
+    @Test
+    public void copyObject() {
+
+        Sha sha = null;
+        Sha shaCopy = null;
+        byte[] data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        byte[] expected = Util.h2b("1CF251472D59F8FADEB3AB258E90999D8491BE19");
+        byte[] result = null;
+        byte[] result2 = null;
+
+        sha = new Sha();
+        sha.update(data);
+
+        /* test making copy of Sha, should retain same state */
+        shaCopy = new Sha(sha);
+
+        result = sha.digest();
+        result2 = shaCopy.digest();
+
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, result2);
+
+        sha.releaseNativeStruct();
+        shaCopy.releaseNativeStruct();
     }
 }
 


### PR DESCRIPTION
This PR adds support for clone() functionality to JCE MessageDigest classes.  To do this, we also wrap the native `wc_ShaCopy()`, etc APIs and add `copy()` support to the `com.wolfssl.wolfcrypt` message digest classes.

`MessageDigest.clone()` is now supported by:

```
com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigestMd5
com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigestSha
com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigestSha256
com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigestSha384
com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigestSha512
```

This PR also:
- Adds tests for both `com.wolfssl.wolfcrypt` and `com.wolfssl.wolfcrypt.provider.jce` levels for added functionality.
- Improves error checking of native Md5 API calls (`jni_md5.c`)
- Adds missing `com.wolfssl.wolfcrypt.Md5` test cases
- Adds one missing `com.wolfssl.wolfcrypt.provider.jce.WolfCryptMessageDigest384` test case for `testSha384Reset()`