### PR TITLE
Add SecureRandom test to ProviderTest example

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -68,6 +68,23 @@ The JCE provider currently supports the following algorithms:
         EC
         DH
 
+### SecureRandom.getInstanceStrong()
+
+When registered as the highest priority security provider, wolfJCE will provide
+`SecureRandom` with the underlying `HashDRBG` algorithm.
+
+Java applications can alternatively call the `SecureRandom.getInstanceStrong()`
+API to get a "known strong SecureRandom implementation". To provide this
+with wolfJCE, the `java.security` file needs to be modified by setting the
+`securerandom.strongAlgorithms` property to:
+
+```
+securerandom.strongAlgorithms=HashDRBG:wolfJCE
+```
+
+Note that the `securerandom.source` property in `java.security` has no affect
+on the wolfJCE provider.
+
 ### Example / Test Code
 ---------
 

--- a/examples/provider/ProviderTest.java
+++ b/examples/provider/ProviderTest.java
@@ -22,6 +22,7 @@
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
+import java.security.SecureRandom;
 
 import com.wolfssl.provider.jce.WolfCryptProvider;
 
@@ -64,6 +65,23 @@ public class ProviderTest {
             System.out.println("Info: " + p.getInfo());
             System.out.println("Services:");
             System.out.println(p.getServices());
+        }
+
+        /* Test which Provider provides SecureRandom */
+        System.out.println(
+              "\nWhat Provider is providing SecureRandom?");
+        System.out.println("--------------------------------");
+        SecureRandom sr = new SecureRandom();
+        Provider prov = sr.getProvider();
+        System.out.println("\tnew SecureRandom() = " + prov);
+
+        /* Test which Provider provides SecureRandom.getInstanceStrong() */
+        try {
+            sr = SecureRandom.getInstanceStrong();
+            prov = sr.getProvider();
+            System.out.println("\tgetInstanceStrong() = " + prov);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
This PR adds a test to the `examples/provider/ProviderTest.java` example which prints out the provider for `new SecureRandom()` and `SecureRandom.getInstanceStrong()`.

The provider for `getInstanceStrong()` is controlled in the system `java.security` file by setting the following property:

```
securerandom.strongAlgorithms=HashDRBG:wolfJCE
```

This example can be built and run with:

```
$ cp makefile.linux makefile
$ make
$ ant build-jce-debug
$ ./examples/provider/ProviderTest.sh
```

If wolfJCE has been installed correctly in `java.security` for `getInstanceStrong()`, you will see:

```
What Provider is providing SecureRandom?
--------------------------------
wolfJCE: [Random] initialized new object
	new SecureRandom() = wolfJCE version 1.5
wolfJCE: [Random] initialized new object
	getInstanceStrong() = wolfJCE version 1.5
```