### PR TITLE
JCE: prepend zero byte to DH shared secret if less than prime length

### DIFF
--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -314,6 +314,17 @@ public class WolfCryptKeyAgreementTest {
             byte secretA[] = aKeyAgree.generateSecret();
             byte secretB[] = bKeyAgree.generateSecret();
 
+            /* Older versions of Java did not prepend a zero byte to shared
+             * secrets that were smaller than the prime length. This was
+             * changed in SunJCE as of JDK-7146728, but we may be running this
+             * test on an older version that does not prepend the zero byte.
+             * Since wolfJCE does prepend the zero byte, for the sake of this
+             * interop test, we strip the zero byte from wolfJCE's secret
+             * if lengths are different and try to compare that. */
+            if (secretB.length == (secretA.length - 1)) {
+                secretA = Arrays.copyOfRange(secretA, 1, secretA.length);
+            }
+
             if (secretA.length != secretB.length) {
                 int i = 0;
                 System.out.println("secretA.length != secretB.length");


### PR DESCRIPTION
This PR adjusts wolfJCE's `KeyAgreement` implementation for generating DH shared secrets.

Native wolfCrypt generates and returns DH shared secrets that have any zero bytes stripped off.  This follows RFC 5246 (8.1.2) which instructs to do so.  Other Java KeyAgreement implementations (SunJCE, Bouncy Castle) for DH follow RFC 2631 (2.1.2) which prepends zero bytes if the total secret size is less than the prime length.

This PR adjusts our wolfJCE implementation to match other existing Java implementations, for interop compatibility. 

This fixes a sporadic JUnit failure which looks similar to this:

```
Testcase: testDHKeyAgreementInterop took 0.016 sec
	FAILED
array lengths differed, expected.length=63 actual.length=64; arrays first differed at element [0]; expected:<-18> but was:<0>
junit.framework.AssertionFailedError: array lengths differed, expected.length=63 actual.length=64; arrays first differed at element [0]; expected:<-18> but was:<0>
	at com.wolfssl.provider.jce.test.WolfCryptKeyAgreementTest.testDHKeyAgreementInterop(WolfCryptKeyAgreementTest.java:333)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
Caused by: java.lang.AssertionError: expected:<-18> but was:<0>

------------- Standard Output ---------------
secretA.length != secretB.length
secretA (wolfJCE, 63 bytes):
eed8b5ff4038cb32bff900b4596b8992e6c6d3f3f98f68155c5897eaa5762837af14989f741f8d55ea36b2ceb17d04530abd54bd5ee5219006950bb0569cfc
secretB (SunJCE, 64 bytes):
00eed8b5ff4038cb32bff900b4596b8992e6c6d3f3f98f68155c5897eaa5762837af14989f741f8d55ea36b2ceb17d04530abd54bd5ee5219006950bb0569cfc
------------- ---------------- ---------------
```