### PR TITLE
Add initial GitHub actions (Linux, Mac)

### DIFF
--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -1,0 +1,104 @@
+name: Common Linux test logic
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      jdk_distro:
+        required: true
+        type: string
+      jdk_version:
+        required: true
+        type: string
+      wolfssl_configure:
+        required: true
+        type: string
+
+jobs:
+  build_wolfcryptjni:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download junit-4.13.2.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+      - name: Download hamcrest-all-1.3.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+
+      - name: Build native wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          repository: wolfSSL/wolfssl
+          ref: master
+          path: wolfssl
+          configure: ${{ inputs.wolfssl_configure }}
+          check: false
+          install: true
+
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ inputs.jdk_distro }}
+          java-version: ${{ inputs.jdk_version }}
+
+      - name: Set JUNIT_HOME
+        run: |
+          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
+      - name: Set LD_LIBRARY_PATH
+        run: |
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
+
+      # Only copy appropriate makefile for platform currently being tested
+      - name: Copy makefile
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              cp makefile.linux makefile
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+              cp makefile.macosx makefile
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Build JNI library
+        run: PREFIX=$GITHUB_WORKSPACE/build-dir make
+
+      # ant build-jni-debug
+      - name: Build jce-debug JAR (ant build-jni-debug)
+        run: ant build-jni-debug
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jni-release
+      - name: Build jce-debug JAR (ant build-jni-release)
+        run: ant build-jni-release
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jce-debug
+      - name: Build jce-debug JAR (ant build-jce-debug)
+        run: ant build-jce-debug
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jce-release
+      - name: Build jce-debug JAR (ant build-jce-release)
+        run: ant build-jce-release
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      - name: Show logs on failure
+        if: failure() || cancelled()
+        run: |
+          cat build/reports/*.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,102 @@
-name: GitHub Actions Demo
-
+name: CI
 on:
   push:
-    branches: [ 'master', 'main', 'testactions', 'release/**' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
 jobs:
-  testjob:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Hello World"
+  # Oracle JDK (Linux, Mac)
+  # Oracle JDK requires JAR to be signed for some classes to load/run
+  # properly, for example KeyAgreement. These tests are commented out
+  # here until we get a solution in place for CI JAR signing
+  #linux-oracle:
+  #  strategy:
+  #    matrix:
+  #      os: [ 'ubuntu-latest', 'macos-latest' ]
+  #      jdk_version: [ '17', '21' ]
+  #      wolfssl_configure: [ '--enable-jni' ]
+  #  name: ${{ matrix.os }} (Oracle JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+  #  uses: ./.github/workflows/linux-common.yml
+  #  with:
+  #    os: ${{ matrix.os }}
+  #    jdk_distro: "oracle"
+  #    jdk_version: ${{ matrix.jdk_version }}
+  #    wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Zulu JDK (Linux, Mac)
+  linux-zulu:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Corretto JDK (Linux, Mac)
+  linux-corretto:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Corretto JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "corretto"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Temurin JDK (Linux, Mac)
+  linux-temurin:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Temurin JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "temurin"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Microsoft JDK (Linux, Mac)
+  linux-microsoft:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11.0.19', '17.0.7', '21.0.0' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Microsoft JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "microsoft"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # -------------------- enable-all sanity checks -----------------------
+  # Only check one Linux and Mac JDK version with --enable-jni --enable-all
+  # as sanity. Using Zulu, but this can be expanded if needed.
+  linux-zulu-all:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [ '--enable-jni --enable-all' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}

--- a/build.xml
+++ b/build.xml
@@ -40,8 +40,8 @@
     <property name="jce.debug" value="false" />
 
     <!-- compatible defaults -->
-    <property name="java.source" value="1.7" />
-    <property name="java.target" value="1.7" />
+    <property name="java.source" value="1.8" />
+    <property name="java.target" value="1.8" />
 
     <!-- property file for code signing -->
     <property file="codeSigning.properties" />

--- a/makefile.macosx
+++ b/makefile.macosx
@@ -2,6 +2,24 @@ OUT_PATH  = lib
 SRC_PATH  = jni
 INC_PATH  = $(SRC_PATH)/include
 
+ifneq ($(PREFIX),)
+    INSTALL_DIR = $(DESTDIR)$(PREFIX)
+else
+    INSTALL_DIR = $(DESTDIR)/usr/local
+endif
+
+ifeq ($(LIBDIR),)
+    LIBDIR=lib
+endif
+
+ifeq ($(INSTALL),)
+    INSTALL=install
+endif
+
+ifeq ($(WOLFSSL_LIBNAME),)
+    WOLFSSL_LIBNAME=wolfssl
+endif
+
 OBJ_LIST  = jni_fips.o jni_native_struct.o jni_aes.o jni_aesgcm.o jni_des3.o \
 			jni_md5.o jni_sha.o jni_hmac.o jni_rng.o jni_rsa.o jni_dh.o \
 			jni_ecc.o jni_ed25519.o jni_curve25519.o jni_chacha.o jni_error.o \
@@ -12,8 +30,8 @@ TARGET    = $(OUT_PATH)/libwolfcryptjni.dylib
 JAVA_HOME ?= $(shell /usr/libexec/java_home)
 CC        = gcc
 override CCFLAGS   += -Wall -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin \
-			-I$(INC_PATH)
-override LDFLAGS   += -dynamiclib -lwolfssl
+			-I$(INC_PATH) -I$(INSTALL_DIR)/include
+override LDFLAGS   += -dynamiclib -L$(INSTALL_DIR)/$(LIBDIR) -l$(WOLFSSL_LIBNAME)
 
 all: $(TARGET)
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -1842,11 +1842,8 @@ public class WolfCryptCipherTest {
             for (int j = 0; j < fourByteBlocks; j++) {
                 tmp = enc.update(Arrays.copyOfRange(vIn, inIdx, inIdx + 4));
                 assertNotNull(tmp);
-                if (FeatureDetect.AesGcmStreamEnabled()) {
-                    assertEquals(4, tmp.length);
-                } else {
-                    assertEquals(0, tmp.length);
-                }
+                /* AES-GCM stream API not supported in JCE yet */
+                assertEquals(0, tmp.length);
                 System.arraycopy(tmp, 0, output, outIdx, tmp.length);
                 inIdx += 4;
                 outIdx += tmp.length;
