### PR TITLE
JCE: add support for Cipher AES/CBC/PKCS5Padding, RSA

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -38,6 +38,7 @@ The JCE provider currently supports the following algorithms:
 
     Cipher Class
         AES/CBC/NoPadding
+        AES/CBC/PKCS5Padding
         DESede/CBC/NoPadding
         RSA/ECB/PKCS1Padding
 

--- a/README_JCE.md
+++ b/README_JCE.md
@@ -40,6 +40,7 @@ The JCE provider currently supports the following algorithms:
         AES/CBC/NoPadding
         AES/CBC/PKCS5Padding
         DESede/CBC/NoPadding
+        RSA
         RSA/ECB/PKCS1Padding
 
     Mac Class

--- a/jni/jni_aes.c
+++ b/jni/jni_aes.c
@@ -36,20 +36,24 @@
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
+    void* ret = NULL;
 
 #ifndef NO_AES
-    ret = (jlong) XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ret = (void*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    if (!ret)
+    if (ret == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Aes object");
+    }
+    else {
+        XMEMSET(ret, 0, sizeof(Aes));
+    }
 
-    LogStr("new Aes() = %p\n", (void*)ret);
+    LogStr("new Aes() = %p\n", ret);
 #else
     throwNotCompiledInException(env);
 #endif
 
-    return ret;
+    return (jlong)ret;
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -868,7 +868,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1SetKey_1fips__Lcom_
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -908,7 +908,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1SetKey_1fips__Lcom_
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -948,7 +948,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1SetIV_1fips__Lcom_w
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -981,7 +981,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1SetIV_1fips__Lcom_w
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -1016,7 +1016,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1CbcEncrypt_1fips__L
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -1055,7 +1055,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1CbcEncrypt_1fips__L
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -1096,7 +1096,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1CbcDecrypt_1fips__L
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;
@@ -1135,7 +1135,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Des3_1CbcDecrypt_1fips__L
     jint ret = NOT_COMPILED_IN;
 
 #if defined(HAVE_FIPS) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)) && \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION <= 2)) && \
     !defined(NO_DES3)
 
     Des3* des = NULL;

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -127,6 +127,8 @@ public final class WolfCryptProvider extends Provider {
         put("Cipher.DESede/CBC/NoPadding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcDESedeCBCNoPadding");
 
+        put("Cipher.RSA",
+                "com.wolfssl.provider.jce.WolfCryptCipher$wcRSAECBPKCS1Padding");
         put("Cipher.RSA/ECB/PKCS1Padding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcRSAECBPKCS1Padding");
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -121,6 +121,8 @@ public final class WolfCryptProvider extends Provider {
         /* Cipher */
         put("Cipher.AES/CBC/NoPadding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcAESCBCNoPadding");
+        put("Cipher.AES/CBC/PKCS5Padding",
+                "com.wolfssl.provider.jce.WolfCryptCipher$wcAESCBCPKCS5Padding");
 
         put("Cipher.DESede/CBC/NoPadding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcDESedeCBCNoPadding");


### PR DESCRIPTION
This PR adds wolfJCE support for:

- `Cipher.AES/CBC/PKCS5Padding` (plus tests)
- `Cipher.RSA` (alias for `RSA/ECB/PKCS1Padding`)