### PR TITLE
Add Windows batch script to run ProviderTest example

### DIFF
--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -384,6 +384,30 @@ $ cp ./lib/signed/release/wolfcrypt-jni.jar ./lib
 $ ant test
 ```
 
+# Running Examples
+
+Windows batch scripts have been included to easily run some of the provided
+examples from the Windows command line.
+
+After the above steps have been followed to compile native wolfSSL and
+wolfCrypt JNI/JCE, open a Command Prompt and navigate to the wolfCrypt JNI/JCE
+directory root (ie: wolfcryptjni).
+
+The examples are already compiled as part of running ant above.
+
+Edit the Windows configuration batch script to set the appropriate paths
+for native wolfSSL and wolfCrypt JNI DLL locations. This can change between
+build types (ex: normal wolfSSL, FIPS 140-2, etc):
+
+**Edit examples\WindowsConfig.bat**
+
+From the root wolfcryptjni directory, run the desired .bat file. For example,
+to run the ProviderTest:
+
+```
+examples\provider\ProviderTest.bat
+```
+
 # Support
 
 For support, please contact support@wolfssl.com.

--- a/examples/WindowsConfig.bat
+++ b/examples/WindowsConfig.bat
@@ -1,0 +1,42 @@
+
+:: -----------------------------------------------------------------------------
+:: Build Configuration
+:: -----------------------------------------------------------------------------
+
+:: Set below directories containing native wolfSSL DLL and wolfSSL JNI DLL
+:: Default pathing expects wolfssl and wolfssljni dirs to be side by side
+:: May uncomment / comment lines below that match your build. This file is
+:: included by other example .bat files.
+
+:: wolfSSL Normal non-FIPS (DLL Debug x64)
+SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Debug\x64
+SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Debug\x64
+
+:: wolfSSL Normal non-FIPS (DLL Release x64)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Release\x64
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Release\x64
+
+:: wolfSSL Normal non-FIPS (DLL Debug Win32)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Debug\Win32
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Debug\Win32
+
+:: wolfSSL Normal non-FIPS (DLL Release Win32)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Release\Win32
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Release\Win32
+
+:: wolfSSL FIPS 140-2 #3389 Build (DLL Debug x64)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Debug\x64
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Debug FIPS\x64
+
+:: wolfSSL FIPS 140-2 #3389 Build (DLL Release x64)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Release\x64
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Release FIPS\x64
+
+:: wolfSSL FIPS 140-2 #3389 Build (DLL Debug Win32)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Debug\Win32
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Debug FIPS\Win32
+
+:: wolfSSL FIPS 140-2 #3389 Build (DLL Release Win32)
+:: SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Release\Win32
+:: SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Release FIPS\Win32
+

--- a/examples/provider/ProviderTest.bat
+++ b/examples/provider/ProviderTest.bat
@@ -1,0 +1,14 @@
+
+cd %~dp0\..\build >NUL 2>NUL
+SETLOCAL
+
+:: Populate correct config for build
+call ..\WindowsConfig.bat
+
+:: Set PATH to include DLL for native wolfSSL and wolfSSL JNI (native library)
+SET PATH="%WOLFCRYPTJNI_DLL_DIR%;%WOLFSSL_DLL_DIR%";%PATH%
+
+java -cp ".;.\provider;..\..\lib\wolfcrypt-jni.jar" -Djava.library.path="%WOLFCRYPTJNI_DLL_DIR%;%WOLFSSL_DLL_DIR%" ProviderTest
+
+ENDLOCAL
+cd %~dp0\..\..


### PR DESCRIPTION
This PR adds a Windows batch script to more easily run the ProviderTest example from the Windows Command Line.  This relates to the recent addition of Windows Visual Studio build support for wolfcryptjni.