@@ -1858,11 +1855,8 @@ public class WolfCryptCipherTest {
                 tmp = enc.update(Arrays.copyOfRange(vIn, inIdx,
                         inIdx + remainingBytes));
                 assertNotNull(tmp);
-                if (FeatureDetect.AesGcmStreamEnabled()) {
-                    assertEquals(remainingBytes, tmp.length);
-                } else {
-                    assertEquals(0, tmp.length);
-                }
+                /* AES-GCM stream API not supported in JCE yet */
+                assertEquals(0, tmp.length);
                 System.arraycopy(tmp, 0, output, outIdx, tmp.length);
                 inIdx += remainingBytes;
                 outIdx += tmp.length;
@@ -1872,11 +1866,8 @@ public class WolfCryptCipherTest {
              * streaming is not enabled at native wolfSSL level) */
             tmp = enc.doFinal();
             assertNotNull(tmp);
-            if (FeatureDetect.AesGcmStreamEnabled()) {
-                assertEquals(vTag.length, tmp.length);
-            } else {
-                assertEquals(tmpOut.length, tmp.length);
-            }
+            /* AES-GCM stream API not supported in JCE yet */
+            assertEquals(tmpOut.length, tmp.length);
             System.arraycopy(tmp, 0, output, outIdx, tmp.length);
             outIdx += tmp.length;
 
@@ -1914,11 +1905,8 @@ public class WolfCryptCipherTest {
             for (int j = 0; j < fourByteBlocks; j++) {
                 tmp = dec.update(Arrays.copyOfRange(output, inIdx, inIdx + 4));
                 assertNotNull(tmp);
-                if (FeatureDetect.AesGcmStreamEnabled()) {
-                    assertEquals(4, tmp.length);
-                } else {
-                    assertEquals(0, tmp.length);
-                }
+                /* AES-GCM stream API not supported in JCE yet */
+                assertEquals(0, tmp.length);
                 System.arraycopy(tmp, 0, plain, outIdx, tmp.length);
                 inIdx += 4;
                 outIdx += tmp.length;
@@ -1930,11 +1918,8 @@ public class WolfCryptCipherTest {
                 tmp = dec.update(Arrays.copyOfRange(output, inIdx,
                         inIdx + remainingBytes));
                 assertNotNull(tmp);
-                if (FeatureDetect.AesGcmStreamEnabled()) {
-                    assertEquals(remainingBytes, tmp.length);
-                } else {
-                    assertEquals(0, tmp.length);
-                }
+                /* AES-GCM stream API not supported in JCE yet */
+                assertEquals(0, tmp.length);
                 System.arraycopy(tmp, 0, plain, outIdx, tmp.length);
                 inIdx += remainingBytes;
                 outIdx += tmp.length;
@@ -1944,11 +1929,8 @@ public class WolfCryptCipherTest {
              * streaming is not enabled at native wolfSSL level */
             tmp = dec.doFinal();
             assertNotNull(tmp);
-            if (FeatureDetect.AesGcmStreamEnabled()) {
-                assertEquals(0, tmp.length);
-            } else {
-                assertEquals(vIn.length, tmp.length);
-            }
+            /* AES-GCM stream API not supported in JCE yet */
+            assertEquals(vIn.length, tmp.length);
             System.arraycopy(tmp, 0, plain, outIdx, tmp.length);
             outIdx += tmp.length;
 


### PR DESCRIPTION
This PR adds GitHub actions for automated testing against various JDK distributions and versions. Current testing includes the following.  Oracle JDK testing was omitted for now since that JDK requires our JAR to be signed.

**wolfSSL ./configure --enable-jni:**

- Test on both Linux (ubuntu-latest) and Mac OSX (macos-latest)
- Zulu JDK (8, 11, 17, 21)
- Corretto JDK (8, 11, 17, 21)
- Microsoft JDK (11.0.19, 17.0.7, 21.0.0)

**wolfSSL ./configure --enable-jni --enable-all:**

- Test on both Linux (ubuntu-latest) and Mac OSX (macos-latest)
- Just a sanity check with --enable-all used, so only currently testing Zulu JDK 11

This PR also fixes a few minor items that showed up in the process of adding action testing:
- Add support to `makefile.macosx` for custom wolfSSL installation location
- Bump build.xml Java min version to 1.8, allows for build compatibility with higher Java versions (ex: 21)
- Fixes WolfCryptCipherTest when `--enable-all` is used, since we don't support AES-GCM streaming API inside wolfJCE yet