### PR TITLE
Add synchronization around native pointers (Md5/Sha/Des3/Hmac/Aes/DhKey/RsaKey/ecc_key)

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Aes.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Aes.h
@@ -23,34 +23,34 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Aes_DECRYPT_MODE 1L
 /*
  * Class:     com_wolfssl_wolfcrypt_Aes
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Aes
- * Method:    native_set_key
+ * Method:    native_set_key_internal
  * Signature: ([B[BI)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1set_1key
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1set_1key_1internal
   (JNIEnv *, jobject, jbyteArray, jbyteArray, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Aes
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (I[BII[BI)I
  */
-JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update__I_3BII_3BI
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__I_3BII_3BI
   (JNIEnv *, jobject, jint, jbyteArray, jint, jint, jbyteArray, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Aes
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (ILjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;I)I
  */
-JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jint, jobject, jint, jint, jobject, jint);
 
 #ifdef __cplusplus

--- a/jni/include/com_wolfssl_wolfcrypt_Des3.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Des3.h
@@ -19,35 +19,35 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Des3_DECRYPT_MODE 1L
 /*
  * Class:     com_wolfssl_wolfcrypt_Des3
+ * Method:    native_set_key_internal
+ * Signature: ([B[BI)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1set_1key_1internal
+  (JNIEnv *, jobject, jbyteArray, jbyteArray, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Des3
+ * Method:    native_update_internal
+ * Signature: (I[BII[BI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__I_3BII_3BI
+  (JNIEnv *, jobject, jint, jbyteArray, jint, jint, jbyteArray, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Des3
+ * Method:    native_update_internal
+ * Signature: (ILjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;I)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
+  (JNIEnv *, jobject, jint, jobject, jint, jint, jobject, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Des3
  * Method:    mallocNativeStruct
  * Signature: ()J
  */
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Des3_mallocNativeStruct
   (JNIEnv *, jobject);
-
-/*
- * Class:     com_wolfssl_wolfcrypt_Des3
- * Method:    native_set_key
- * Signature: ([B[BI)V
- */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1set_1key
-  (JNIEnv *, jobject, jbyteArray, jbyteArray, jint);
-
-/*
- * Class:     com_wolfssl_wolfcrypt_Des3
- * Method:    native_update
- * Signature: (I[BII[BI)I
- */
-JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1update__I_3BII_3BI
-  (JNIEnv *, jobject, jint, jbyteArray, jint, jint, jbyteArray, jint);
-
-/*
- * Class:     com_wolfssl_wolfcrypt_Des3
- * Method:    native_update
- * Signature: (ILjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;I)I
- */
-JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1update__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
-  (JNIEnv *, jobject, jint, jobject, jint, jint, jobject, jint);
 
 #ifdef __cplusplus
 }

--- a/jni/include/com_wolfssl_wolfcrypt_Dh.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Dh.h
@@ -11,10 +11,10 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Dh_NULL 0LL
 /*
  * Class:     com_wolfssl_wolfcrypt_Dh
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Dh_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Dh_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*

--- a/jni/include/com_wolfssl_wolfcrypt_Md5.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Md5.h
@@ -15,58 +15,58 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Md5_DIGEST_SIZE 16L
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_init
+ * Method:    native_init_internal
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1init
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1init_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_copy
+ * Method:    native_copy_internal
  * Signature: (Lcom/wolfssl/wolfcrypt/Md5;)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy_1internal
   (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1update__Ljava_nio_ByteBuffer_2II
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal__Ljava_nio_ByteBuffer_2II
   (JNIEnv *, jobject, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: ([BII)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1update___3BII
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal___3BII
   (JNIEnv *, jobject, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: (Ljava/nio/ByteBuffer;I)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1final__Ljava_nio_ByteBuffer_2I
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal__Ljava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Md5
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: ([B)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1final___3B
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal___3B
   (JNIEnv *, jobject, jbyteArray);
 
 #ifdef __cplusplus

--- a/jni/include/com_wolfssl_wolfcrypt_Sha.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha.h
@@ -15,58 +15,58 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Sha_DIGEST_SIZE 20L
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_init
+ * Method:    native_init_internal
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1init
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1init_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_copy
+ * Method:    native_copy_internal
  * Signature: (Lcom/wolfssl/wolfcrypt/Sha;)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy_1internal
   (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1update__Ljava_nio_ByteBuffer_2II
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal__Ljava_nio_ByteBuffer_2II
   (JNIEnv *, jobject, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: ([BII)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1update___3BII
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal___3BII
   (JNIEnv *, jobject, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: (Ljava/nio/ByteBuffer;I)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1final__Ljava_nio_ByteBuffer_2I
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal__Ljava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: ([B)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1final___3B
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal___3B
   (JNIEnv *, jobject, jbyteArray);
 
 #ifdef __cplusplus

--- a/jni/include/com_wolfssl_wolfcrypt_Sha256.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha256.h
@@ -15,58 +15,58 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Sha256_DIGEST_SIZE 32L
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_init
+ * Method:    native_init_internal
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1init
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1init_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_copy
+ * Method:    native_copy_internal
  * Signature: (Lcom/wolfssl/wolfcrypt/Sha256;)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy_1internal
   (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1update__Ljava_nio_ByteBuffer_2II
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal__Ljava_nio_ByteBuffer_2II
   (JNIEnv *, jobject, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: ([BII)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1update___3BII
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal___3BII
   (JNIEnv *, jobject, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: (Ljava/nio/ByteBuffer;I)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1final__Ljava_nio_ByteBuffer_2I
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal__Ljava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha256
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: ([B)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1final___3B
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal___3B
   (JNIEnv *, jobject, jbyteArray);
 
 #ifdef __cplusplus

--- a/jni/include/com_wolfssl_wolfcrypt_Sha384.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha384.h
@@ -15,58 +15,58 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Sha384_DIGEST_SIZE 48L
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_init
+ * Method:    native_init_internal
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1init
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1init_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_copy
+ * Method:    native_copy_internal
  * Signature: (Lcom/wolfssl/wolfcrypt/Sha384;)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy_1internal
   (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1update__Ljava_nio_ByteBuffer_2II
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1update_1internal__Ljava_nio_ByteBuffer_2II
   (JNIEnv *, jobject, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: ([BII)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1update___3BII
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1update_1internal___3BII
   (JNIEnv *, jobject, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: (Ljava/nio/ByteBuffer;I)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1final__Ljava_nio_ByteBuffer_2I
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal__Ljava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha384
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: ([B)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1final___3B
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal___3B
   (JNIEnv *, jobject, jbyteArray);
 
 #ifdef __cplusplus

--- a/jni/include/com_wolfssl_wolfcrypt_Sha512.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Sha512.h
@@ -15,58 +15,58 @@ extern "C" {
 #define com_wolfssl_wolfcrypt_Sha512_DIGEST_SIZE 64L
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    mallocNativeStruct
+ * Method:    mallocNativeStruct_internal
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_init
+ * Method:    native_init_internal
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1init
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1init_1internal
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_copy
+ * Method:    native_copy_internal
  * Signature: (Lcom/wolfssl/wolfcrypt/Sha512;)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy_1internal
   (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1update__Ljava_nio_ByteBuffer_2II
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1update_1internal__Ljava_nio_ByteBuffer_2II
   (JNIEnv *, jobject, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_update
+ * Method:    native_update_internal
  * Signature: ([BII)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1update___3BII
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1update_1internal___3BII
   (JNIEnv *, jobject, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: (Ljava/nio/ByteBuffer;I)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1final__Ljava_nio_ByteBuffer_2I
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal__Ljava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint);
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Sha512
- * Method:    native_final
+ * Method:    native_final_internal
  * Signature: ([B)V
  */
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1final___3B
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal___3B
   (JNIEnv *, jobject, jbyteArray);
 
 #ifdef __cplusplus

--- a/jni/jni_aes.c
+++ b/jni/jni_aes.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -36,24 +38,26 @@
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    void* ret = NULL;
-
 #ifndef NO_AES
