### PR TITLE
JCE: add support for SecureRandom.getInstance("DEFAULT")

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -34,6 +34,7 @@ The JCE provider currently supports the following algorithms:
         SHA-512
 
     SecureRandom Class
+        DEFAULT (maps to HashDRBG)
         HashDRBG
 
     Cipher Class

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -65,6 +65,8 @@ public final class WolfCryptProvider extends Provider {
         /* SecureRandom */
         /* TODO: May need to add "SHA1PRNG" alias, other JCA consumemrs may
          * explicitly request it? Needs more testing. */
+        put("SecureRandom.DEFAULT",
+                "com.wolfssl.provider.jce.WolfCryptRandom");
         put("SecureRandom.HashDRBG",
                 "com.wolfssl.provider.jce.WolfCryptRandom");
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptRandomTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptRandomTest.java
@@ -57,7 +57,13 @@ public class WolfCryptRandomTest {
     public void testGetRandomFromProvider()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        SecureRandom rand = SecureRandom.getInstance("HashDRBG", "wolfJCE");
+        SecureRandom rand = null;
+
+        /* HashDRBG */
+        rand = SecureRandom.getInstance("HashDRBG", "wolfJCE");
+
+        /* DEFAULT */
+        rand = SecureRandom.getInstance("DEFAULT", "wolfJCE");
     }
 
     @Test


### PR DESCRIPTION
This PR adds `SecureRandom` DEFAULT algorithm support, which maps to `HashDRBG`. This catches an edge case for users who have applications that are requesting the DEFAULT algorithm type:

```
SecureRandom rand = SecureRandom.getInstance("DEFAULT");
```