### PR TITLE
JNI/JCE: fix Javadoc warnings with newer Java versions

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -73,6 +73,9 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
 
     private WolfCryptDebug debug;
 
+    /**
+     * Create new WolfCryptPKIXCertPathValidator object.
+     */
     public WolfCryptPKIXCertPathValidator() {
         if (debug.DEBUG) {
             log("created new WolfCryptPKIXCertPathValidator");

--- a/src/main/java/com/wolfssl/wolfcrypt/AesGcm.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesGcm.java
@@ -28,7 +28,7 @@ public class AesGcm extends NativeStruct {
 
     private WolfCryptState state = WolfCryptState.UNINITIALIZED;
 
-    /* Lock around object state */
+    /** Lock around object state */
     protected final Object stateLock = new Object();
 
     /* Lock around native Aes poiner use */
@@ -51,6 +51,11 @@ public class AesGcm extends NativeStruct {
         init();
     }
 
+    /**
+     * Create and initialize new AesGcm object using provided key.
+     *
+     * @param key AES-GCM key to be used with this object
+     */
     public AesGcm(byte[] key) {
         init();
         setKey(key);

--- a/src/main/java/com/wolfssl/wolfcrypt/Dh.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Dh.java
@@ -31,7 +31,7 @@ public class Dh extends NativeStruct {
     private byte[] publicKey = null;
     private int pSize = 0;
 
-    /* Lock around object state */
+    /** Lock around object state */
     protected final Object stateLock = new Object();
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
@@ -38,7 +38,7 @@ public class Ecc extends NativeStruct {
     /* used with native wc_ecc_set_rng() */
     private Rng rng = null;
 
-    /* Lock around object state */
+    /** Lock around object state */
     protected final Object stateLock = new Object();
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -50,7 +50,7 @@ public class Hmac extends NativeStruct {
     private int type = -1;
     private byte[] key;
 
-    /* Lock around object state */
+    /** Lock around object state */
     protected final Object stateLock = new Object();
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
@@ -39,7 +39,7 @@ public abstract class NativeStruct extends WolfObject {
     /* points to the internal native structure */
     private long pointer = 0;
 
-    /* Lock around native pointer use */
+    /** Lock around native pointer use */
     protected final Object pointerLock = new Object();
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Rsa.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Rsa.java
@@ -32,7 +32,7 @@ public class Rsa extends NativeStruct {
     private boolean hasPrivateKey = false;
     private Rng rng;
 
-    /* Lock around object state */
+    /** Lock around object state */
     protected final Object stateLock = new Object();
 
     /**


### PR DESCRIPTION
This PR fixes a few small Javadoc warnings that showed up when tested with newer Java versions (21, 22).

Only includes comment/doc changes, no functional code changes.