### PR TITLE
Call PRIVATE_KEY_LOCK/UNLOCK and FIPS_CAST_ECC_CDH for 140-3 compatibility

### DIFF
--- a/jni/jni_dh.c
+++ b/jni/jni_dh.c
@@ -208,7 +208,9 @@ Java_com_wolfssl_wolfcrypt_Dh_wc_1DhGenerateKeyPair(
         }
         XMEMSET(pub, 0, pubSz);
 
+        PRIVATE_KEY_UNLOCK();
         ret = wc_DhGenerateKeyPair(key, rng, priv, &privSz, pub, &pubSz);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret == 0) {
@@ -367,7 +369,9 @@ Java_com_wolfssl_wolfcrypt_Dh_wc_1DhAgree(
         ret = BAD_FUNC_ARG;
     }
     else {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_DhAgree(key, secret, &secretSz, priv, privSz, pub, pubSz);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret == 0) {

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -434,7 +434,9 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1export_1x963(
 
     /* get size */
     if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_x963(ecc, NULL, &outputSz);
+        PRIVATE_KEY_LOCK();
         if (ret == LENGTH_ONLY_E) {
             ret = 0;
         }
@@ -451,7 +453,9 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1export_1x963(
     }
 
     if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_x963(ecc, output, &outputSz);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret == 0) {
@@ -771,7 +775,9 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1shared_1secret(
 #endif
 
     if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_shared_secret(ecc, pub, output, &outputSz);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret == 0) {

--- a/jni/jni_wolfobject.c
+++ b/jni/jni_wolfobject.c
@@ -52,85 +52,118 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_WolfObject_init
 #if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 5)
     /* run FIPS 140-3 conditional algorithm self tests early to prevent
      * multi threaded issues later on */
+#if !defined(NO_AES) && !defined(NO_AES_CBC)
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_AES_CBC);
         if (ret != 0) {
             printf("AES-CBC CAST failed");
         }
     }
+#endif
+#ifdef HAVE_AESGCM
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_AES_GCM);
         if (ret != 0) {
             printf("AES-GCM CAST failed");
         }
     }
+#endif
+#ifndef NO_SHA
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_HMAC_SHA1);
         if (ret != 0) {
             printf("HMAC-SHA1 CAST failed");
         }
     }
+#endif
+    /* the only non-optional CAST */
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_HMAC_SHA2_256);
         if (ret != 0) {
             printf("HMAC-SHA2-256 CAST failed");
         }
     }
+#ifdef WOLFSSL_SHA512
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_HMAC_SHA2_512);
         if (ret != 0) {
             printf("HMAC-SHA2-512 CAST failed");
         }
     }
-
+#endif
+#ifdef WOLFSSL_SHA3
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_HMAC_SHA3_256);
         if (ret != 0) {
             printf("HMAC-SHA3-256 CAST failed");
         }
     }
+#endif
+#ifdef HAVE_HASHDRBG
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_DRBG);
         if (ret != 0) {
             printf("Hash_DRBG CAST failed");
         }
     }
+#endif
+#ifndef NO_RSA
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_RSA_SIGN_PKCS1v15);
         if (ret != 0) {
             printf("RSA sign CAST failed");
         }
     }
+#endif
+#if defined(HAVE_ECC_CDH) && defined(HAVE_ECC_CDH_CAST)
+    if (ret == 0) {
+        ret = wc_RunCast_fips(FIPS_CAST_ECC_CDH);
+        if (ret != 0) {
+            printf("ECC CDH CAST failed");
+        }
+    }
+#endif
+#ifdef HAVE_ECC_DHE
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_ECC_PRIMITIVE_Z);
         if (ret != 0) {
             printf("ECC Primitive Z CAST failed");
         }
     }
-    if (ret == 0) {
-        ret = wc_RunCast_fips(FIPS_CAST_DH_PRIMITIVE_Z);
-        if (ret != 0) {
-            printf("DH Primitive Z CAST failed");
-        }
-    }
+#endif
+#ifdef HAVE_ECC
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_ECDSA);
         if (ret != 0) {
             printf("ECDSA CAST failed");
         }
     }
+#endif
+#ifndef NO_DH
+    if (ret == 0) {
+        ret = wc_RunCast_fips(FIPS_CAST_DH_PRIMITIVE_Z);
+        if (ret != 0) {
+            printf("DH Primitive Z CAST failed");
+        }
+    }
+#endif
+#ifdef WOLFSSL_HAVE_PRF
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_KDF_TLS12);
         if (ret != 0) {
             printf("KDF TLSv1.2 CAST failed");
         }
     }
+#endif
+#if defined(WOLFSSL_HAVE_PRF) && defined(WOLFSSL_TLS13)
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_KDF_TLS13);
         if (ret != 0) {
             printf("KDF TLSv1.3 CAST failed");
         }
     }
+#endif
+#ifdef WOLFSSL_WOLFSSH
     if (ret == 0) {
         ret = wc_RunCast_fips(FIPS_CAST_KDF_SSH);
         if (ret != 0) {
@@ -138,6 +171,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_WolfObject_init
         }
     }
 #endif
+#endif /* HAVE_FIPS && HAVE_FIPS_VERSION == 5 */
 
     if (ret < 0) {
         return ret;


### PR DESCRIPTION
This PR improves compatibility with wolfCrypt FIPS 140-3:
- Calls `PRIVATE_KEY_LOCK()` and `PRIVATE_KEY_UNLOCK()` for native JNI operations that need key unlocked with FIPS 140-3
- Adds missing CAST call for ECC CDH on library initialization
- Adds feature detection ifdefs to CAST calls