### PR TITLE
Standardize JNI library name on OSX to .dylib

### DIFF
--- a/makefile.macosx
+++ b/makefile.macosx
@@ -7,7 +7,7 @@ OBJ_LIST  = jni_fips.o jni_native_struct.o jni_aes.o jni_des3.o jni_md5.o \
 			jni_ed25519.o jni_curve25519.o jni_chacha.o jni_error.o jni_asn.o \
 			jni_logging.o jni_feature_detect.o jni_wolfobject.o
 OBJS      = $(patsubst %,$(OUT_PATH)/%,$(OBJ_LIST))
-TARGET    = $(OUT_PATH)/libwolfcryptjni.jnilib
+TARGET    = $(OUT_PATH)/libwolfcryptjni.dylib
 
 JAVA_HOME ?= $(shell /usr/libexec/java_home)
 CC        = gcc


### PR DESCRIPTION
This PR standardizes the native JNI shared library on OSX to `.dylib` extension, which matches OSX shared library naming. Some Java versions won't find `libwolfcryptjni.jnilib` if installed unless it is named `libwolfcrypt.dylib` instead.