### PR TITLE
JCE: add "SHA1" alias for MessageDigest SHA-1, for interop with Sun

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -44,6 +44,8 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.ShaEnabled()) {
             put("MessageDigest.SHA",
                     "com.wolfssl.provider.jce.WolfCryptMessageDigestSha");
+            put("MessageDigest.SHA1",
+                    "com.wolfssl.provider.jce.WolfCryptMessageDigestSha");
             put("MessageDigest.SHA-1",
                     "com.wolfssl.provider.jce.WolfCryptMessageDigestSha");
         }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
@@ -58,12 +58,15 @@ public class WolfCryptMessageDigestShaTest {
         assertNotNull(p);
 
         try {
-            /* Try "SHA" cipher string, for SUN interop */
+            /* Try "SHA" and "SHA1" cipher strings, for SUN interop */
             MessageDigest sha = MessageDigest.getInstance("SHA",
                                                           "wolfJCE");
 
-            MessageDigest sha1 = MessageDigest.getInstance("SHA-1",
-                                                           "wolfJCE");
+            MessageDigest sha1 = MessageDigest.getInstance("SHA1",
+                                                          "wolfJCE");
+
+            MessageDigest shaDash1 = MessageDigest.getInstance("SHA-1",
+                                                               "wolfJCE");
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.ShaEnabled() == false) {


### PR DESCRIPTION
This PR adds the string "SHA1" as an algorithm alias for "SHA-1".  Customer testing showed this interop issue, although the "SHA1" string does not seem to be an officially-defined [Java Security Algorithm name](https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#messagedigest-algorithms).