### PR TITLE
Prep for 1.5 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ files to be on your `JUNIT_HOME` path.
 
 To install and set up JUnit:
 
-a) Download "junit-4.13.jar" and "hamcrest-all-1.3.jar" from junit.org
+a) Download "junit-4.13.2.jar" and "hamcrest-all-1.3.jar" from junit.org
 
 b) Place these JAR files on your system and set `JUNIT_HOME` to point to
    that location:
@@ -158,6 +158,17 @@ that requires JCE provider JAR's to be authenticated.  Please see
 
 ### Revision History
 ---------
+
+#### wolfCrypt JNI Release 1.5.0 (11/14/2022)
+
+Release 1.5.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Add build compatibility for Java 7 (PR 38)
+- Add support for "SHA" algorithm string in wolfJCE (PR 39)
+- Add rpm package support (PR 40)
+- Add wolfJCE MessageDigest.clone() support (PR 41)
+- Improve error checking of native Md5 API calls (PR 41)
+- Add unit tests for com.wolfssl.wolfcrypt.Md5 (PR 41)
 
 #### wolfCrypt JNI Release 1.4.0 (08/11/2022)
 

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.4" />
+    <property name="implementation.version" value="1.5" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
 #ifndef __ANDROID__
     #include <wolfssl/options.h>
 #endif
@@ -50,7 +51,7 @@ Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct(
     jlong ret = 0;
 
 #ifndef NO_MD5
-    ret = (jlong) XMALLOC(sizeof(Md5), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ret = (jlong)(uintptr_t)XMALLOC(sizeof(Md5), NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     if (!ret)
         throwOutOfMemoryException(env, "Failed to allocate Md5 object");

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -34,7 +34,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.4, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.5, "wolfCrypt JCE Provider");
 
         /* MessageDigest */
         if (FeatureDetect.Md5Enabled()) {


### PR DESCRIPTION
This PR preps for v1.5 release:
- Bumps version in WolfCryptProvider.java
- Bumps version in build.xml
- Adds release notes to README.md
- Adds one cast to `uintptr_t` to Md5.java