### PR TITLE
Facebook Infer script and fixes

### DIFF
--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Simple script to run Facebook Infer over java files included in this package.
+#
+# This is set up to run entire infer over Java classes in this package. To
+# only run the RacerD thread safety analysis tool, change the command
+# invocation below from "run" to "--racerd-only", ie:
+#
+# infer --racerd-only -- javac \
+#
+# Run from wolfssljni root:
+#
+#    $ cd wolfcryptjni
+#    $ ./scripts/infer.sh
+#
+# wolfSSL Inc, May 2023
+#
+
+infer run -- javac \
+    src/main/java/com/wolfssl/wolfcrypt/Aes.java \
+    src/main/java/com/wolfssl/wolfcrypt/Asn.java \
+    src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java \
+    src/main/java/com/wolfssl/wolfcrypt/Chacha.java \
+    src/main/java/com/wolfssl/wolfcrypt/Curve25519.java \
+    src/main/java/com/wolfssl/wolfcrypt/Des3.java \
+    src/main/java/com/wolfssl/wolfcrypt/Dh.java \
+    src/main/java/com/wolfssl/wolfcrypt/Ecc.java \
+    src/main/java/com/wolfssl/wolfcrypt/Ed25519.java \
+    src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java \
+    src/main/java/com/wolfssl/wolfcrypt/Fips.java \
+    src/main/java/com/wolfssl/wolfcrypt/Hmac.java \
+    src/main/java/com/wolfssl/wolfcrypt/Logging.java \
+    src/main/java/com/wolfssl/wolfcrypt/Md5.java \
+    src/main/java/com/wolfssl/wolfcrypt/MessageDigest.java \
+    src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java \
+    src/main/java/com/wolfssl/wolfcrypt/Rng.java \
+    src/main/java/com/wolfssl/wolfcrypt/Rsa.java \
+    src/main/java/com/wolfssl/wolfcrypt/Sha256.java \
+    src/main/java/com/wolfssl/wolfcrypt/Sha384.java \
+    src/main/java/com/wolfssl/wolfcrypt/Sha512.java \
+    src/main/java/com/wolfssl/wolfcrypt/Sha.java \
+    src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java \
+    src/main/java/com/wolfssl/wolfcrypt/WolfCryptException.java \
+    src/main/java/com/wolfssl/wolfcrypt/WolfCrypt.java \
+    src/main/java/com/wolfssl/wolfcrypt/WolfCryptState.java \
+    src/main/java/com/wolfssl/wolfcrypt/WolfObject.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+
+# remove compiled class files
+rm -r ./com
+
+# remove infer out directory (comment this out to inspect logs if needed)
+rm -r ./infer-out
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -646,7 +646,9 @@ public class WolfCryptCipher extends CipherSpi {
                 inputLen + ", out offset: " + outputOffset + ")");
 
         tmpOut = wolfCryptUpdate(input, inputOffset, inputLen);
-
+        if (tmpOut == null) {
+            return 0;
+        }
         System.arraycopy(tmpOut, 0, output, outputOffset, tmpOut.length);
 
         return tmpOut.length;

--- a/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
@@ -75,8 +75,8 @@ public class FeatureDetect {
     static {
         int fipsLoaded = 0;
 
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.contains("win")) {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("win")) {
             try {
                 /* Default wolfCrypt FIPS library on Windows is compiled
                  * as "wolfssl-fips" by Visual Studio solution */

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
@@ -42,8 +42,8 @@ public class WolfObject {
     static {
         int fipsLoaded = 0;
 
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.contains("win")) {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("win")) {
             try {
                 /* Default wolfCrypt FIPS library on Windows is compiled
                  * as "wolfssl-fips" by Visual Studio solution */


### PR DESCRIPTION
This PR adds a simple bash script to run Facebook Infer over Java classes in this project:

```
$ cd wolfcryptjni
$ ./scripts/infer.sh
```

This also fixes reports that showed up on the current codebase.