### PR TITLE
Adjust native HMAC feature detection, account for no HMAC-MD5 in FIPS 140-3

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
+++ b/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
@@ -47,6 +47,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_Sha384Enable
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_Sha512Enabled
   (JNIEnv *, jclass);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    HmacMd5Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacMd5Enabled
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
+++ b/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
@@ -55,6 +55,38 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_Sha512Enable
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacMd5Enabled
   (JNIEnv *, jclass);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    HmacShaEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacShaEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    HmacSha256Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha256Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    HmacSha384Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha384Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    HmacSha512Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha512Enabled
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/jni_feature_detect.c
+++ b/jni/jni_feature_detect.c
@@ -25,6 +25,7 @@
     #include <wolfssl/options.h>
 #endif
 #include <jni.h>
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfcrypt_jni_debug.h>
 
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_Md5Enabled
@@ -81,6 +82,18 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_Sha512Enable
     (void)env;
     (void)jcl;
 #ifdef WOLFSSL_SHA512
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacMd5Enabled
+  (JNIEnv* env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+#if !defined(NO_HMAC) && !defined(NO_MD5) && FIPS_VERSION_LT(5,2)
     return JNI_TRUE;
 #else
     return JNI_FALSE;

--- a/jni/jni_feature_detect.c
+++ b/jni/jni_feature_detect.c
@@ -100,3 +100,51 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacMd5Enabl
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacShaEnabled
+  (JNIEnv* env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+#if !defined(NO_HMAC) && !defined(NO_SHA)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha256Enabled
+  (JNIEnv* env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+#if !defined(NO_HMAC) && !defined(NO_SHA256)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha384Enabled
+  (JNIEnv* env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+#if !defined(NO_HMAC) && defined(WOLFSSL_SHA384)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha512Enabled
+  (JNIEnv* env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+#if !defined(NO_HMAC) && defined(WOLFSSL_SHA512)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -97,7 +97,7 @@ public final class WolfCryptProvider extends Provider {
         }
 
         /* Mac */
-        if (FeatureDetect.Md5Enabled()) {
+        if (FeatureDetect.HmacMd5Enabled()) {
             put("Mac.HmacMD5",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacMD5");
         }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -101,19 +101,19 @@ public final class WolfCryptProvider extends Provider {
             put("Mac.HmacMD5",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacMD5");
         }
-        if (FeatureDetect.ShaEnabled()) {
+        if (FeatureDetect.HmacShaEnabled()) {
             put("Mac.HmacSHA1",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacSHA1");
         }
-        if (FeatureDetect.Sha256Enabled()) {
+        if (FeatureDetect.HmacSha256Enabled()) {
             put("Mac.HmacSHA256",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacSHA256");
         }
-        if (FeatureDetect.Sha384Enabled()) {
+        if (FeatureDetect.HmacSha384Enabled()) {
             put("Mac.HmacSHA384",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacSHA384");
         }
-        if (FeatureDetect.Sha512Enabled()) {
+        if (FeatureDetect.HmacSha512Enabled()) {
             put("Mac.HmacSHA512",
                     "com.wolfssl.provider.jce.WolfCryptMac$wcHmacSHA512");
         }

--- a/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
@@ -75,6 +75,34 @@ public class FeatureDetect {
     public static native boolean HmacMd5Enabled();
 
     /**
+     * Tests if HMAC-SHA1 is compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false.
+     */
+    public static native boolean HmacShaEnabled();
+
+    /**
+     * Tests if HMAC-SHA256 is compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false.
+     */
+    public static native boolean HmacSha256Enabled();
+
+    /**
+     * Tests if HMAC-SHA384 is compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false.
+     */
+    public static native boolean HmacSha384Enabled();
+
+    /**
+     * Tests if HMAC-SHA512 is compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false.
+     */
+    public static native boolean HmacSha512Enabled();
+
+    /**
      * Loads JNI library.
      *
      * The native library is expected to be called "wolfcryptjni", and must be

--- a/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
@@ -63,6 +63,18 @@ public class FeatureDetect {
     public static native boolean Sha512Enabled();
 
     /**
+     * Tests if HMAC-MD5 is compiled into the native wolfSSL library and
+     * available for use.
+     *
+     * For FIPS 140-3, even if MD5 is compiled into the
+     * library, HMAC-MD5 is not available and will throw BAD_FUNC_ARG.
+     * Use this helper to prevent people from calling it in the first place.
+     *
+     * @return true if enabled, otherwise false.
+     */
+    public static native boolean HmacMd5Enabled();
+
+    /**
      * Loads JNI library.
      *
      * The native library is expected to be called "wolfcryptjni", and must be


### PR DESCRIPTION
This PR adjusts the native wolfSSL feature detection for HMAC availablility:
- Includes check for `NO_HMAC` when checking if native HMAC functionality is available. If not, HMAC algo won't be broadcast as supported for wolfJCE provider.
- For FIPS 140-3, HMAC-MD5 is not available. Account for this when checking for native features.