### PR TITLE
CertPathValidator: set PKIXParameters Signature provider if null with wolfCrypt FIPS

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -653,9 +653,16 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
         /* If we are in FIPS mode, verify wolfJCE is the Signature provider
          * to help maintain FIPS compliance */
         if (Fips.enabled && pkixParams.getSigProvider() != "wolfJCE") {
-            throw new CertPathValidatorException(
-                "CertPathParameters Signature Provider must be wolfJCE " +
-                "when using wolfCrypt FIPS");
+            if (pkixParams.getSigProvider() == null) {
+                /* Preferred Signature provider not set, set to wolfJCE */
+                pkixParams.setSigProvider("wolfJCE");
+            }
+            else {
+                throw new CertPathValidatorException(
+                    "CertPathParameters Signature Provider must be wolfJCE " +
+                    "when using wolfCrypt FIPS: " +
+                    pkixParams.getSigProvider());
+            }
         }
 
         /* Use wolfSSL CertManager to facilitate chain verification */


### PR DESCRIPTION
This PR makes one fix to wolfJCE's `CertPathValidator` implementation (`WolfCryptPKIXCertPathValidator`). If `PKIXParameters.getSigProvider()` returns null in `engineValidate()`, the `Signature` provider has not been set. If using wolfCrypt FIPS, explicitly set to `wolfJCE` to help maintain FIPS compliance.

If set to a different Signature provider, we throw an exception when used with wolfCrypt FIPS.