-    ret = (void*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Aes* aes = NULL;
 
-    if (ret == NULL) {
+    aes = (Aes*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (aes == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Aes object");
     }
     else {
-        XMEMSET(ret, 0, sizeof(Aes));
+        XMEMSET(aes, 0, sizeof(Aes));
     }
 
-    LogStr("new Aes() = %p\n", ret);
+    LogStr("new Aes() = %p\n", aes);
+
+    return (jlong)(uintptr_t)aes;
+
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return (jlong)ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_aes.c
+++ b/jni/jni_aes.c
@@ -35,7 +35,7 @@
 /* #define WOLFCRYPT_JNI_DEBUG_ON */
 #include <wolfcrypt_jni_debug.h>
 
-JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct(
+JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
 #ifndef NO_AES
@@ -61,7 +61,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Aes_mallocNativeStruct(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Aes_native_1set_1key(
+Java_com_wolfssl_wolfcrypt_Aes_native_1set_1key_1internal(
     JNIEnv* env, jobject this, jbyteArray key_object, jbyteArray iv_object,
     jint opmode)
 {
@@ -100,7 +100,7 @@ Java_com_wolfssl_wolfcrypt_Aes_native_1set_1key(
 }
 
 JNIEXPORT jint JNICALL
-Java_com_wolfssl_wolfcrypt_Aes_native_1update__I_3BII_3BI(
+Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__I_3BII_3BI(
     JNIEnv* env, jobject this, jint opmode,
     jbyteArray input_object, jint offset, jint length,
     jbyteArray output_object, jint outputOffset)
@@ -168,7 +168,7 @@ Java_com_wolfssl_wolfcrypt_Aes_native_1update__I_3BII_3BI(
 }
 
 JNIEXPORT jint JNICALL
-Java_com_wolfssl_wolfcrypt_Aes_native_1update__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jint opmode,
     jobject input_object, jint offset, jint length,
     jobject output_object, jint outputOffset)

--- a/jni/jni_chacha.c
+++ b/jni/jni_chacha.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -40,21 +41,26 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Chacha_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    void* ret = 0;
-
 #ifdef HAVE_CHACHA
-    ret = (void*)XMALLOC(sizeof(ChaCha), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ChaCha* chacha = NULL;
 
-    if (ret == NULL)
+    chacha = (ChaCha*)XMALLOC(sizeof(ChaCha), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (chacha == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate ChaCha object");
+    }
+    else {
+        XMEMSET(chacha, 0, sizeof(ChaCha));
+    }
 
-    XMEMSET(ret, 0, sizeof(ChaCha));
-    LogStr("new ChaCha object allocated = %p\n", ret);
+    LogStr("new ChaCha object allocated = %p\n", chacha);
+
+    return (jlong)(uintptr_t)chacha;
+
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return (jlong)(uintptr_t)ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
@@ -162,6 +168,8 @@ Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1process(
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, inputSz);
+
         ret = wc_Chacha_Process(chacha, output, input, inputSz);
     }
 

--- a/jni/jni_curve25519.c
+++ b/jni/jni_curve25519.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -44,20 +46,26 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Curve25519_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    void* ret = 0;
-
 #ifdef HAVE_CURVE25519
-    ret = XMALLOC(sizeof(curve25519_key), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    curve25519_key* key = NULL;
 
-    if (ret == NULL)
+    key = (curve25519_key*)XMALLOC(sizeof(curve25519_key), NULL,
+                DYNAMIC_TYPE_TMP_BUFFER);
+    if (key == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Curve25519 object");
+    }
+    else {
+        XMEMSET(key, 0, sizeof(curve25519_key));
+    }
 
-    LogStr("new Curve25519() = %p\n", (void*)ret);
+    LogStr("new Curve25519() = %p\n", key);
+
+    return (jlong)(uintptr_t)key;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return (jlong) ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL
@@ -277,6 +285,7 @@ Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1export_1private(
         throwOutOfMemoryException(env, "Failed to allocate key buffer");
         return result;
     }
+    XMEMSET(output, 0, outputSz);
 
     ret = (!curve25519)
         ? BAD_FUNC_ARG
@@ -332,6 +341,7 @@ Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1export_1public (
         throwOutOfMemoryException(env, "Failed to allocate key buffer");
         return result;
     }
+    XMEMSET(output, 0, outputSz);
 
     ret = (!curve25519)
         ? BAD_FUNC_ARG
@@ -394,6 +404,7 @@ Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1make_1shared_1secret(
                                      "Failed to allocate shared secret buffer");
         return result;
     }
+    XMEMSET(output, 0, outputSz);
 
     ret = (!curve25519 || !pub)
         ? BAD_FUNC_ARG

--- a/jni/jni_des3.c
+++ b/jni/jni_des3.c
@@ -60,7 +60,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Des3_mallocNativeStruct(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Des3_native_1set_1key(
+Java_com_wolfssl_wolfcrypt_Des3_native_1set_1key_1internal(
     JNIEnv* env, jobject this, jbyteArray key_object, jbyteArray iv_object,
     jint opmode)
 {
@@ -96,7 +96,7 @@ Java_com_wolfssl_wolfcrypt_Des3_native_1set_1key(
 }
 
 JNIEXPORT jint JNICALL
-Java_com_wolfssl_wolfcrypt_Des3_native_1update__I_3BII_3BI(
+Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__I_3BII_3BI(
     JNIEnv* env, jobject this, jint opmode,
     jbyteArray input_object, jint offset, jint length,
     jbyteArray output_object, jint outputOffset)
@@ -163,7 +163,7 @@ Java_com_wolfssl_wolfcrypt_Des3_native_1update__I_3BII_3BI(
 }
 
 JNIEXPORT jint JNICALL
-Java_com_wolfssl_wolfcrypt_Des3_native_1update__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jint opmode,
     jobject input_object, jint offset, jint length,
     jobject output_object, jint outputOffset)

--- a/jni/jni_des3.c
+++ b/jni/jni_des3.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -36,20 +38,25 @@
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Des3_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef NO_DES3
-    ret = (jlong) XMALLOC(sizeof(Des3), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Des3* des = NULL;
 
-    if (!ret)
+    des = (Des3*) XMALLOC(sizeof(Des3), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (des == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Des3 object");
+    }
+    else {
+        XMEMSET(des, 0, sizeof(Des3));
+    }
 
-    LogStr("new Des3() = %p\n", (void*)ret);
+    LogStr("new Des3() = %p\n", des);
+
+    return (jlong)(uintptr_t)des;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -44,24 +46,25 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Ecc_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    void* ret = NULL;
-
 #ifdef HAVE_ECC
-    ret = (void*)XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key* ecc = NULL;
 
-    if (ret == NULL) {
+    ecc = (ecc_key*)XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (ecc == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Ecc object");
     }
     else {
-        XMEMSET(ret, 0, sizeof(ecc_key));
+        XMEMSET(ecc, 0, sizeof(ecc_key));
     }
 
-    LogStr("new Ecc() = %p\n", (void*)ret);
+    LogStr("new Ecc() = %p\n", ecc);
+
+    return (jlong)(uintptr_t)ecc;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return (jlong) ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -104,20 +106,26 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Hmac_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef NO_HMAC
-    ret = (jlong) XMALLOC(sizeof(Hmac), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Hmac* hmac = NULL;
 
-    if (!ret)
+    hmac = (Hmac*) XMALLOC(sizeof(Hmac), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (hmac == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Hmac object");
+    }
+    else {
+        XMEMSET(hmac, 0, sizeof(Hmac));
+    }
 
-    LogStr("new Hmac() = %p\n", (void*)ret);
+    LogStr("new Hmac() = %p\n", hmac);
+
+    return (jlong)(uintptr_t)hmac;
+
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -50,20 +51,25 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef NO_MD5
-    ret = (jlong)(uintptr_t)XMALLOC(sizeof(Md5), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Md5* md5 = NULL;
 
-    if (!ret)
+    md5 = (Md5*)XMALLOC(sizeof(Md5), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (md5 == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Md5 object");
+    }
+    else {
+        XMEMSET(md5, 0, sizeof(Md5));
+    }
 
-    LogStr("new Md5() = %p\n", (void*)ret);
+    LogStr("new Md5() = %p\n", md5);
+
+    return (jlong)(uintptr_t)md5;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -47,7 +47,7 @@
 #endif
 
 JNIEXPORT jlong JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct(
+Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
     jlong ret = 0;
@@ -67,7 +67,7 @@ Java_com_wolfssl_wolfcrypt_Md5_mallocNativeStruct(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_native_1init(
+Java_com_wolfssl_wolfcrypt_Md5_native_1init_1internal(
     JNIEnv* env, jobject this)
 {
 #ifndef NO_MD5
@@ -91,7 +91,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1init(
 #endif
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy_1internal
   (JNIEnv* env, jobject this, jobject toBeCopied)
 {
 #ifndef NO_MD5
@@ -125,7 +125,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Md5_native_1copy
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_native_1update__Ljava_nio_ByteBuffer_2II(
+Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifndef NO_MD5
@@ -159,7 +159,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update__Ljava_nio_ByteBuffer_2II(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_native_1update___3BII(
+Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal___3BII(
     JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset, jint len)
 {
 #ifndef NO_MD5
@@ -198,7 +198,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update___3BII(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_native_1final__Ljava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifndef NO_MD5
@@ -232,7 +232,7 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final__Ljava_nio_ByteBuffer_2I(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Md5_native_1final___3B(
+Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifndef NO_MD5

--- a/jni/jni_rng.c
+++ b/jni/jni_rng.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -43,20 +45,25 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Rng_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef WC_NO_RNG
-    ret = (jlong) XMALLOC(sizeof(RNG), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    RNG* rng = NULL;
 
-    if (!ret)
+    rng = (RNG*)XMALLOC(sizeof(RNG), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (rng == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Rng object");
+    }
+    else {
+        XMEMSET(rng, 0, sizeof(RNG));
+    }
 
-    LogStr("new Rng() = %p\n", (void*)ret);
+    LogStr("new Rng() = %p\n", rng);
+
+    return (jlong)(uintptr_t)rng;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_rsa.c
+++ b/jni/jni_rsa.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -45,23 +47,25 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Rsa_mallocNativeStruct(
     JNIEnv* env, jobject this)
 {
-    void* ret = NULL;
-
 #ifndef NO_RSA
-    ret = (void*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (ret == NULL) {
+    RsaKey* rsa = NULL;
+
+    rsa = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (rsa == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Rsa object");
     }
     else {
-        XMEMSET(ret, 0, sizeof(RsaKey));
+        XMEMSET(rsa, 0, sizeof(RsaKey));
     }
 
-    LogStr("new Rsa() = %p\n", (void*)ret);
+    LogStr("new Rsa() = %p\n", rsa);
+
+    return (jlong)(uintptr_t)rsa;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return (jlong)ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Rsa_getDefaultRsaExponent
@@ -366,6 +370,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaKeyToDer
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaKeyToDer(key, output, outputSz);
         if (ret > 0) {
             outputSz = ret;
@@ -441,6 +447,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaKeyToPublicDe
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaKeyToPublicDer(key, output, outputSz);
         if (ret > 0) {
             outputSz = ret;
@@ -898,6 +906,8 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPublicEncrypt(
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaPublicEncrypt(plaintext, size, output, outputSz, key, rng);
         if (ret > 0) {
             outputSz = ret;
@@ -974,6 +984,8 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPrivateDecrypt(
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaPrivateDecrypt(ciphertext, size, output, outputSz, key);
         if (ret > 0) {
             outputSz = ret;
@@ -1057,6 +1069,8 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSSL_1Sign(
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaSSL_Sign(data, size, output, outputSz, key, rng);
         if (ret > 0) {
             outputSz = ret;
@@ -1133,6 +1147,8 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSSL_1Verify(
     }
 
     if (ret == 0) {
+        XMEMSET(output, 0, outputSz);
+
         ret = wc_RsaSSL_Verify(signature, size, output, outputSz, key);
         if (ret > 0) {
             outputSz = ret;

--- a/jni/jni_sha.c
+++ b/jni/jni_sha.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdint.h>
+
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>
 #elif !defined(__ANDROID__)
@@ -67,80 +69,100 @@ JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef NO_SHA
-    ret = (jlong) XMALLOC(sizeof(Sha), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Sha* sha = NULL;
 
-    if (!ret)
+    sha = (Sha*) XMALLOC(sizeof(Sha), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sha == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Sha object");
+    }
+    else {
+        XMEMSET(sha, 0, sizeof(Sha));
+    }
 
-    LogStr("new Sha() = %p\n", (void*)ret);
+    LogStr("new Sha() = %p\n", sha);
+
+    return (jlong)(uintptr_t)sha;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifndef NO_SHA256
-    ret = (jlong) XMALLOC(sizeof(Sha256), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Sha256* sha = NULL;
 
-    if (!ret)
+    sha = (Sha256*) XMALLOC(sizeof(Sha256), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sha == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Sha256 object");
+    }
+    else {
+        XMEMSET(sha, 0, sizeof(Sha256));
+    }
 
-    LogStr("new Sha256() = %p\n", (void*)ret);
+    LogStr("new Sha256() = %p\n", sha);
+
+    return (jlong)(uintptr_t)sha;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifdef WOLFSSL_SHA384
-    ret = (jlong) XMALLOC(sizeof(Sha384), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Sha384* sha = NULL;
 
-    if (!ret)
+    sha = (Sha384*) XMALLOC(sizeof(Sha384), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sha == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Sha384 object");
+    }
+    else {
+        XMEMSET(sha, 0, sizeof(Sha384));
+    }
 
-    LogStr("new Sha384() = %p\n", (void*)ret);
+    LogStr("new Sha384() = %p\n", sha);
+
+    return (jlong)(uintptr_t)sha;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
-    jlong ret = 0;
-
 #ifdef WOLFSSL_SHA512
-    ret = (jlong) XMALLOC(sizeof(Sha512), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    Sha512* sha = NULL;
 
-    if (!ret)
+    sha = (Sha512*) XMALLOC(sizeof(Sha512), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sha == NULL) {
         throwOutOfMemoryException(env, "Failed to allocate Sha512 object");
+    }
+    else {
+        XMEMSET(sha, 0, sizeof(Sha512));
+    }
 
-    LogStr("new Sha512() = %p\n", (void*)ret);
+    LogStr("new Sha512() = %p\n", sha);
+
+    return (jlong)(uintptr_t)sha;
 #else
     throwNotCompiledInException(env);
-#endif
 
-    return ret;
+    return (jlong)0;
+#endif
 }
 
 JNIEXPORT void JNICALL

--- a/jni/jni_sha.c
+++ b/jni/jni_sha.c
@@ -64,7 +64,7 @@
 #endif
 
 JNIEXPORT jlong JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct(
+Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
     jlong ret = 0;
@@ -84,7 +84,7 @@ Java_com_wolfssl_wolfcrypt_Sha_mallocNativeStruct(
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct(
+Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
     jlong ret = 0;
@@ -104,7 +104,7 @@ Java_com_wolfssl_wolfcrypt_Sha256_mallocNativeStruct(
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct(
+Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
     jlong ret = 0;
@@ -124,7 +124,7 @@ Java_com_wolfssl_wolfcrypt_Sha384_mallocNativeStruct(
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct(
+Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
     jlong ret = 0;
@@ -144,7 +144,7 @@ Java_com_wolfssl_wolfcrypt_Sha512_mallocNativeStruct(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_native_1init(
+Java_com_wolfssl_wolfcrypt_Sha_native_1init_1internal(
     JNIEnv* env, jobject this)
 {
 #ifndef NO_SHA
@@ -166,7 +166,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1init(
 #endif
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy_1internal
   (JNIEnv* env, jobject this, jobject toBeCopied)
 {
 #ifndef NO_SHA
@@ -200,7 +200,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha_native_1copy
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_native_1update__Ljava_nio_ByteBuffer_2II(
+Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifndef NO_SHA
@@ -232,7 +232,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1update__Ljava_nio_ByteBuffer_2II(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_native_1update___3BII(
+Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal___3BII(
     JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset, jint len)
 {
 #ifndef NO_SHA
@@ -272,7 +272,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1update___3BII(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_native_1final__Ljava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifndef NO_SHA
@@ -304,7 +304,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1final__Ljava_nio_ByteBuffer_2I(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha_native_1final___3B(
+Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifndef NO_SHA
@@ -338,7 +338,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1final___3B(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_native_1init(
+Java_com_wolfssl_wolfcrypt_Sha256_native_1init_1internal(
     JNIEnv* env, jobject this)
 {
 #ifndef NO_SHA256
@@ -360,7 +360,7 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1init(
 #endif
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy_1internal
   (JNIEnv* env, jobject this, jobject toBeCopied)
 {
 #ifndef NO_SHA256
@@ -394,7 +394,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha256_native_1copy
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_native_1update__Ljava_nio_ByteBuffer_2II(
+Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifndef NO_SHA256
@@ -426,9 +426,9 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1update__Ljava_nio_ByteBuffer_2II(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_native_1update___3BII(
+Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal___3BII(
     JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset,
-   jint len)
+    jint len)
 {
 #ifndef NO_SHA256
     int ret = 0;
@@ -468,7 +468,7 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1update___3BII(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_native_1final__Ljava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifndef NO_SHA256
@@ -500,7 +500,7 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1final__Ljava_nio_ByteBuffer_2I(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha256_native_1final___3B(
+Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifndef NO_SHA256
@@ -534,7 +534,7 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1final___3B(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_native_1init(
+Java_com_wolfssl_wolfcrypt_Sha384_native_1init_1internal(
     JNIEnv* env, jobject this)
 {
 #ifdef WOLFSSL_SHA384
@@ -556,7 +556,7 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1init(
 #endif
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy_1internal
   (JNIEnv* env, jobject this, jobject toBeCopied)
 {
 #ifdef WOLFSSL_SHA384
@@ -590,7 +590,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha384_native_1copy
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_native_1update__Ljava_nio_ByteBuffer_2II(
+Java_com_wolfssl_wolfcrypt_Sha384_native_1update_1internal__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifdef WOLFSSL_SHA384
@@ -622,9 +622,8 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1update__Ljava_nio_ByteBuffer_2II(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_native_1update___3BII(
-    JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset,
-   jint len)
+Java_com_wolfssl_wolfcrypt_Sha384_native_1update_1internal___3BII(
+    JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset, jint len)
 {
 #ifdef WOLFSSL_SHA384
     int ret = 0;
@@ -664,7 +663,7 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1update___3BII(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_native_1final__Ljava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifdef WOLFSSL_SHA384
@@ -696,7 +695,7 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1final__Ljava_nio_ByteBuffer_2I(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha384_native_1final___3B(
+Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifdef WOLFSSL_SHA384
@@ -730,7 +729,7 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1final___3B(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_native_1init(
+Java_com_wolfssl_wolfcrypt_Sha512_native_1init_1internal(
     JNIEnv* env, jobject this)
 {
 #ifdef WOLFSSL_SHA512
@@ -752,7 +751,7 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1init(
 #endif
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy_1internal
   (JNIEnv* env, jobject this, jobject toBeCopied)
 {
 #ifdef WOLFSSL_SHA512
@@ -786,7 +785,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha512_native_1copy
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_native_1update__Ljava_nio_ByteBuffer_2II(
+Java_com_wolfssl_wolfcrypt_Sha512_native_1update_1internal__Ljava_nio_ByteBuffer_2II(
     JNIEnv* env, jobject this, jobject data_buffer, jint position, jint len)
 {
 #ifdef WOLFSSL_SHA512
@@ -818,9 +817,9 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1update__Ljava_nio_ByteBuffer_2II(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_native_1update___3BII(
+Java_com_wolfssl_wolfcrypt_Sha512_native_1update_1internal___3BII(
     JNIEnv* env, jobject this, jbyteArray data_buffer, jint offset,
-   jint len)
+    jint len)
 {
 #ifdef WOLFSSL_SHA512
     int ret = 0;
@@ -860,7 +859,7 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1update___3BII(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_native_1final__Ljava_nio_ByteBuffer_2I(
+Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     JNIEnv* env, jobject this, jobject hash_buffer, jint position)
 {
 #ifdef WOLFSSL_SHA512
@@ -892,7 +891,7 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1final__Ljava_nio_ByteBuffer_2I(
 }
 
 JNIEXPORT void JNICALL
-Java_com_wolfssl_wolfcrypt_Sha512_native_1final___3B(
+Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal___3B(
     JNIEnv* env, jobject this, jbyteArray hash_buffer)
 {
 #ifdef WOLFSSL_SHA512

--- a/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
@@ -84,7 +84,8 @@ public abstract class BlockCipher extends NativeStruct {
      * @param iv block cipher initialization vector (IV) array
      * @param opmode block cipher operation mode, dependent on subclass type
      */
-    public void setKey(byte[] key, byte[] iv, int opmode) {
+    public synchronized void setKey(byte[] key, byte[] iv, int opmode) {
+
         native_set_key(key, iv, opmode);
 
         this.opmode = opmode;
@@ -96,7 +97,8 @@ public abstract class BlockCipher extends NativeStruct {
      *
      * @throws IllegalStateException if algorithm or key not usable
      */
-    public void willUseKey() {
+    public synchronized void willUseKey() {
+
         if (state != WolfCryptState.READY)
             throw new IllegalStateException(
                     "No available key to perform the opperation.");
@@ -109,7 +111,8 @@ public abstract class BlockCipher extends NativeStruct {
      *
      * @return output data array from update operation
      */
-    public byte[] update(byte[] input) {
+    public synchronized byte[] update(byte[] input) {
+
         return update(input, 0, input.length);
     }
 
@@ -122,7 +125,8 @@ public abstract class BlockCipher extends NativeStruct {
      *
      * @return output data array from update operation
      */
-    public byte[] update(byte[] input, int offset, int length) {
+    public synchronized byte[] update(byte[] input, int offset, int length) {
+
         willUseKey();
 
         byte[] output = new byte[input.length];
@@ -145,8 +149,9 @@ public abstract class BlockCipher extends NativeStruct {
      *
      * @throws ShortBufferException if output buffer is too small
      */
-    public int update(byte[] input, int offset, int length, byte[] output,
-            int outputOffset) throws ShortBufferException {
+    public synchronized int update(byte[] input, int offset, int length,
+        byte[] output, int outputOffset) throws ShortBufferException {
+
         willUseKey();
 
         if (outputOffset + length > output.length)
@@ -167,8 +172,9 @@ public abstract class BlockCipher extends NativeStruct {
      *
      * @throws ShortBufferException if output buffer is not large enough
      */
-    public int update(ByteBuffer input, ByteBuffer output)
-            throws ShortBufferException {
+    public synchronized int update(ByteBuffer input, ByteBuffer output)
+        throws ShortBufferException {
+
         willUseKey();
 
         int ret = 0;
@@ -187,7 +193,7 @@ public abstract class BlockCipher extends NativeStruct {
     }
 
     @Override
-    public void releaseNativeStruct() {
+    public synchronized void releaseNativeStruct() {
 
         /* reset state first, then free */
         state = WolfCryptState.UNINITIALIZED;
@@ -203,7 +209,8 @@ public abstract class BlockCipher extends NativeStruct {
      * @return Number of PKCS#7 pad bytes that would be appended to an input
      *         of size inputSize.
      */
-    public static int getPKCS7PadSize(int inputSize, int blockSize) {
+    public static synchronized int getPKCS7PadSize(int inputSize,
+        int blockSize) {
 
         int padSz = 0;
 
@@ -228,7 +235,7 @@ public abstract class BlockCipher extends NativeStruct {
      * @throws WolfCryptException if input is null, zero length,
      *         or blockSize is invalid
      */
-    public static byte[] padPKCS7(byte[] in, int blockSize)
+    public static synchronized byte[] padPKCS7(byte[] in, int blockSize)
         throws WolfCryptException {
 
         int padSz = 0;
@@ -268,7 +275,7 @@ public abstract class BlockCipher extends NativeStruct {
      * @throws WolfCryptException if input is null, zero length,
      *         or blockSize is invalid
      */
-    public static byte[] unPadPKCS7(byte[] in, int blockSize) {
+    public static synchronized byte[] unPadPKCS7(byte[] in, int blockSize) {
 
         byte padValue = 0;
         byte[] unpadded = null;

--- a/src/main/java/com/wolfssl/wolfcrypt/Md5.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Md5.java
@@ -33,6 +33,19 @@ public class Md5 extends MessageDigest {
     /** MD5 digest size */
     public static final int DIGEST_SIZE = 16;
 
+    /* native JNI methods, internally reach back and grab/use pointer from
+     * NativeStruct.java. We wrap calls to these below in order to
+     * synchronize access to native pointer between threads */
+    private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_init_internal();
+    private native void native_copy_internal(Md5 toBeCopied);
+    private native void native_update_internal(ByteBuffer data, int offset,
+        int len);
+    private native void native_update_internal(byte[] data, int offset,
+        int len);
+    private native void native_final_internal(ByteBuffer hash, int offset);
+    private native void native_final_internal(byte[] hash);
+
     /**
      * Malloc native JNI Md5 structure
      *
@@ -40,12 +53,26 @@ public class Md5 extends MessageDigest {
      *
      * @throws OutOfMemoryError when malloc fails with memory error
      */
-    protected native long mallocNativeStruct() throws OutOfMemoryError;
+    protected long mallocNativeStruct()
+        throws OutOfMemoryError {
+
+        synchronized (pointerLock) {
+            return mallocNativeStruct_internal();
+        }
+    }
 
     /**
      * Initialize Md5 object
+     *
+     * @throws WolfCryptException if native operation fails
      */
-    protected native void native_init();
+    protected void native_init()
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_init_internal();
+        }
+    }
 
     /**
      * Copy existing native WC_MD5 struct (Md5 object) into this one.
@@ -55,7 +82,13 @@ public class Md5 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_copy(Md5 toBeCopied);
+    protected void native_copy(Md5 toBeCopied)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_copy_internal(toBeCopied);
+        }
+    }
 
     /**
      * Native Md5 update
@@ -66,7 +99,13 @@ public class Md5 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(ByteBuffer data, int offset, int len);
+    protected void native_update(ByteBuffer data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native Md5 update
@@ -77,7 +116,13 @@ public class Md5 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(byte[] data, int offset, int len);
+    protected void native_update(byte[] data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native Md5 final, calculate final digest
@@ -87,7 +132,13 @@ public class Md5 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(ByteBuffer hash, int offset);
+    protected void native_final(ByteBuffer hash, int offset)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash, offset);
+        }
+    }
 
     /**
      * Native Md5 final, calculate final digest
@@ -96,7 +147,13 @@ public class Md5 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(byte[] hash);
+    protected void native_final(byte[] hash)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash);
+        }
+    }
 
     /**
      * Create new Md5 object

--- a/src/main/java/com/wolfssl/wolfcrypt/MessageDigest.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/MessageDigest.java
@@ -92,7 +92,7 @@ public abstract class MessageDigest extends NativeStruct {
     /**
      * Initialize object
      */
-    public void init() {
+    public synchronized void init() {
         native_init();
         state = WolfCryptState.READY;
     }
@@ -106,7 +106,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public void update(ByteBuffer data, int length) {
+    public synchronized void update(ByteBuffer data, int length)
+        throws WolfCryptException, IllegalStateException {
+
         if (state == WolfCryptState.READY) {
             length = Math.min(length, data.remaining());
 
@@ -126,7 +128,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public void update(ByteBuffer data) {
+    public synchronized void update(ByteBuffer data)
+        throws WolfCryptException, IllegalStateException {
+
         update(data, data.remaining());
     }
 
@@ -140,7 +144,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public void update(byte[] data, int offset, int len) {
+    public synchronized void update(byte[] data, int offset, int len)
+        throws WolfCryptException, IllegalStateException {
+
         if (state == WolfCryptState.READY) {
             if (offset >= data.length || offset < 0 || len < 0)
                 return;
@@ -164,7 +170,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public void update(byte[] data, int len) {
+    public synchronized void update(byte[] data, int len)
+        throws WolfCryptException, IllegalStateException {
+
         update(data, 0, len);
     }
 
@@ -176,7 +184,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public void update(byte[] data) {
+    public synchronized void update(byte[] data)
+        throws WolfCryptException, IllegalStateException {
+
         update(data, 0, data.length);
     }
 
@@ -189,7 +199,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws ShortBufferException if input buffer is too small
      * @throws IllegalStateException object not initialized
      */
-    public void digest(ByteBuffer hash) throws ShortBufferException {
+    public synchronized void digest(ByteBuffer hash)
+        throws ShortBufferException, WolfCryptException, IllegalStateException {
+
         if (state == WolfCryptState.READY) {
             if (hash.remaining() < digestSize())
                 throw new ShortBufferException(
@@ -212,7 +224,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws ShortBufferException if input buffer is too small
      * @throws IllegalStateException object not initialized
      */
-    public void digest(byte[] hash) throws ShortBufferException {
+    public synchronized void digest(byte[] hash)
+        throws ShortBufferException, WolfCryptException, IllegalStateException {
+
         if (state == WolfCryptState.READY) {
             if (hash.length < digestSize())
                 throw new ShortBufferException(
@@ -233,7 +247,9 @@ public abstract class MessageDigest extends NativeStruct {
      * @throws WolfCryptException if native operation fails
      * @throws IllegalStateException object not initialized
      */
-    public byte[] digest() {
+    public synchronized byte[] digest()
+        throws WolfCryptException, IllegalStateException {
+
         if (state == WolfCryptState.READY) {
             byte[] hash = new byte[digestSize()];
 
@@ -247,7 +263,7 @@ public abstract class MessageDigest extends NativeStruct {
     }
 
     @Override
-    public void releaseNativeStruct() {
+    public synchronized void releaseNativeStruct() {
 
         /* reset state first, then free */
         state = WolfCryptState.UNINITIALIZED;

--- a/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
@@ -39,8 +39,15 @@ public abstract class NativeStruct extends WolfObject {
     /* points to the internal native structure */
     private long pointer;
 
+    /* Lock around native pointer use */
+    protected final Object pointerLock = new Object();
+
     /**
      * Get pointer to wrapped native structure
+     *
+     * WARNING: the pointer returned from this function has not been locked
+     * and may cause threading synchronization issues if used in a
+     * multi-threaded use case or application.
      *
      * @return pointer to native structure
      */
@@ -57,10 +64,14 @@ public abstract class NativeStruct extends WolfObject {
      * @param nativeStruct pointer to initialized native structure
      */
     protected void setNativeStruct(long nativeStruct) {
-        if (this.pointer != NULL)
-            xfree(this.pointer);
 
-        this.pointer = nativeStruct;
+        synchronized (pointerLock) {
+            if (this.pointer != NULL) {
+                xfree(this.pointer);
+            }
+
+            this.pointer = nativeStruct;
+        }
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
@@ -37,7 +37,7 @@ public abstract class NativeStruct extends WolfObject {
     }
 
     /* points to the internal native structure */
-    private long pointer;
+    private long pointer = 0;
 
     /* Lock around native pointer use */
     protected final Object pointerLock = new Object();

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha.java
@@ -33,6 +33,19 @@ public class Sha extends MessageDigest {
     /** SHA-1 digest size */
     public static final int DIGEST_SIZE = 20;
 
+    /* native JNI methods, internally reach back and grab/use pointer from
+     * NativeStruct.java. We wrap calls to these below in order to
+     * synchronize access to native pointer between threads */
+    private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_init_internal();
+    private native void native_copy_internal(Sha toBeCopied);
+    private native void native_update_internal(ByteBuffer data, int offset,
+        int len);
+    private native void native_update_internal(byte[] data, int offset,
+        int len);
+    private native void native_final_internal(ByteBuffer hash, int offset);
+    private native void native_final_internal(byte[] hash);
+
     /**
      * Malloc native JNI Sha structure
      *
@@ -40,12 +53,26 @@ public class Sha extends MessageDigest {
      *
      * @throws OutOfMemoryError when malloc fails with memory error
      */
-    protected native long mallocNativeStruct() throws OutOfMemoryError;
+    protected long mallocNativeStruct()
+        throws OutOfMemoryError {
+
+        synchronized (pointerLock) {
+            return mallocNativeStruct_internal();
+        }
+    }
 
     /**
      * Initialize Sha object
+     *
+     * @throws WolfCryptException if native operation fails
      */
-    protected native void native_init();
+    protected void native_init()
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_init_internal();
+        }
+    }
 
     /**
      * Copy existing native WC_SHA struct (Sha object) into this one.
@@ -55,7 +82,13 @@ public class Sha extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_copy(Sha toBeCopied);
+    protected void native_copy(Sha toBeCopied)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_copy_internal(toBeCopied);
+        }
+    }
 
     /**
      * Native SHA-1 update
@@ -66,7 +99,13 @@ public class Sha extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(ByteBuffer data, int offset, int len);
+    protected void native_update(ByteBuffer data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA-1 update
@@ -77,7 +116,13 @@ public class Sha extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(byte[] data, int offset, int len);
+    protected void native_update(byte[] data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA-1 final, calculate final digest
@@ -87,7 +132,13 @@ public class Sha extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(ByteBuffer hash, int offset);
+    protected void native_final(ByteBuffer hash, int offset)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash, offset);
+        }
+    }
 
     /**
      * Native SHA-1 final, calculate final digest
@@ -96,7 +147,13 @@ public class Sha extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(byte[] hash);
+    protected void native_final(byte[] hash)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash);
+        }
+    }
 
     /**
      * Create new SHA-1 object

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha256.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha256.java
@@ -33,6 +33,19 @@ public class Sha256 extends MessageDigest {
     /** SHA2-256 digest size */
     public static final int DIGEST_SIZE = 32;
 
+    /* native JNI methods, internally reach back and grab/use pointer
+     * from NativeStruct.java. We wrap calls to these below in order to
+     * synchronize access to native pointer between threads */
+    private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_init_internal();
+    private native void native_copy_internal(Sha256 toBeCopied);
+    private native void native_update_internal(ByteBuffer data, int offset,
+        int len);
+    private native void native_update_internal(byte[] data, int offset,
+        int len);
+    private native void native_final_internal(ByteBuffer hash, int offset);
+    private native void native_final_internal(byte[] hash);
+
     /**
      * Malloc native JNI Sha256 structure
      *
@@ -40,12 +53,26 @@ public class Sha256 extends MessageDigest {
      *
      * @throws OutOfMemoryError when malloc fails with memory error
      */
-    protected native long mallocNativeStruct() throws OutOfMemoryError;
+    protected long mallocNativeStruct()
+        throws OutOfMemoryError {
+
+        synchronized (pointerLock) {
+            return mallocNativeStruct_internal();
+        }
+    }
 
     /**
      * Initialize Sha256 object
+     *
+     * @throws WolfCryptException if native operation fails
      */
-    protected native void native_init();
+    protected void native_init()
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_init_internal();
+        }
+    }
 
     /**
      * Copy existing native WC_SHA256 struct (Sha256 object) into this one.
@@ -55,7 +82,13 @@ public class Sha256 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_copy(Sha256 toBeCopied);
+    protected void native_copy(Sha256 toBeCopied)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_copy_internal(toBeCopied);
+        }
+    }
 
     /**
      * Native SHA2-256 update
@@ -66,7 +99,13 @@ public class Sha256 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(ByteBuffer data, int offset, int len);
+    protected void native_update(ByteBuffer data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-256 update
@@ -77,7 +116,13 @@ public class Sha256 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(byte[] data, int offset, int len);
+    protected void native_update(byte[] data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-256 final, calculate final digest
@@ -87,7 +132,13 @@ public class Sha256 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(ByteBuffer hash, int offset);
+    protected void native_final(ByteBuffer hash, int offset)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash, offset);
+        }
+    }
 
     /**
      * Native SHA2-256 final, calculate final digest
@@ -96,7 +147,13 @@ public class Sha256 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(byte[] hash);
+    protected void native_final(byte[] hash)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash);
+        }
+    }
 
     /**
      * Create new SHA2-256 object

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha384.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha384.java
@@ -33,6 +33,19 @@ public class Sha384 extends MessageDigest {
     /** SHA2-384 digest size */
     public static final int DIGEST_SIZE = 48;
 
+    /* native JNI methods, internally reach back and grab/use pointer from
+     * NativeStruct.java. We wrap calls to these below in order to
+     * synchronize access to native pointer between threads */
+    private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_init_internal();
+    private native void native_copy_internal(Sha384 toBeCopied);
+    private native void native_update_internal(ByteBuffer data, int offset,
+        int len);
+    private native void native_update_internal(byte[] data, int offset,
+        int len);
+    private native void native_final_internal(ByteBuffer hash, int offset);
+    private native void native_final_internal(byte[] hash);
+
     /**
      * Malloc native JNI Sha384 structure
      *
@@ -40,12 +53,26 @@ public class Sha384 extends MessageDigest {
      *
      * @throws OutOfMemoryError when malloc fails with memory error
      */
-    protected native long mallocNativeStruct() throws OutOfMemoryError;
+    protected long mallocNativeStruct()
+        throws OutOfMemoryError {
+
+        synchronized (pointerLock) {
+            return mallocNativeStruct_internal();
+        }
+    }
 
     /**
      * Initialize Sha384 object
+     *
+     * @throws WolfCryptException if native operation fails
      */
-    protected native void native_init();
+    protected void native_init()
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_init_internal();
+        }
+    }
 
     /**
      * Copy existing native WC_SHA384 struct (Sha384 object) into this one.
@@ -55,7 +82,13 @@ public class Sha384 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_copy(Sha384 toBeCopied);
+    protected void native_copy(Sha384 toBeCopied)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_copy_internal(toBeCopied);
+        }
+    }
 
     /**
      * Native SHA2-384 update
@@ -66,7 +99,13 @@ public class Sha384 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(ByteBuffer data, int offset, int len);
+    protected void native_update(ByteBuffer data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-384 update
@@ -77,7 +116,13 @@ public class Sha384 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(byte[] data, int offset, int len);
+    protected void native_update(byte[] data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-384 final, calculate final digest
@@ -87,7 +132,13 @@ public class Sha384 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(ByteBuffer hash, int offset);
+    protected void native_final(ByteBuffer hash, int offset)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash, offset);
+        }
+    }
 
     /**
      * Native SHA2-384 final, calculate final digest
@@ -96,7 +147,13 @@ public class Sha384 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(byte[] hash);
+    protected void native_final(byte[] hash)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash);
+        }
+    }
 
     /**
      * Create new SHA2-384 object

--- a/src/main/java/com/wolfssl/wolfcrypt/Sha512.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Sha512.java
@@ -33,6 +33,19 @@ public class Sha512 extends MessageDigest {
     /** SHA2-512 digest size */
     public static final int DIGEST_SIZE = 64;
 
+    /* native JNI methods, internally reach back and grab/use pointer from
+     * NativeStruct.java. We wrap calls to these below in order to
+     * synchronize access to native pointer between threads */
+    private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_init_internal();
+    private native void native_copy_internal(Sha512 toBeCopied);
+    private native void native_update_internal(ByteBuffer data, int offset,
+        int len);
+    private native void native_update_internal(byte[] data, int offset,
+        int len);
+    private native void native_final_internal(ByteBuffer hash, int offset);
+    private native void native_final_internal(byte[] hash);
+
     /**
      * Malloc native JNI Sha512 structure
      *
@@ -40,12 +53,26 @@ public class Sha512 extends MessageDigest {
      *
      * @throws OutOfMemoryError when malloc fails with memory error
      */
-    protected native long mallocNativeStruct() throws OutOfMemoryError;
+    protected long mallocNativeStruct()
+        throws OutOfMemoryError {
+
+        synchronized (pointerLock) {
+            return mallocNativeStruct_internal();
+        }
+    }
 
     /**
      * Initialize Sha512 object
+     *
+     * @throws WolfCryptException if native operation fails
      */
-    protected native void native_init();
+    protected void native_init()
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_init_internal();
+        }
+    }
 
     /**
      * Copy existing native WC_SHA512 struct (Sha512 object) into this one.
@@ -55,7 +82,13 @@ public class Sha512 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_copy(Sha512 toBeCopied);
+    protected void native_copy(Sha512 toBeCopied)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_copy_internal(toBeCopied);
+        }
+    }
 
     /**
      * Native SHA2-512 update
@@ -66,7 +99,13 @@ public class Sha512 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(ByteBuffer data, int offset, int len);
+    protected void native_update(ByteBuffer data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-512 update
@@ -77,7 +116,13 @@ public class Sha512 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_update(byte[] data, int offset, int len);
+    protected void native_update(byte[] data, int offset, int len)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_update_internal(data, offset, len);
+        }
+    }
 
     /**
      * Native SHA2-512 final, calculate final digest
@@ -87,7 +132,13 @@ public class Sha512 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(ByteBuffer hash, int offset);
+    protected void native_final(ByteBuffer hash, int offset)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash, offset);
+        }
+    }
 
     /**
      * Native SHA2-512 final, calculate final digest
@@ -96,7 +147,13 @@ public class Sha512 extends MessageDigest {
      *
      * @throws WolfCryptException if native operation fails
      */
-    protected native void native_final(byte[] hash);
+    protected void native_final(byte[] hash)
+        throws WolfCryptException {
+
+        synchronized (pointerLock) {
+            native_final_internal(hash);
+        }
+    }
 
     /**
      * Create new SHA2-512 object

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -83,6 +83,9 @@ public class WolfCryptCipherTest {
     private static HashMap<String, Integer> expectedBlockSizes =
         new HashMap<String, Integer>();
 
+    /* One static SecureRandom to share */
+    private static SecureRandom secureRandom = new SecureRandom();
+
     @BeforeClass
     public static void testProviderInstallationAtRuntime()
         throws NoSuchProviderException, NoSuchPaddingException {
@@ -1747,7 +1750,7 @@ public class WolfCryptCipherTest {
         byte[] plaintext = null;
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(2048, new SecureRandom());
+        keyGen.initialize(2048, secureRandom);
 
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
@@ -1805,7 +1808,7 @@ public class WolfCryptCipherTest {
         byte[] plaintext = null;
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(2048, new SecureRandom());
+        keyGen.initialize(2048, secureRandom);
 
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
@@ -1896,7 +1899,7 @@ public class WolfCryptCipherTest {
         byte[] plaintextB  = null;
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(2048, new SecureRandom());
+        keyGen.initialize(2048, secureRandom);
 
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
@@ -2012,7 +2015,7 @@ public class WolfCryptCipherTest {
         byte[] inputB = new byte[100];
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(2048, new SecureRandom());
+        keyGen.initialize(2048, secureRandom);
 
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
@@ -2130,7 +2133,7 @@ public class WolfCryptCipherTest {
         byte[] plaintext = null;
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(2048, new SecureRandom());
+        keyGen.initialize(2048, secureRandom);
 
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -27,7 +27,13 @@ import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Random;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -1358,6 +1364,114 @@ public class WolfCryptCipherTest {
     }
 
     @Test
+    public void testAesCbcThreaded() throws InterruptedException {
+
+        int numThreads = 50;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+        final byte[] rand2kBuf = new byte[2048];
+
+        final byte[] key = new byte[] {
+            (byte)0x30, (byte)0x31, (byte)0x32, (byte)0x33,
+            (byte)0x34, (byte)0x35, (byte)0x36, (byte)0x37,
+            (byte)0x38, (byte)0x39, (byte)0x61, (byte)0x62,
+            (byte)0x63, (byte)0x64, (byte)0x65, (byte)0x66
+        };
+        final byte[] iv = new byte[] {
+            (byte)0x31, (byte)0x32, (byte)0x33, (byte)0x34,
+            (byte)0x35, (byte)0x36, (byte)0x37, (byte)0x38,
+            (byte)0x39, (byte)0x30, (byte)0x61, (byte)0x62,
+            (byte)0x63, (byte)0x64, (byte)0x65, (byte)0x66
+        };
+
+        if (!enabledJCEAlgos.contains("AES/CBC/NoPadding")) {
+            /* skip if AES/CBC/NoPadding is not enabled */
+            return;
+        }
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand2kBuf);
+
+        /* encrypt / decrypt input data, make sure decrypted matches original */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int ret = 0;
+
+                    try {
+                        Cipher enc = Cipher.getInstance(
+                            "AES/CBC/NoPadding", jceProvider);
+                        enc.init(Cipher.ENCRYPT_MODE,
+                            new SecretKeySpec(key, "AES"),
+                            new IvParameterSpec(iv));
+
+                        Cipher dec = Cipher.getInstance(
+                            "AES/CBC/NoPadding", jceProvider);
+                        dec.init(Cipher.DECRYPT_MODE,
+                            new SecretKeySpec(key, "AES"),
+                            new IvParameterSpec(iv));
+
+                        byte[] encrypted = new byte[2048];
+                        byte[] plaintext = new byte[2048];
+
+                        /* encrypt in 128-byte chunks */
+                        Arrays.fill(encrypted, (byte)0);
+                        for (int j = 0; j < rand2kBuf.length; j+= 128) {
+                            ret = enc.update(rand2kBuf, j, 128, encrypted, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Cipher.update(Aes,ENCRYPT_MODE) returned "
+                                    + ret);
+                            }
+                        }
+
+                        /* decrypt in 128-byte chunks */
+                        Arrays.fill(plaintext, (byte)0);
+                        for (int j = 0; j < encrypted.length; j+= 128) {
+                            ret = dec.update(encrypted, j, 128, plaintext, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Cipher.update(Aes,DECRYPT_MODE) returned "
+                                    + ret);
+                            }
+                        }
+
+                        /* make sure decrypted is same as input */
+                        if (Arrays.equals(rand2kBuf, plaintext)) {
+                            results.add(0);
+                        }
+                        else {
+                            /* not equal, error case */
+                            results.add(1);
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        results.add(1);
+
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in AES Cipher thread test");
+            }
+        }
+    }
+
+    @Test
     public void testDESedeCbcNoPadding()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                NoSuchPaddingException, InvalidKeyException,
@@ -1493,6 +1607,115 @@ public class WolfCryptCipherTest {
         } catch (IllegalBlockSizeException e) {
             assertEquals(e.getMessage(),
                          "Input length not multiple of 8 bytes");
+        }
+    }
+
+    @Test
+    public void testDESedeCbcNoPaddingThreaded() throws InterruptedException {
+
+        int numThreads = 50;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+        final byte[] rand2kBuf = new byte[2048];
+
+        final byte key[] = new byte[] {
+            (byte)0x01, (byte)0x23, (byte)0x45, (byte)0x67,
+            (byte)0x89, (byte)0xab, (byte)0xcd, (byte)0xef,
+            (byte)0xfe, (byte)0xde, (byte)0xba, (byte)0x98,
+            (byte)0x76, (byte)0x54, (byte)0x32, (byte)0x10,
+            (byte)0x89, (byte)0xab, (byte)0xcd, (byte)0xef,
+            (byte)0x01, (byte)0x23, (byte)0x45, (byte)0x67
+        };
+
+        final byte iv[] = new byte[] {
+            (byte)0x12, (byte)0x34, (byte)0x56, (byte)0x78,
+            (byte)0x90, (byte)0xab, (byte)0xcd, (byte)0xef,
+        };
+
+        if (!enabledJCEAlgos.contains("DESede/CBC/NoPadding")) {
+            /* skip if DESede/CBC/NoPadding is not enabled */
+            return;
+        }
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand2kBuf);
+
+        /* encrypt / decrypt input data, make sure decrypted matches original */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int ret = 0;
+
+                    try {
+                        Cipher enc = Cipher.getInstance(
+                            "DESede/CBC/NoPadding", jceProvider);
+                        enc.init(Cipher.ENCRYPT_MODE,
+                            new SecretKeySpec(key, "DESede"),
+                            new IvParameterSpec(iv));
+
+                        Cipher dec = Cipher.getInstance(
+                            "DESede/CBC/NoPadding", jceProvider);
+                        dec.init(Cipher.DECRYPT_MODE,
+                            new SecretKeySpec(key, "DESede"),
+                            new IvParameterSpec(iv));
+
+                        byte[] encrypted = new byte[2048];
+                        byte[] plaintext = new byte[2048];
+
+                        /* encrypt in 128-byte chunks */
+                        Arrays.fill(encrypted, (byte)0);
+                        for (int j = 0; j < rand2kBuf.length; j+= 128) {
+                            ret = enc.update(rand2kBuf, j, 128, encrypted, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Cipher.update(DES,ENCRYPT_MODE) returned "
+                                    + ret);
+                            }
+                        }
+
+                        /* decrypt in 128-byte chunks */
+                        Arrays.fill(plaintext, (byte)0);
+                        for (int j = 0; j < encrypted.length; j+= 128) {
+                            ret = dec.update(encrypted, j, 128, plaintext, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Cipher.update(DES,DECRYPT_MODE) returned "
+                                    + ret);
+                            }
+                        }
+
+                        /* make sure decrypted is same as input */
+                        if (Arrays.equals(rand2kBuf, plaintext)) {
+                            results.add(0);
+                        }
+                        else {
+                            /* not equal, error case */
+                            results.add(1);
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        results.add(1);
+
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in DESede Cipher thread test");
+            }
         }
     }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -100,6 +100,9 @@ public class WolfCryptKeyAgreementTest {
     private static ArrayList<String> disabledCurves =
         new ArrayList<String>();
 
+    /* One static SecureRandom to share */
+    private static SecureRandom secureRandom = new SecureRandom();
+
     private static void printDisabledCurves() {
 
         if (disabledCurves.size() > 0)
@@ -185,7 +188,7 @@ public class WolfCryptKeyAgreementTest {
 
         /* initialize key pair generator */
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH", "wolfJCE");
-        keyGen.initialize(dhParams, new SecureRandom());
+        keyGen.initialize(dhParams, secureRandom);
 
         KeyAgreement aKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
         KeyAgreement bKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
@@ -236,7 +239,7 @@ public class WolfCryptKeyAgreementTest {
 
         /* initialize key pair generator */
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH", "wolfJCE");
-        keyGen.initialize(dhParams, new SecureRandom());
+        keyGen.initialize(dhParams, secureRandom);
 
         KeyAgreement aKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
         KeyAgreement bKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
@@ -290,7 +293,7 @@ public class WolfCryptKeyAgreementTest {
 
         /* initialize key pair generator */
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH", "wolfJCE");
-        keyGen.initialize(dhParams, new SecureRandom());
+        keyGen.initialize(dhParams, secureRandom);
 
         KeyAgreement aKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
         KeyAgreement bKeyAgree = KeyAgreement.getInstance("DH");

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -27,6 +27,12 @@ import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Random;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.ShortBufferException;
@@ -493,6 +499,137 @@ public class WolfCryptKeyAgreementTest {
         byte secretC[]  = cKeyAgree.generateSecret();
 
         assertArrayEquals(secretA2, secretC);
+    }
+
+    private void threadRunnerKeyAgreeTest(String algo)
+        throws InterruptedException, NoSuchAlgorithmException {
+
+        int numThreads = 10;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+        final String currentAlgo = algo;
+
+        /* DH Tests */
+        AlgorithmParameterGenerator paramGen =
+            AlgorithmParameterGenerator.getInstance("DH");
+        paramGen.init(512);
+        final AlgorithmParameters params = paramGen.generateParameters();
+
+        /* Do encrypt/decrypt and sign/verify in parallel across numThreads
+         * threads, all operations should pass */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int failed = 0;
+                    KeyPairGenerator keyGen = null;
+                    KeyAgreement aKeyAgree = null;
+                    KeyAgreement bKeyAgree = null;
+                    KeyAgreement cKeyAgree = null;
+                    KeyPair aPair = null;
+                    KeyPair bPair = null;
+                    KeyPair cPair = null;
+
+                    try {
+
+                        /* Set up KeyPairGenerator */
+                        if (currentAlgo.equals("DH")) {
+                            DHParameterSpec dhParams =
+                                (DHParameterSpec)params.getParameterSpec(
+                                    DHParameterSpec.class);
+
+                            keyGen = KeyPairGenerator.getInstance(
+                                "DH", "wolfJCE");
+                            keyGen.initialize(dhParams, secureRandom);
+                        } else {
+                            ECGenParameterSpec ecsp =
+                                new ECGenParameterSpec("secp256r1");
+
+                            keyGen = KeyPairGenerator.getInstance(
+                                "EC", "wolfJCE");
+                            keyGen.initialize(ecsp);
+                        }
+
+                        /* Get KeyAgreement objects */
+                        aKeyAgree = KeyAgreement.getInstance(
+                            currentAlgo, "wolfJCE");
+                        bKeyAgree = KeyAgreement.getInstance(
+                            currentAlgo, "wolfJCE");
+
+                        /* Generate key pairs */
+                        aPair = keyGen.generateKeyPair();
+                        bPair = keyGen.generateKeyPair();
+
+                        /* Initialize KeyAgreement objects with private keys */
+                        aKeyAgree.init(aPair.getPrivate());
+                        bKeyAgree.init(bPair.getPrivate());
+
+                        aKeyAgree.doPhase(bPair.getPublic(), true);
+                        bKeyAgree.doPhase(aPair.getPublic(), true);
+
+                        /* Generate shared secrets */
+                        byte secretA[] = aKeyAgree.generateSecret();
+                        byte secretB[] = bKeyAgree.generateSecret();
+
+                        if (!Arrays.equals(secretA, secretB)) {
+                            failed = 1;
+                        }
+
+                        if (failed == 0) {
+                            cKeyAgree = KeyAgreement.getInstance(
+                                currentAlgo, "wolfJCE");
+                            cPair = keyGen.generateKeyPair();
+                            cKeyAgree.init(cPair.getPrivate());
+
+                            aKeyAgree.doPhase(cPair.getPublic(), true);
+                            cKeyAgree.doPhase(aPair.getPublic(), true);
+
+                            byte secretA2[] = aKeyAgree.generateSecret();
+                            byte secretC[]  = cKeyAgree.generateSecret();
+
+                            if (!Arrays.equals(secretA2, secretC)) {
+                                failed = 1;
+                            }
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        failed = 1;
+
+                    } finally {
+                        latch.countDown();
+                    }
+
+                    if (failed == 1) {
+                        results.add(1);
+                    }
+                    else {
+                        results.add(0);
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* Look for any failures that happened */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in KeyAgreement thread test");
+            }
+        }
+    }
+
+    @Test
+    public void testThreadedKeyAgreement()
+        throws InterruptedException, NoSuchAlgorithmException {
+
+        threadRunnerKeyAgreeTest("DH");
+        threadRunnerKeyAgreeTest("ECDH");
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
@@ -26,6 +26,14 @@ import org.junit.Test;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import java.security.Security;
 import java.security.Provider;
 import java.security.MessageDigest;
@@ -272,6 +280,67 @@ public class WolfCryptMessageDigestMd5Test {
 
         MessageDigest md5 = MessageDigest.getInstance("MD5", "wolfJCE");
         assertEquals(Md5.DIGEST_SIZE, md5.getDigestLength());
+    }
+
+    @Test
+    public void testMd5Threaded()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    MessageDigest md5 = null;
+
+                    try {
+                        md5 = MessageDigest.getInstance(
+                            "MD5", "wolfJCE");
+                    } catch (NoSuchAlgorithmException |
+                             NoSuchProviderException e) {
+                        /* add empty array on failure, will error out below */
+                        results.add(new byte[] {0});
+                    }
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        md5.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = md5.digest();
+                    results.add(hash.clone());
+
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
@@ -26,6 +26,14 @@ import org.junit.Test;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import java.security.Security;
 import java.security.Provider;
 import java.security.MessageDigest;
@@ -261,6 +269,67 @@ public class WolfCryptMessageDigestSha256Test {
 
         MessageDigest sha256 = MessageDigest.getInstance("SHA-256", "wolfJCE");
         assertEquals(Sha256.DIGEST_SIZE, sha256.getDigestLength());
+    }
+
+    @Test
+    public void testSha256Threaded()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    MessageDigest sha = null;
+
+                    try {
+                        sha = MessageDigest.getInstance(
+                            "SHA-256", "wolfJCE");
+                    } catch (NoSuchAlgorithmException |
+                             NoSuchProviderException e) {
+                        /* add empty array on failure, will error out below */
+                        results.add(new byte[] {0});
+                    }
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
@@ -26,6 +26,14 @@ import org.junit.Test;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import java.security.Security;
 import java.security.Provider;
 import java.security.MessageDigest;
@@ -318,6 +326,67 @@ public class WolfCryptMessageDigestSha384Test {
 
         MessageDigest sha384 = MessageDigest.getInstance("SHA-384", "wolfJCE");
         assertEquals(Sha384.DIGEST_SIZE, sha384.getDigestLength());
+    }
+
+    @Test
+    public void testSha384Threaded()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    MessageDigest sha = null;
+
+                    try {
+                        sha = MessageDigest.getInstance(
+                            "SHA-384", "wolfJCE");
+                    } catch (NoSuchAlgorithmException |
+                             NoSuchProviderException e) {
+                        /* add empty array on failure, will error out below */
+                        results.add(new byte[] {0});
+                    }
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
@@ -26,6 +26,14 @@ import org.junit.Test;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import java.security.Security;
 import java.security.Provider;
 import java.security.MessageDigest;
@@ -346,6 +354,67 @@ public class WolfCryptMessageDigestSha512Test {
 
         MessageDigest sha512 = MessageDigest.getInstance("SHA-512", "wolfJCE");
         assertEquals(Sha512.DIGEST_SIZE, sha512.getDigestLength());
+    }
+
+    @Test
+    public void testSha512Threaded()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    MessageDigest sha = null;
+
+                    try {
+                        sha = MessageDigest.getInstance(
+                            "SHA-512", "wolfJCE");
+                    } catch (NoSuchAlgorithmException |
+                             NoSuchProviderException e) {
+                        /* add empty array on failure, will error out below */
+                        results.add(new byte[] {0});
+                    }
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
@@ -68,6 +68,9 @@ public class WolfCryptSignatureTest {
     private static ArrayList<String> enabledAlgos =
         new ArrayList<String>();
 
+    /* One static SecureRandom to share */
+    private static SecureRandom secureRandom = new SecureRandom();
+
     @BeforeClass
     public static void testProviderInstallationAtRuntime()
         throws NoSuchProviderException {
@@ -131,12 +134,8 @@ public class WolfCryptSignatureTest {
             assertNotNull(signer);
             assertNotNull(verifier);
 
-            SecureRandom rand =
-                SecureRandom.getInstance("HashDRBG", "wolfJCE");
-            assertNotNull(rand);
-
             /* generate key pair */
-            KeyPair pair = generateKeyPair(enabledAlgos.get(i), rand);
+            KeyPair pair = generateKeyPair(enabledAlgos.get(i), secureRandom);
             assertNotNull(pair);
 
             PrivateKey priv = pair.getPrivate();
@@ -180,12 +179,8 @@ public class WolfCryptSignatureTest {
             assertNotNull(signer);
             assertNotNull(verifier);
 
-            SecureRandom rand =
-                SecureRandom.getInstance("HashDRBG", "wolfJCE");
-            assertNotNull(rand);
-
             /* generate key pair */
-            KeyPair pair = generateKeyPair(enabledAlgos.get(i), rand);
+            KeyPair pair = generateKeyPair(enabledAlgos.get(i), secureRandom);
             assertNotNull(pair);
 
             PrivateKey priv = pair.getPrivate();
@@ -241,12 +236,8 @@ public class WolfCryptSignatureTest {
                 return;
             }
 
-            SecureRandom rand =
-                SecureRandom.getInstance("HashDRBG", "wolfJCE");
-            assertNotNull(rand);
-
             /* generate key pair */
-            KeyPair pair = generateKeyPair(enabledAlgos.get(i), rand);
+            KeyPair pair = generateKeyPair(enabledAlgos.get(i), secureRandom);
             assertNotNull(pair);
 
             PrivateKey priv = pair.getPrivate();
@@ -297,12 +288,8 @@ public class WolfCryptSignatureTest {
                 return;
             }
 
-            SecureRandom rand =
-                SecureRandom.getInstance("HashDRBG", "wolfJCE");
-            assertNotNull(rand);
-
             /* generate key pair */
-            KeyPair pair = generateKeyPair(enabledAlgos.get(i), rand);
+            KeyPair pair = generateKeyPair(enabledAlgos.get(i), secureRandom);
             assertNotNull(pair);
 
             PrivateKey priv = pair.getPrivate();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
@@ -23,6 +23,13 @@ package com.wolfssl.wolfcrypt.test;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.nio.ByteBuffer;
 
 import javax.crypto.ShortBufferException;
@@ -235,6 +242,88 @@ public class Des3Test {
         /* free objects */
         enc.releaseNativeStruct();
         dec.releaseNativeStruct();
+    }
+
+    @Test
+    public void threadedDes3Test() throws InterruptedException {
+
+        int numThreads = 50;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+        final byte[] rand2kBuf = new byte[2048];
+        final byte[] key = Util.h2b("e61a38548694f1fd8cef251c518" +
+                                    "cc70bb613751c1ce52aa8");
+        final byte[] iv = Util.h2b("48a8ceb8551fd4ad");
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand2kBuf);
+
+        /* encrypt / decrypt input data, make sure decrypted matches original */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int ret = 0;
+                    Des3 enc = new Des3(key, iv, Des3.ENCRYPT_MODE);
+                    Des3 dec = new Des3(key, iv, Des3.DECRYPT_MODE);
+                    byte[] encrypted = new byte[2048];
+                    byte[] plaintext = new byte[2048];
+
+                    try {
+                        /* encrypt in 128-byte chunks */
+                        Arrays.fill(encrypted, (byte)0);
+                        for (int j = 0; j < rand2kBuf.length; j+= 128) {
+                            ret = enc.update(rand2kBuf, j, 128, encrypted, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Des3.update(ENCRYPT_MODE) returned " + ret);
+                            }
+                        }
+
+                        /* decrypt in 128-byte chunks */
+                        Arrays.fill(plaintext, (byte)0);
+                        for (int j = 0; j < encrypted.length; j+= 128) {
+                            ret = dec.update(encrypted, j, 128, plaintext, j);
+                            if (ret != 128) {
+                                throw new Exception(
+                                    "Des3.update(DECRYPT_MODE) returned " + ret);
+                            }
+                        }
+
+                        /* make sure decrypted is same as input */
+                        if (Arrays.equals(rand2kBuf, plaintext)) {
+                            results.add(0);
+                        }
+                        else {
+                            /* not equal, error case */
+                            results.add(1);
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        results.add(1);
+
+                    } finally {
+                        enc.releaseNativeStruct();
+                        dec.releaseNativeStruct();
+                        latch.countDown();
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in 3DES thread test");
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/DhTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/DhTest.java
@@ -27,6 +27,14 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import com.wolfssl.wolfcrypt.Dh;
 import com.wolfssl.wolfcrypt.Rng;
 import com.wolfssl.wolfcrypt.WolfCryptError;
@@ -35,6 +43,7 @@ import com.wolfssl.wolfcrypt.Fips;
 
 public class DhTest {
     private static Rng rng = new Rng();
+    private final Object rngLock = new Rng();
 
     @BeforeClass
     public static void setUpRng() {
@@ -74,8 +83,10 @@ public class DhTest {
         assertNull(alice.getPublicKey());
         assertNull(bob.getPublicKey());
 
-        alice.makeKey(rng);
-        bob.makeKey(rng);
+        synchronized (rngLock) {
+            alice.makeKey(rng);
+            bob.makeKey(rng);
+        }
 
         assertNotNull(alice.getPublicKey());
         assertNotNull(bob.getPublicKey());
@@ -86,5 +97,103 @@ public class DhTest {
         assertNotNull(sharedSecretA);
         assertNotNull(sharedSecretB);
         assertArrayEquals(sharedSecretA, sharedSecretB);
+    }
+
+    @Test
+    public void threadedDhSharedSecretTest() throws InterruptedException {
+
+        int numThreads = 10;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+
+        final byte[] p = Util.h2b(
+                "E6969D3D495BE32C7CF180C3BDD4798E91B7818251BB055E"
+              + "2A2064904A79A770FA15A259CBD523A6A6EF09C43048D5A22F971F3C20"
+              + "129B48000E6EDD061CBC053E371D794E5327DF611EBBBE1BAC9B5C6044"
+              + "CF023D76E05EEA9BAD991B13A63C974E9EF1839EB5DB125136F7262E56"
+              + "A8871538DFD823C6505085E21F0DD5C86B");
+        final byte[] g = Util.h2b("02");
+
+        /* make sure alice and bob shared secret generation matches when done
+         * in parallel over numThreads threads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int failed = 0;
+                    Dh alice = null;
+                    Dh bob = null;
+
+                    try {
+                        alice = new Dh(p, g);
+                        bob = new Dh();
+
+                        bob.setParams(p, g);
+
+                        /* keys should be null before generation */
+                        if (alice.getPublicKey() != null ||
+                            bob.getPublicKey() != null) {
+                            failed = 1;
+                        }
+
+                        /* generate Dh keys */
+                        if (failed == 0) {
+                            synchronized (rngLock) {
+                                alice.makeKey(rng);
+                                bob.makeKey(rng);
+                            }
+                        }
+
+                        /* keys should not be null after generation */
+                        if (failed == 0) {
+                            if (alice.getPublicKey() == null ||
+                                bob.getPublicKey() == null) {
+                                failed = 1;
+                            }
+                        }
+
+                        if (failed == 0) {
+                            byte[] sharedSecretA = alice.makeSharedSecret(bob);
+                            byte[] sharedSecretB = bob.makeSharedSecret(alice);
+
+                            if (sharedSecretA == null ||
+                                sharedSecretB == null ||
+                                !Arrays.equals(sharedSecretA, sharedSecretB)) {
+                                failed = 1;
+                            }
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        failed = 1;
+
+                    } finally {
+                        alice.releaseNativeStruct();
+                        bob.releaseNativeStruct();
+                        latch.countDown();
+                    }
+
+                    if (failed == 1) {
+                        results.add(1);
+                    }
+                    else {
+                        results.add(0);
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* Look for any failures that happened */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in DH shared secret thread test");
+            }
+        }
     }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -27,6 +27,14 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import java.security.KeyPairGenerator;
 import java.security.KeyPair;
 import java.security.spec.ECGenParameterSpec;
@@ -43,10 +51,13 @@ import com.wolfssl.wolfcrypt.WolfCryptException;
 
 public class EccTest {
     private static Rng rng = new Rng();
+    private static final Object rngLock = new Rng();
 
     @BeforeClass
     public static void setUpRng() {
-        rng.init();
+        synchronized (rngLock) {
+            rng.init();
+        }
     }
 
     @BeforeClass
@@ -71,8 +82,10 @@ public class EccTest {
         Ecc bob = new Ecc();
         Ecc aliceX963 = new Ecc();
 
-        alice.makeKey(rng, 66);
-        bob.makeKey(rng, 66);
+        synchronized (rngLock) {
+            alice.makeKey(rng, 66);
+            bob.makeKey(rng, 66);
+        }
         aliceX963.importX963(alice.exportX963());
 
         byte[] sharedSecretA = alice.makeSharedSecret(bob);
@@ -112,7 +125,10 @@ public class EccTest {
 
         byte[] hash = "Everyone gets Friday off. ecc p".getBytes();
 
-        byte[] signature = alice.sign(hash, rng);
+        byte[] signature = null;
+        synchronized (rngLock) {
+            signature = alice.sign(hash, rng);
+        }
 
         assertTrue(bob.verify(hash, signature));
 
@@ -157,11 +173,15 @@ public class EccTest {
     @Test
     public void eccMakeKeyOnCurve() {
         Ecc alice = new Ecc();
-        alice.makeKeyOnCurve(rng, 32, "secp256r1");
+        synchronized (rngLock) {
+            alice.makeKeyOnCurve(rng, 32, "secp256r1");
+        }
 
         try {
             alice = new Ecc();
-            alice.makeKeyOnCurve(rng, 32, "BADCURVE");
+            synchronized (rngLock) {
+                alice.makeKeyOnCurve(rng, 32, "BADCURVE");
+            }
             fail("Creating ECC key on bad curve should fail with exception");
         } catch (WolfCryptException e) {
             /* should throw exception here */
@@ -299,6 +319,200 @@ public class EccTest {
         String curveName = Ecc.getCurveName(spec);
 
         assertEquals(curveName, "SECP256R1");
+    }
+
+    @Test
+    public void threadedEccSharedSecretTest() throws InterruptedException {
+
+        int numThreads = 20;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+
+        /* make sure alice and bob shared secret generation matches when done
+         * in parallel over numThreads threads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int failed = 0;
+                    Ecc alice = null;
+                    Ecc bob = null;
+                    Ecc aliceX963 = null;
+                    Ecc alice2 = null;
+
+                    try {
+                        alice = new Ecc();
+                        bob = new Ecc();
+                        aliceX963 = new Ecc();
+
+                        synchronized (rngLock) {
+                            alice.makeKey(rng, 66);
+                            bob.makeKey(rng, 66);
+                        }
+                        aliceX963.importX963(alice.exportX963());
+
+                        byte[] sharedSecretA = alice.makeSharedSecret(bob);
+                        byte[] sharedSecretB = bob.makeSharedSecret(aliceX963);
+
+                        if (!Arrays.equals(sharedSecretA, sharedSecretB)) {
+                            failed = 1;
+                        }
+
+                        if (failed == 0) {
+                            alice2 = new Ecc();
+                            alice2.importPrivate(alice.exportPrivate(),
+                                alice.exportX963());
+
+                            if (!Arrays.equals(sharedSecretA,
+                                    alice2.makeSharedSecret(bob))) {
+                                failed = 1;
+                            }
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        failed = 1;
+
+                    } finally {
+                        alice.releaseNativeStruct();
+                        alice2.releaseNativeStruct();
+                        aliceX963.releaseNativeStruct();
+                        bob.releaseNativeStruct();
+                        latch.countDown();
+                    }
+
+                    if (failed == 1) {
+                        results.add(1);
+                    }
+                    else {
+                        results.add(0);
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* Look for any failures that happened */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in ECC shared secret thread test");
+            }
+        }
+    }
+
+    @Test
+    public void threadedEccSignVerifyTest() throws InterruptedException {
+
+        int numThreads = 10;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+
+        final byte[] prvKey = Util.h2b("30770201010420F8CF92"
+                + "6BBD1E28F1A8ABA1234F3274188850AD7EC7EC92"
+                + "F88F974DAF568965C7A00A06082A8648CE3D0301"
+                + "07A1440342000455BFF40F44509A3DCE9BB7F0C5"
+                + "4DF5707BD4EC248E1980EC5A4CA22403622C9BDA"
+                + "EFA2351243847616C6569506CC01A9BDF6751A42"
+                + "F7BDA9B236225FC75D7FB4");
+
+        final byte[] pubKey = Util.h2b("3059301306072A8648CE"
+                + "3D020106082A8648CE3D0301070342000455BFF4"
+                + "0F44509A3DCE9BB7F0C54DF5707BD4EC248E1980"
+                + "EC5A4CA22403622C9BDAEFA2351243847616C656"
+                + "9506CC01A9BDF6751A42F7BDA9B236225FC75D7FB4");
+
+        final byte[] hash = "Everyone gets Friday off. ecc p".getBytes();
+
+        /* Do sign/verify in each thread, in parallel across numThreads threads,
+         * all operations should pass */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int failed = 0;
+                    Ecc alice = null;
+                    Ecc bob = null;
+                    Ecc aliceX963 = null;
+                    Ecc alice2 = null;
+
+                    try {
+
+                        alice = new Ecc();
+                        bob = new Ecc();
+                        aliceX963 = new Ecc();
+
+                        /* import keys */
+                        alice.privateKeyDecode(prvKey);
+                        bob.publicKeyDecode(pubKey);
+
+                        /* alice sign */
+                        byte[] signature = null;
+                        synchronized (rngLock) {
+                            signature = alice.sign(hash, rng);
+                        }
+
+                        /* bob verify */
+                        if (bob.verify(hash, signature) != true) {
+                            failed = 1;
+                        }
+
+                        /* test alice verify with export/import pub key */
+                        if (failed == 0) {
+                            aliceX963.importX963(alice.exportX963());
+                            if (aliceX963.verify(hash, signature) != true) {
+                                failed = 1;
+                            }
+                        }
+
+                        /* test alice verify with export/import priv key */
+                        if (failed == 0) {
+                            alice2 = new Ecc();
+                            alice2.importPrivate(alice.exportPrivate(),
+                                alice.exportX963());
+                            if (alice2.verify(hash, signature) != true) {
+                                failed = 1;
+                            }
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        failed = 1;
+
+                    } finally {
+                        alice.releaseNativeStruct();
+                        alice2.releaseNativeStruct();
+                        aliceX963.releaseNativeStruct();
+                        bob.releaseNativeStruct();
+                        latch.countDown();
+                    }
+
+                    if (failed == 1) {
+                        results.add(1);
+                    }
+                    else {
+                        results.add(0);
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* Look for any failures that happened */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in ECC sign/verify thread test");
+            }
+        }
     }
 }
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -29,6 +29,14 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import com.wolfssl.wolfcrypt.Rsa;
 import com.wolfssl.wolfcrypt.Rng;
 import com.wolfssl.wolfcrypt.Fips;
@@ -366,5 +374,137 @@ public class RsaTest {
         byte[] signature = priv.sign(plaintext, rng);
 
         assertArrayEquals(plaintext, pub.verify(signature));
+    }
+
+    @Test
+    public void threadedRsaSignVerifyTest() throws InterruptedException {
+
+        int numThreads = 20;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
+
+        final byte[] prvKey = Util
+                .h2b("308204a40201000282010100c303d12bfe39a432453b53c8842b2a7c"
+                        + "749abdaa2a520747d6a636b207328ed0ba697bc6c3449ed48148"
+                        + "fd2d68a28b67bba175c8362c4ad21bf78bbacf0df9efecf1811e"
+                        + "7b9b03479abf65cc7f652469a6e814895be434f7c5b01493f567"
+                        + "7b3a7a78e101565691a613428dd23c409c4cefd186df37511b0c"
+                        + "a13bf5f1a34a35e4e1ce96df1b7ebf4e97d010e8a8083081af20"
+                        + "0b4314c57467b432826f8d86c28840993683ba1e40722217d752"
+                        + "652473b0ceef19cdaeff786c7bc01203d44e720d506d3ba33ba3"
+                        + "995e9dc8d90c85b3d98ad95426db6dfaacbbff254cc4d179f471"
+                        + "d386401813b063b5724e30c49784862d562fd715f77fc0aef5fc"
+                        + "5be5fba1bad302030100010282010100a2e6d85f107164089e2e"
+                        + "6dd16d1e85d20ab18c47ce2c516aa0129e53de914c1d6dea597b"
+                        + "f277aad9c6d98aabd8e116e46326ffb56c1359b8e3a5c872172e"
+                        + "0c9f6fe5593f766f49b111c25a2e16290ddeb78edc40d5a2eee0"
+                        + "1ea1f4be97db86639614cd9809602d30769c3ccde688ee479279"
+                        + "0b5a00e25e5f117c7df908b72006892a5dfd00ab22e1f0b3bc24"
+                        + "a95e260e1f002dfe219a535b6dd32bab9482684336d8f62fc622"
+                        + "fcb5415d0d3360eaa47d7ee84b559156d35c578f1f94172faade"
+                        + "e99ea8f4cf8a4c8ea0e45673b2cf4f86c5693cf324208b5c960c"
+                        + "fa6b123b9a67c1dfc696b2a5d5920d9b094268241045d450e417"
+                        + "3948d0358b946d11de8fca5902818100ea24a7f96933e971dc52"
+                        + "7d8821282f49deba7216e9cc477a880d94578458163a81b03fa2"
+                        + "cfa66c1eb00629008fe77776acdbcac7d95e9b3f269052aefc38"
+                        + "900014bbb40f5894e72f6a7e1c4f4121d431591f4e8a1a8da757"
+                        + "6c22d8e5f47e32a610cb64a5550387a627058cc3d7b627b24dba"
+                        + "30da478f54d33d8b848d949858a502818100d5381bc38fc5930c"
+                        + "470b6f3592c5b08d46c892188ff5800af7efa1fe80b9b52abaca"
+                        + "18b05da507d0938dd89c041cd4628ea6268101ffce8a2a633435"
+                        + "40aa6d80de89236a574d9e6ead934e56900b6d9d738b0cae273d"
+                        + "de4ef0aac56c78676c94529c37676c2defbbafdfa6903cc447cf"
+                        + "8d969e98a9b49fc5a650dcb3f0fb74170281805e830962bdba7c"
+                        + "a2bf4274f57c1cd269c9040d857e3e3d2412c3187bf329f35f0e"
+                        + "766c5975e44184699d32f3cd22abb035ba4ab23ce5d958b6624f"
+                        + "5ddee59e0aca53b22cf79eb36b0a5b7965ec6e914e9220f6fcfc"
+                        + "16edd3760ce2ec7fb269136b780e5a4664b45eb725a05a753a4b"
+                        + "efc73c3ef7fd26b820c4990a9a73bec31902818100ba449314ac"
+                        + "34193b5f9160acf7b4d681053651533de865dcaf2edc613ec97d"
+                        + "b87f87f03b9b03822937ce724e11d5b1c10c07a099914a8d7fec"
+                        + "79cff139b5e985ec62f7da7dbc644d223c0ef2d651f587d899c0"
+                        + "11205d0f29fd5be2aed91cd921566dfc84d05fed10151c1821e7"
+                        + "c43d4bd7d09e6a95cf22c9037b9ee36001fc2f02818011d04bcf"
+                        + "1b67b99f1075478665ae31c2c630ac590650d90fb57006f7f0d3"
+                        + "c8627ca8da6ef6213fd37f5fea8aab3fd92a5ef351d2c23037e3"
+                        + "2da3750d1e4d2134d557705c89bf72ec4a6e68d5cd1874334e8c"
+                        + "3a458fe69640eb63f919863a51dd894bb0f3f99f5d289538be35"
+                        + "abca5ce7935334a1455d1339654246a19fcdf5bf");
+
+        final byte[] plaintext = "Now is the time for all".getBytes();
+
+        /* Do encrypt/decrypt and sign/verify in parallel across numThreads
+         * threads, all operations should pass */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+
+                    int failed = 0;
+
+                    Rsa priv = null;
+                    Rsa pub = null;
+
+                    byte[] n_out = new byte[256];
+                    byte[] e_out = new byte[3];
+                    long[] n_len = new long[1];
+                    long[] e_len = new long[1];
+                    n_len[0] = n_out.length;
+                    e_len[0] = e_out.length;
+
+                    try {
+                        priv = new Rsa(prvKey);
+                        priv.exportRawPublicKey(n_out, n_len, e_out, e_len);
+                        priv.setRng(rng);
+
+                        pub = new Rsa(n_out, e_out);
+
+                        byte[] ciphertext = pub.encrypt(plaintext, rng);
+
+                        if (!Arrays.equals(plaintext,
+                                priv.decrypt(ciphertext))) {
+                            failed = 1;
+                        }
+
+                        if (failed == 0) {
+                            byte[] signature = priv.sign(plaintext, rng);
+
+                            if (!Arrays.equals(plaintext,
+                                    pub.verify(signature))) {
+                                failed = 1;
+                            }
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        failed = 1;
+
+                    } finally {
+                        priv.releaseNativeStruct();
+                        pub.releaseNativeStruct();
+                        latch.countDown();
+                    }
+
+                    if (failed == 1) {
+                        results.add(1);
+                    }
+                    else {
+                        results.add(0);
+                    }
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* Look for any failures that happened */
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail("Threading error in RSA sign/verify thread test");
+            }
+        }
     }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
@@ -24,7 +24,13 @@ package com.wolfssl.wolfcrypt.test;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
 import org.junit.Test;
@@ -187,4 +193,55 @@ public class Sha256Test {
         sha.releaseNativeStruct();
         shaCopy.releaseNativeStruct();
     }
+
+    @Test
+    public void threadedHashTest() throws InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+                    Sha256 sha = new Sha256();
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    sha.releaseNativeStruct();
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
+    }
 }
+

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
@@ -24,7 +24,13 @@ package com.wolfssl.wolfcrypt.test;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
 import org.junit.Test;
@@ -198,5 +204,55 @@ public class Sha384Test {
 
         sha.releaseNativeStruct();
         shaCopy.releaseNativeStruct();
+    }
+
+    @Test
+    public void threadedHashTest() throws InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+                    Sha384 sha = new Sha384();
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    sha.releaseNativeStruct();
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
@@ -24,7 +24,13 @@ package com.wolfssl.wolfcrypt.test;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
 import org.junit.Test;
@@ -202,5 +208,55 @@ public class Sha512Test {
 
         sha.releaseNativeStruct();
         shaCopy.releaseNativeStruct();
+    }
+
+    @Test
+    public void threadedHashTest() throws InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+                    Sha512 sha = new Sha512();
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    sha.releaseNativeStruct();
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
@@ -24,6 +24,13 @@ package com.wolfssl.wolfcrypt.test;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
 import org.junit.Test;
@@ -183,6 +190,56 @@ public class ShaTest {
 
         sha.releaseNativeStruct();
         shaCopy.releaseNativeStruct();
+    }
+
+    @Test
+    public void threadedHashTest() throws InterruptedException {
+
+        int numThreads = 100;
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
+        final byte[] rand10kBuf = new byte[10240];
+
+        /* fill large input buffer with random bytes */
+        new Random().nextBytes(rand10kBuf);
+
+        /* generate hash over input data concurrently across numThreads */
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(new Runnable() {
+                @Override public void run() {
+                    Sha sha = new Sha();
+
+                    /* process/update in 1024-byte chunks */
+                    for (int j = 0; j < rand10kBuf.length; j+= 1024) {
+                        sha.update(rand10kBuf, j, 1024);
+                    }
+
+                    /* get final hash */
+                    byte[] hash = sha.digest();
+                    results.add(hash.clone());
+
+                    sha.releaseNativeStruct();
+                    latch.countDown();
+                }
+            });
+        }
+
+        /* wait for all threads to complete */
+        latch.await();
+
+        /* compare all digests, all should be the same across threads */
+        Iterator<byte[]> listIterator = results.iterator();
+        byte[] current = listIterator.next();
+        while (listIterator.hasNext()) {
+            byte[] next = listIterator.next();
+            if (!Arrays.equals(current, next)) {
+                fail("Found two non-identical digests in thread test");
+            }
+            if (listIterator.hasNext()) {
+                current = listIterator.next();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds synchronization around use of native use of wolfCrypt structure pointers, specifically in this PR are:
- Md5
- Sha/Sha224/Sha384/Sha512
- Des3/Aes
- Hmac
- RsaKey/DhKey/ecc_key

Other remaining algos will come in a follow up PR.  Multi-threaded test cases have been added for these as well as the JCE-level wrapping classes.