### PR TITLE
Add JCE KeyPairGenerator support for "RSA"

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -65,6 +65,7 @@ The JCE provider currently supports the following algorithms:
         ECDH
 
     KeyPairGenerator Class
+        RSA
         EC
         DH
 

--- a/jni/include/com_wolfssl_wolfcrypt_Rsa.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Rsa.h
@@ -59,6 +59,30 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Rsa_MakeRsaKey
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Rsa
+ * Method:    wc_RsaKeyToDer
+ * Signature: ()[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaKeyToDer
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Rsa
+ * Method:    wc_RsaKeyToPublicDer
+ * Signature: ()[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaKeyToPublicDer
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Rsa
+ * Method:    wc_RsaPrivateKeyToPkcs8
+ * Signature: ()[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPrivateKeyToPkcs8
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Rsa
  * Method:    wc_InitRsaKey
  * Signature: ()V
  */
@@ -144,6 +168,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSSL_1Sign
  */
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSSL_1Verify
   (JNIEnv *, jobject, jbyteArray);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Rsa
+ * Method:    getDefaultRsaExponent
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Rsa_getDefaultRsaExponent
+  (JNIEnv *, jclass);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -136,6 +136,8 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfCryptKeyAgreement$wcECDH");
 
         /* KeyPairGenerator */
+        put("KeyPairGenerator.RSA",
+                "com.wolfssl.provider.jce.WolfCryptKeyPairGenerator$wcKeyPairGenRSA");
         put("KeyPairGenerator.EC",
                 "com.wolfssl.provider.jce.WolfCryptKeyPairGenerator$wcKeyPairGenECC");
         put("KeyPairGenerator.DH",

--- a/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
@@ -170,7 +170,7 @@ public class Ecc extends NativeStruct {
             wc_ecc_check_key();
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -225,7 +225,7 @@ public class Ecc extends NativeStruct {
             return wc_ecc_export_private();
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -259,7 +259,7 @@ public class Ecc extends NativeStruct {
             return wc_ecc_export_x963();
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -293,7 +293,7 @@ public class Ecc extends NativeStruct {
             return wc_EccKeyToDer();
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -327,7 +327,7 @@ public class Ecc extends NativeStruct {
             return wc_EccPublicKeyToDer();
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -346,7 +346,7 @@ public class Ecc extends NativeStruct {
             return wc_ecc_shared_secret(pubKey, this.rng);
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
     }
 
@@ -368,7 +368,7 @@ public class Ecc extends NativeStruct {
             signature = wc_ecc_sign_hash(hash, rng);
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
 
         return signature;
@@ -392,7 +392,7 @@ public class Ecc extends NativeStruct {
             result = wc_ecc_verify_hash(hash, signature);
         } else {
             throw new IllegalStateException(
-                    "No available key to perform the opperation.");
+                    "No available key to perform the operation.");
         }
 
         return result;

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import com.wolfssl.wolfcrypt.Rsa;
 import com.wolfssl.wolfcrypt.Rng;
+import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.NativeStruct;
 import com.wolfssl.wolfcrypt.WolfCryptError;
 import com.wolfssl.wolfcrypt.WolfCryptException;
@@ -60,10 +61,177 @@ public class RsaTest {
     }
 
     @Test
-    public void makeKeyShouldNotRaiseExceptions() {
-        Rsa key = new Rsa();
+    public void testMakeKey() {
 
+        Rsa key = new Rsa();
         key.makeKey(1024, 65537, rng);
+        key.releaseNativeStruct();
+
+        key = new Rsa();
+        key.makeKey(2048, 65537, rng);
+        key.releaseNativeStruct();
+
+        key = new Rsa();
+        key.makeKey(3072, 65537, rng);
+        key.releaseNativeStruct();
+
+        key = new Rsa();
+        key.makeKey(4096, 65537, rng);
+        key.releaseNativeStruct();
+    }
+
+    @Test
+    public void testDerExportImportSignVerify() {
+
+        /* generate new 2048-bit key */
+        Rsa key = new Rsa();
+        key.makeKey(2048, 65537, rng);
+
+        /* export key to DER */
+        byte[] rsaDer = key.exportPrivateDer();
+        assertNotNull(rsaDer);
+        assertTrue(rsaDer.length > 0);
+        key.releaseNativeStruct();
+
+        /* try to re-import DER into new Rsa object */
+        key = new Rsa();
+        key.decodePrivateKey(rsaDer);
+
+        /* sign data */
+        byte[] data = "Hello wolfSSL".getBytes();
+        byte[] signed = key.sign(data, rng);
+
+        /* verify data matches original */
+        byte[] verify = key.verify(signed);
+        assertNotNull(verify);
+        assertArrayEquals(data, verify);
+
+        key.releaseNativeStruct();
+    }
+
+    @Test
+    public void rsaPrivateToPkcs8() {
+        Rsa key = new Rsa();
+        byte[] pkcs8;
+        int size;
+        byte[] prvKey = Util.h2b(
+                "308204a40201000282010100c303d12bfe39a432453b53c8842b2a7c"
+              + "749abdaa2a520747d6a636b207328ed0ba697bc6c3449ed48148"
+              + "fd2d68a28b67bba175c8362c4ad21bf78bbacf0df9efecf1811e"
+              + "7b9b03479abf65cc7f652469a6e814895be434f7c5b01493f567"
+              + "7b3a7a78e101565691a613428dd23c409c4cefd186df37511b0c"
+              + "a13bf5f1a34a35e4e1ce96df1b7ebf4e97d010e8a8083081af20"
+              + "0b4314c57467b432826f8d86c28840993683ba1e40722217d752"
+              + "652473b0ceef19cdaeff786c7bc01203d44e720d506d3ba33ba3"
+              + "995e9dc8d90c85b3d98ad95426db6dfaacbbff254cc4d179f471"
+              + "d386401813b063b5724e30c49784862d562fd715f77fc0aef5fc"
+              + "5be5fba1bad302030100010282010100a2e6d85f107164089e2e"
+              + "6dd16d1e85d20ab18c47ce2c516aa0129e53de914c1d6dea597b"
+              + "f277aad9c6d98aabd8e116e46326ffb56c1359b8e3a5c872172e"
+              + "0c9f6fe5593f766f49b111c25a2e16290ddeb78edc40d5a2eee0"
+              + "1ea1f4be97db86639614cd9809602d30769c3ccde688ee479279"
+              + "0b5a00e25e5f117c7df908b72006892a5dfd00ab22e1f0b3bc24"
+              + "a95e260e1f002dfe219a535b6dd32bab9482684336d8f62fc622"
+              + "fcb5415d0d3360eaa47d7ee84b559156d35c578f1f94172faade"
+              + "e99ea8f4cf8a4c8ea0e45673b2cf4f86c5693cf324208b5c960c"
+              + "fa6b123b9a67c1dfc696b2a5d5920d9b094268241045d450e417"
+              + "3948d0358b946d11de8fca5902818100ea24a7f96933e971dc52"
+              + "7d8821282f49deba7216e9cc477a880d94578458163a81b03fa2"
+              + "cfa66c1eb00629008fe77776acdbcac7d95e9b3f269052aefc38"
+              + "900014bbb40f5894e72f6a7e1c4f4121d431591f4e8a1a8da757"
+              + "6c22d8e5f47e32a610cb64a5550387a627058cc3d7b627b24dba"
+              + "30da478f54d33d8b848d949858a502818100d5381bc38fc5930c"
+              + "470b6f3592c5b08d46c892188ff5800af7efa1fe80b9b52abaca"
+              + "18b05da507d0938dd89c041cd4628ea6268101ffce8a2a633435"
+              + "40aa6d80de89236a574d9e6ead934e56900b6d9d738b0cae273d"
+              + "de4ef0aac56c78676c94529c37676c2defbbafdfa6903cc447cf"
+              + "8d969e98a9b49fc5a650dcb3f0fb74170281805e830962bdba7c"
+              + "a2bf4274f57c1cd269c9040d857e3e3d2412c3187bf329f35f0e"
+              + "766c5975e44184699d32f3cd22abb035ba4ab23ce5d958b6624f"
+              + "5ddee59e0aca53b22cf79eb36b0a5b7965ec6e914e9220f6fcfc"
+              + "16edd3760ce2ec7fb269136b780e5a4664b45eb725a05a753a4b"
+              + "efc73c3ef7fd26b820c4990a9a73bec31902818100ba449314ac"
+              + "34193b5f9160acf7b4d681053651533de865dcaf2edc613ec97d"
+              + "b87f87f03b9b03822937ce724e11d5b1c10c07a099914a8d7fec"
+              + "79cff139b5e985ec62f7da7dbc644d223c0ef2d651f587d899c0"
+              + "11205d0f29fd5be2aed91cd921566dfc84d05fed10151c1821e7"
+              + "c43d4bd7d09e6a95cf22c9037b9ee36001fc2f02818011d04bcf"
+              + "1b67b99f1075478665ae31c2c630ac590650d90fb57006f7f0d3"
+              + "c8627ca8da6ef6213fd37f5fea8aab3fd92a5ef351d2c23037e3"
+              + "2da3750d1e4d2134d557705c89bf72ec4a6e68d5cd1874334e8c"
+              + "3a458fe69640eb63f919863a51dd894bb0f3f99f5d289538be35"
+              + "abca5ce7935334a1455d1339654246a19fcdf5bf");
+
+        byte[] expectedPkcs8 = Util.h2b(
+                "308204be020100300d06092a864886f70d0101010500048204a8"
+              + "308204a40201000282010100c303d12bfe39a432453b53c8842b"
+              + "2a7c749abdaa2a520747d6a636b207328ed0ba697bc6c3449ed4"
+              + "8148fd2d68a28b67bba175c8362c4ad21bf78bbacf0df9efecf1"
+              + "811e7b9b03479abf65cc7f652469a6e814895be434f7c5b01493"
+              + "f5677b3a7a78e101565691a613428dd23c409c4cefd186df3751"
+              + "1b0ca13bf5f1a34a35e4e1ce96df1b7ebf4e97d010e8a8083081"
+              + "af200b4314c57467b432826f8d86c28840993683ba1e40722217"
+              + "d752652473b0ceef19cdaeff786c7bc01203d44e720d506d3ba3"
+              + "3ba3995e9dc8d90c85b3d98ad95426db6dfaacbbff254cc4d179"
+              + "f471d386401813b063b5724e30c49784862d562fd715f77fc0ae"
+              + "f5fc5be5fba1bad302030100010282010100a2e6d85f10716408"
+              + "9e2e6dd16d1e85d20ab18c47ce2c516aa0129e53de914c1d6dea"
+              + "597bf277aad9c6d98aabd8e116e46326ffb56c1359b8e3a5c872"
+              + "172e0c9f6fe5593f766f49b111c25a2e16290ddeb78edc40d5a2"
+              + "eee01ea1f4be97db86639614cd9809602d30769c3ccde688ee47"
+              + "92790b5a00e25e5f117c7df908b72006892a5dfd00ab22e1f0b3"
+              + "bc24a95e260e1f002dfe219a535b6dd32bab9482684336d8f62f"
+              + "c622fcb5415d0d3360eaa47d7ee84b559156d35c578f1f94172f"
+              + "aadee99ea8f4cf8a4c8ea0e45673b2cf4f86c5693cf324208b5c"
+              + "960cfa6b123b9a67c1dfc696b2a5d5920d9b094268241045d450"
+              + "e4173948d0358b946d11de8fca5902818100ea24a7f96933e971"
+              + "dc527d8821282f49deba7216e9cc477a880d94578458163a81b0"
+              + "3fa2cfa66c1eb00629008fe77776acdbcac7d95e9b3f269052ae"
+              + "fc38900014bbb40f5894e72f6a7e1c4f4121d431591f4e8a1a8d"
+              + "a7576c22d8e5f47e32a610cb64a5550387a627058cc3d7b627b2"
+              + "4dba30da478f54d33d8b848d949858a502818100d5381bc38fc5"
+              + "930c470b6f3592c5b08d46c892188ff5800af7efa1fe80b9b52a"
+              + "baca18b05da507d0938dd89c041cd4628ea6268101ffce8a2a63"
+              + "343540aa6d80de89236a574d9e6ead934e56900b6d9d738b0cae"
+              + "273dde4ef0aac56c78676c94529c37676c2defbbafdfa6903cc4"
+              + "47cf8d969e98a9b49fc5a650dcb3f0fb74170281805e830962bd"
+              + "ba7ca2bf4274f57c1cd269c9040d857e3e3d2412c3187bf329f3"
+              + "5f0e766c5975e44184699d32f3cd22abb035ba4ab23ce5d958b6"
+              + "624f5ddee59e0aca53b22cf79eb36b0a5b7965ec6e914e9220f6"
+              + "fcfc16edd3760ce2ec7fb269136b780e5a4664b45eb725a05a75"
+              + "3a4befc73c3ef7fd26b820c4990a9a73bec31902818100ba4493"
+              + "14ac34193b5f9160acf7b4d681053651533de865dcaf2edc613e"
+              + "c97db87f87f03b9b03822937ce724e11d5b1c10c07a099914a8d"
+              + "7fec79cff139b5e985ec62f7da7dbc644d223c0ef2d651f587d8"
+              + "99c011205d0f29fd5be2aed91cd921566dfc84d05fed10151c18"
+              + "21e7c43d4bd7d09e6a95cf22c9037b9ee36001fc2f02818011d0"
+              + "4bcf1b67b99f1075478665ae31c2c630ac590650d90fb57006f7"
+              + "f0d3c8627ca8da6ef6213fd37f5fea8aab3fd92a5ef351d2c230"
+              + "37e32da3750d1e4d2134d557705c89bf72ec4a6e68d5cd187433"
+              + "4e8c3a458fe69640eb63f919863a51dd894bb0f3f99f5d289538"
+              + "be35abca5ce7935334a1455d1339654246a19fcdf5bf");
+
+        /* Test that exception is thrown without private key available */
+        try {
+            pkcs8 = key.privateKeyEncodePKCS8();
+            fail("Rsa.privateKeyEncodePKCS8() should throw exception");
+        } catch (IllegalStateException e) {
+            /* expected */
+        }
+
+        /* Test that encoded PKCS#8 private key matches expected */
+        key.decodePrivateKey(prvKey);
+        pkcs8 = key.privateKeyEncodePKCS8();
+        assertArrayEquals(pkcs8, expectedPkcs8);
+        key.releaseNativeStruct();
+
+        /* Test that generated key encodes without error */
+        key = new Rsa();
+        key.makeKey(1024, 65537, rng);
+        pkcs8 = key.privateKeyEncodePKCS8();
+        assertTrue(pkcs8 != null);
+        assertTrue(pkcs8.length != 0);
+        key.releaseNativeStruct();
     }
 
     @Test


### PR DESCRIPTION
This PR primarily adds RSA support for the JCE KeyPairGenerator class.  In addition, it also:

- Expands `com.wolfssl.wolfcrypt.Rsa` to support the KeyPairGenerator addition
- Clean up pass on native RSA and ECC code, better adhere to coding standards
- Fix typos in `com.wolfssl.wolfcrypt.Ecc` class