### PR TITLE
Prep for 1.6 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,155 @@
+### wolfCrypt JNI Release 1.6.0 (4/17/2024)
+
+Release 1.6.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
+
+**New JCE Functionality:**
+- Add RSA support to `KeyPairGenerator` class (PR 49)
+- Add `AES/CBC/PKCS5Padding` support to `Cipher` class (PR 51)
+- Add `RSA` support to `Cipher` class (PR 51)
+- Add `PKIX` implementation of `CertPathValidator` class (PR 60, 66)
+- Add `SHA1` alias for `MessageDigest` `SHA-1` for interop compatibility (PR 61)
+- Add `AES/GCM/NoPadding` support to `Cipher` class (PR 62)
+- Add `SecretKeyFactory` implementation supporting `PBKDF2` (PR 70)
+- Add `DEFAULT` support to `SecureRandom` class (PR 72)
+
+**New JNI Wrapped APIs and Functionality:**
+- Add `AES-GCM` support to `com.wolfssl.wolfcrypt.AesGcm` class (PR 62)
+
+**JNI and JCE Changes:**
+- Add synchronization to `com.wolfssl.wolfcrypt.Rng` class (PR 44)
+- Correct preprocessor guards for 3DES with wolfCrypt FIPS (PR 47)
+- Correct order of operations in `wc_CreatePKCS8Key()` JNI wrapper API (PR 50)
+- Add synchronization around native structure pointer use (PR 53)
+- Remove inclusion of CyaSSL header includes, switch to wolfSSL (PR 56)
+- Call `PRIVATE_KEY_LOCK/UNLOCK()` for wolfCrypt FIPS 140-3 compatibility (PR 57)
+- Improve native HMAC feature detection (PR 58)
+- Prepend zero byte to DH shared secret if less than prime length (PR 69)
+- Add synchronization to protected methods in `WolfCryptSignature` (PR 68)
+- Add synchronization to public methods of `WolfCryptKeyPairGenerator` (PR 73)
+- Only allocate one `Rng` object per `WolfCryptSignature`, not per sign operation (PR 73)
+- Reduce extra `WolfCryptRng` object creation in `Signature` and `KeyPairGenerator` (PR 73)
+
+**New Platform Support:**
+- Add Windows support with Visual Studio, see IDE/WIN/README.md (PR 46)
+
+**Build System Changes:**
+- Support custom wolfSSL library prefix and name in `makefile.linux` (PR 45)
+- Standardize JNI library name on OSX to .dylib (PR 54)
+- Update Maven build support (PR 55)
+
+**Example Changes:**
+- Print provider of `SecureRandom` from `ProviderTest.java` (PR 43)
+- Add Windows batch script to run `ProviderTest` example (PR 52)
+
+**Testing Changes:**
+- Add extended threading test for `WolfCryptRandom` class (PR 44)
+- Add Facebook Infer test script, make fixes (PR 48, 63)
+- Add GitHub Actions tests for Oracle/Zulu/Coretto/Temurin/Microsoft JDKs on Linux and OS X (PR 65)
+
+**Documentation Changes:**
+- Remove build instructions from `README.md` for FIPS historical cert #2425 (PR 56)
+- Fix Javadoc warnings for Java 21 and 22 (PR 71)
+
+The wolfCrypt JNI/JCE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
+instructions and more details comments, please check the manual.
+
+### wolfCrypt JNI Release 1.5.0 (11/14/2022)
+
+Release 1.5.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Add build compatibility for Java 7 (PR 38)
+- Add support for "SHA" algorithm string in wolfJCE (PR 39)
+- Add rpm package support (PR 40)
+- Add wolfJCE MessageDigest.clone() support (PR 41)
+- Improve error checking of native Md5 API calls (PR 41)
+- Add unit tests for com.wolfssl.wolfcrypt.Md5 (PR 41)
+
+### wolfCrypt JNI Release 1.4.0 (08/11/2022)
+
+Release 1.4.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Add example directory with one simple ProviderTest example (PR 32)
+- Fix double free of ChaCha pointer (PR 34)
+- Add test cases for ChaCha.java (PR 34)
+- Skip WolfCryptMacTest for HMAC-MD5 when using wolfCrypt FIPS 140-3 (PR 35)
+- Use new hash struct names (wc\_Md5/wc\_Sha/etc) in native code (PR 35)
+- Fix potential build error with non-ASCII apostrophes in Fips.java (PR 36)
+
+### wolfCrypt JNI Release 1.3.0 (05/13/2022)
+
+Release 1.3.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Run FIPS tests on `ant test` when linked against a wolfCrypt FIPS library (PR 24)
+- Wrap native AesGcmSetExtIV\_fips() API (PR 24)
+- Fix releaseByteArray() usage in Fips.RsaSSL\_Sign() (PR 24)
+- Fix AES-GCM FIPS test cases (PR 24)
+- Keep existing JAVA\_HOME in makefiles if already set (PR 25)
+- Add JCE support for MessageDigestSpi.engineGetDigestLength() (PR 27)
+- Update junit to 4.13.2 (PR 28)
+- Update missing Javadocs, fixes warnings on newer Java versions (PR 29)
+
+### wolfCrypt JNI Release 1.2.0 (11/16/2021)
+
+Release 1.2.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Add **FIPS 140-3** compatibility when using wolfCrypt FIPS or FIPS Ready
+- Increase junit version from 4.12 to 4.13 in pom.xml
+- Add local `./lib` directory to `java.library.path` in pom.xml
+- Fix builds with `WOLFCRYPT_JNI_DEBUG_ON` defined
+- Fix compatibility with wolfCrypt `NO_OLD_*` defines
+- Fix compatibility with wolfSSL `./configure --enable-all` and ECC tests
+
+### wolfCrypt JNI Release 1.1.0 (08/26/2020)
+
+Release 1.1.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- New JNI-level wrappers for ChaCha, Curve25519, and Ed25519
+- Maven pom.xml build file
+- Runtime detection of hash type enum values for broader wolfSSL support
+- Updated wolfSSL error codes to match native wolfSSL updates
+- Native HMAC wrapper fixes for building with wolfCrypt FIPSv2
+- Native wrapper to return `HAVE_FIPS_VERSION` value to Java
+- Remove Blake2b from HMAC types, to match native wolfSSL changes
+- Better native wolfSSL feature detection
+- Increase Junit version to 4.13
+- Use nativeheaderdir on supported platforms instead of javah
+- Use hamcrest-all-1.3.jar in build.xml
+- Add call to `wc_ecc_set_rng()` when needed
+
+### wolfCrypt JNI Release 1.0.0 (7/10/2017)
+
+Release 1.0.0 of wolfCrypt JNI has bug fixes and new features including:
+
+- Bug fixes to JCE classes: Cipher, KeyAgreement (DH), Signature
+- JCE debug logging with wolfjce.debug system property
+- Additional unit tests for JCE provider
+- Conditional ant build for JNI and/or JCE
+- New ant targets with choice of debug or release builds
+
+### wolfCrypt JNI Release 0.3 BETA
+
+Release 0.3 BETA of wolfCrypt JNI includes:
+
+- Support for ECC and DH key generation
+- Bug fixes regarding key import/export
+- Better argument sanitization at JNI level
+
+### wolfCrypt JNI Release 0.2 BETA
+
+Release 0.2 BETA of wolfCrypt JNI includes:
+
+- Support for Android
+- Support for Oracle JDK/JVM
+- Support for code signing wolfcrypt-jni.jar file
+- Compatibility with non-FIPS wolfSSL and wolfCrypt builds
+- Bug fixes regarding releasing native resources
+- Test package changed to (com.wolfssl.provider.jce.test)
+
+### wolfCrypt JNI Release 0.1 BETA
+
+Release 0.1 BETA of wolfCrypt JNI includes:
+
+- Initial JCE package
+- Support for OpenJDK
+

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -136,6 +136,7 @@ section titled `/* Configuration */`:
 
 ```
 #define WOLFSSL_KEY_GEN
+#define HAVE_CRL
 ```
 
 After editing and saving the `user_settings.h` file, select one of the following
@@ -202,6 +203,7 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 
 ```
 #define WOLFSSL_KEY_GEN
+#define HAVE_CRL
 ```
 
 6. Build the `wolfssl-fips` project, which will create a DLL in one of the
@@ -258,6 +260,7 @@ The following additional defines will also need to be added to
 
 ```
 #define WOLFSSL_KEY_GEN
+#define HAVE_CRL
 ```
 
 For additional help, contact support@wolfssl.com.

--- a/IDE/WIN/wolfcryptjni.vcxproj
+++ b/IDE/WIN/wolfcryptjni.vcxproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\jni\jni_aes.c" />
+    <ClCompile Include="..\..\jni\jni_aesgcm.c" />
     <ClCompile Include="..\..\jni\jni_asn.c" />
     <ClCompile Include="..\..\jni\jni_chacha.c" />
     <ClCompile Include="..\..\jni\jni_curve25519.c" />
@@ -80,10 +81,13 @@
     <ClCompile Include="..\..\jni\jni_logging.c" />
     <ClCompile Include="..\..\jni\jni_md5.c" />
     <ClCompile Include="..\..\jni\jni_native_struct.c" />
+    <ClCompile Include="..\..\jni\jni_pwdbased.c" />
     <ClCompile Include="..\..\jni\jni_rng.c" />
     <ClCompile Include="..\..\jni\jni_rsa.c" />
     <ClCompile Include="..\..\jni\jni_sha.c" />
+    <ClCompile Include="..\..\jni\jni_wolfcrypt.c" />
     <ClCompile Include="..\..\jni\jni_wolfobject.c" />
+    <ClCompile Include="..\..\jni\jni_wolfssl_cert_manager.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -97,52 +101,52 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug FIPS|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release FIPS|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug FIPS|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release FIPS|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/IDE/WIN/wolfcryptjni.vcxproj.filters
+++ b/IDE/WIN/wolfcryptjni.vcxproj.filters
@@ -158,5 +158,17 @@
     <ClCompile Include="..\..\jni\jni_wolfobject.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\jni\jni_aesgcm.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\jni\jni_pwdbased.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\jni\jni_wolfcrypt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\jni\jni_wolfssl_cert_manager.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ wolfSSL library must be compiled and installed.
 Compile and install a wolfSSL (wolfssl-x.x.x), wolfSSL FIPS
 release (wolfssl-x.x.x-commercial-fips), or wolfSSL FIPS Ready release:
 
-In any of these cases, you will need the `--enable-keygen` ./configure option.
+In any of these cases, you will need the `--enable-jni` ./configure option.
+The `--enable-jni` option includes all native wolfSSL features needed by
+both wolfCrypt JNI/JCE (this package) as well as wolfSSL JNI/JSSE (a
+separate package and repo). If you want the minimal set of requirements needed
+for only wolfJCE, you can use `--enable-keygen --enable-crl`, where
+CRL support is needed to support JCE `CertPathValidator(PKIX)` CRL support.
 
 **wolfSSL Standard Build**:
 ```
 $ cd wolfssl-x.x.x
-$ ./configure --enable-keygen
+$ ./configure --enable-jni
 $ make check
 $ sudo make install
 ```
@@ -34,7 +39,7 @@ $ sudo make install
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
-$ ./configure --enable-fips=v2 --enable-keygen
+$ ./configure --enable-fips=v2 --enable-jni
 $ make check
 $ sudo make install
 ```
@@ -43,7 +48,7 @@ $ sudo make install
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
-$ ./configure --enable-fips=ready --enable-keygen
+$ ./configure --enable-fips=ready --enable-jni
 $ make check
 $ sudo make install
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ on the current release):
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfcrypt-jni</artifactId>
-            <version>1.5.0-SNAPSHOT</version>
+            <version>1.6.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 
 ## wolfCrypt JCE Provider and JNI Wrapper
 
-This package provides a Java, JNI-based interface to the native wolfCrypt
-(and wolfCrypt FIPS API, if using with a FIPS version of wolfCrypt). It also
-includes a JCE provider for wolfCrypt.
+This packages includes both a JNI wrapper and JCE provider around the native
+wolfCrypt cryptography library. It supports both normal and FIPS validated
+versions of wolfCrypt.
 
-For instructions and notes on the JNI wrapper, please reference this README.md,
-or the wolfSSL online documentation.
+For instructions and notes on the **JNI wrapper**, please reference this
+README.md, or the wolfSSL online user manual.
 
-For instructions and notes on the JCE provider, please reference the
-[README_JCE.md](./README_JCE.md) file, or online instructions.
+For instructions and notes on the **JCE provider**, please reference the
+[README_JCE.md](./README_JCE.md) file, or online user manual.
 
 ### Compiling Native wolfSSL (Dependency)
 ---------
@@ -18,7 +18,7 @@ To compile the wolfCrypt JNI wrapper and JCE provider, first the native (C)
 wolfSSL library must be compiled and installed.
 
 Compile and install a wolfSSL (wolfssl-x.x.x), wolfSSL FIPS
-release (wolfssl-x.x.x-commercial-fips), or wolfSSL FIPS Ready release:
+release (wolfssl-x.x.x-commercial-fips), or wolfSSL FIPS Ready release.
 
 In any of these cases, you will need the `--enable-jni` ./configure option.
 The `--enable-jni` option includes all native wolfSSL features needed by
@@ -253,105 +253,8 @@ Signing the JAR is important especially if using the JCE Provider with a JDK
 that requires JCE provider JAR's to be authenticated.  Please see
 [README_JCE.md](./README_JCE.md) for more details.
 
-### Revision History
+### Release Notes
 ---------
 
-#### wolfCrypt JNI Release 1.5.0 (11/14/2022)
-
-Release 1.5.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- Add build compatibility for Java 7 (PR 38)
-- Add support for "SHA" algorithm string in wolfJCE (PR 39)
-- Add rpm package support (PR 40)
-- Add wolfJCE MessageDigest.clone() support (PR 41)
-- Improve error checking of native Md5 API calls (PR 41)
-- Add unit tests for com.wolfssl.wolfcrypt.Md5 (PR 41)
-
-#### wolfCrypt JNI Release 1.4.0 (08/11/2022)
-
-Release 1.4.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- Add example directory with one simple ProviderTest example (PR 32)
-- Fix double free of ChaCha pointer (PR 34)
-- Add test cases for ChaCha.java (PR 34)
-- Skip WolfCryptMacTest for HMAC-MD5 when using wolfCrypt FIPS 140-3 (PR 35)
-- Use new hash struct names (wc\_Md5/wc\_Sha/etc) in native code (PR 35)
-- Fix potential build error with non-ASCII apostrophes in Fips.java (PR 36)
-
-#### wolfCrypt JNI Release 1.3.0 (05/13/2022)
-
-Release 1.3.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- Run FIPS tests on `ant test` when linked against a wolfCrypt FIPS library (PR 24)
-- Wrap native AesGcmSetExtIV\_fips() API (PR 24)
-- Fix releaseByteArray() usage in Fips.RsaSSL\_Sign() (PR 24)
-- Fix AES-GCM FIPS test cases (PR 24)
-- Keep existing JAVA\_HOME in makefiles if already set (PR 25)
-- Add JCE support for MessageDigestSpi.engineGetDigestLength() (PR 27)
-- Update junit to 4.13.2 (PR 28)
-- Update missing Javadocs, fixes warnings on newer Java versions (PR 29)
-
-#### wolfCrypt JNI Release 1.2.0 (11/16/2021)
-
-Release 1.2.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- Add **FIPS 140-3** compatibility when using wolfCrypt FIPS or FIPS Ready
-- Increase junit version from 4.12 to 4.13 in pom.xml
-- Add local `./lib` directory to `java.library.path` in pom.xml
-- Fix builds with `WOLFCRYPT_JNI_DEBUG_ON` defined
-- Fix compatibility with wolfCrypt `NO_OLD_*` defines
-- Fix compatibility with wolfSSL `./configure --enable-all` and ECC tests
-
-#### wolfCrypt JNI Release 1.1.0 (08/26/2020)
-
-Release 1.1.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- New JNI-level wrappers for ChaCha, Curve25519, and Ed25519
-- Maven pom.xml build file
-- Runtime detection of hash type enum values for broader wolfSSL support
-- Updated wolfSSL error codes to match native wolfSSL updates
-- Native HMAC wrapper fixes for building with wolfCrypt FIPSv2
-- Native wrapper to return `HAVE_FIPS_VERSION` value to Java
-- Remove Blake2b from HMAC types, to match native wolfSSL changes
-- Better native wolfSSL feature detection
-- Increase Junit version to 4.13
-- Use nativeheaderdir on supported platforms instead of javah
-- Use hamcrest-all-1.3.jar in build.xml
-- Add call to `wc_ecc_set_rng()` when needed
-
-#### wolfCrypt JNI Release 1.0.0 (7/10/2017)
-
-Release 1.0.0 of wolfCrypt JNI has bug fixes and new features including:
-
-- Bug fixes to JCE classes: Cipher, KeyAgreement (DH), Signature
-- JCE debug logging with wolfjce.debug system property
-- Additional unit tests for JCE provider
-- Conditional ant build for JNI and/or JCE
-- New ant targets with choice of debug or release builds
-
-#### wolfCrypt JNI Release 0.3 BETA
-
-Release 0.3 BETA of wolfCrypt JNI includes:
-
-- Support for ECC and DH key generation
-- Bug fixes regarding key import/export
-- Better argument sanitization at JNI level
-
-#### wolfCrypt JNI Release 0.2 BETA
-
-Release 0.2 BETA of wolfCrypt JNI includes:
-
-- Support for Android
-- Support for Oracle JDK/JVM
-- Support for code signing wolfcrypt-jni.jar file
-- Compatibility with non-FIPS wolfSSL and wolfCrypt builds
-- Bug fixes regarding releasing native resources
-- Test package changed to (com.wolfssl.provider.jce.test)
-
-#### wolfCrypt JNI Release 0.1 BETA
-
-Release 0.1 BETA of wolfCrypt JNI includes:
-
-- Initial JCE package
-- Support for OpenJDK
+Release notes can be found in [ChangeLog.md](./ChangeLog.md).
 

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.5" />
+    <property name="implementation.version" value="1.6" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/jni/jni_feature_detect.c
+++ b/jni/jni_feature_detect.c
@@ -213,7 +213,7 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_HmacSha224En
 {
     (void)env;
     (void)jcl;
-#if !defined(NO_HMAC) && !defined(WOLFSSL_SHA224)
+#if !defined(NO_HMAC) && defined(WOLFSSL_SHA224)
     return JNI_TRUE;
 #else
     return JNI_FALSE;

--- a/jni/jni_native_struct.c
+++ b/jni/jni_native_struct.c
@@ -151,9 +151,10 @@ byte* getByteArray(JNIEnv* env, jbyteArray array)
 
 void releaseByteArray(JNIEnv* env, jbyteArray array, byte* elements, jint abort)
 {
-    if (elements)
+    if ((env != NULL) && (array != NULL) && (elements != NULL)) {
         (*env)->ReleaseByteArrayElements(env, array, (jbyte*) elements,
             abort ? JNI_ABORT : 0);
+    }
 }
 
 word32 getByteArrayLength(JNIEnv* env, jbyteArray array)

--- a/jni/jni_wolfobject.c
+++ b/jni/jni_wolfobject.c
@@ -49,7 +49,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_WolfObject_init
     }
 #endif
 
-#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 5)
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION >= 7)
+
+    ret = wc_RunAllCast_fips();
+    if (ret != 0) {
+        printf("FIPS CASTs failed to run");
+    }
+
+#elif defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION == 5)
+
     /* run FIPS 140-3 conditional algorithm self tests early to prevent
      * multi threaded issues later on */
 #if !defined(NO_AES) && !defined(NO_AES_CBC)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.5.0-SNAPSHOT</version>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
     <url>https://www.wolfssl.com</url>

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -91,9 +91,6 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
 
         this.type = type;
 
-        this.rng = new Rng();
-        this.rng.init();
-
         if (debug.DEBUG)
             algString = typeToString(type);
     }
@@ -114,6 +111,13 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
             this.publicExponent = Rsa.getDefaultRsaExponent();
         }
 
+        synchronized (rngLock) {
+            if (this.rng == null) {
+                this.rng = new Rng();
+                this.rng.init();
+            }
+        }
+
         if (debug.DEBUG)
             log("init with keysize: " + keysize);
     }
@@ -125,6 +129,13 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
         if (params == null) {
             throw new InvalidAlgorithmParameterException(
                 "AlgorithmParameterSpec must not be null");
+        }
+
+        synchronized (rngLock) {
+            if (this.rng == null) {
+                this.rng = new Rng();
+                this.rng.init();
+            }
         }
 
         switch (type) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -96,7 +96,7 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
     }
 
     @Override
-    public void initialize(int keysize, SecureRandom random) {
+    public synchronized void initialize(int keysize, SecureRandom random) {
 
         if (type == KeyType.WC_DH) {
             throw new RuntimeException(
@@ -116,8 +116,8 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
     }
 
     @Override
-    public void initialize(AlgorithmParameterSpec params,
-            SecureRandom random) throws InvalidAlgorithmParameterException {
+    public synchronized void initialize(AlgorithmParameterSpec params,
+        SecureRandom random) throws InvalidAlgorithmParameterException {
 
         if (params == null) {
             throw new InvalidAlgorithmParameterException(
@@ -206,7 +206,7 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
     }
 
     @Override
-    public KeyPair generateKeyPair() {
+    public synchronized KeyPair generateKeyPair() {
 
         KeyPair pair = null;
 
@@ -401,7 +401,7 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected void finalize() throws Throwable {
+    protected synchronized void finalize() throws Throwable {
         try {
             if (this.rng != null) {
                 rng.free();

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -34,7 +34,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.5, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.6, "wolfCrypt JCE Provider");
 
         /* MessageDigest */
         if (FeatureDetect.Md5Enabled()) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -181,41 +181,43 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfCryptPKIXCertPathValidator");
 
         /* SecretKeyFactory */
-        if (FeatureDetect.HmacShaEnabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA1",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA1");
-        }
-        if (FeatureDetect.HmacSha224Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA224",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA224");
-        }
-        if (FeatureDetect.HmacSha256Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA256",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA256");
-        }
-        if (FeatureDetect.HmacSha384Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA384",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA384");
-        }
-        if (FeatureDetect.HmacSha512Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA512",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA512");
-        }
-        if (FeatureDetect.HmacSha3_224Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA3-224",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_224");
-        }
-        if (FeatureDetect.HmacSha3_256Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA3-256",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_256");
-        }
-        if (FeatureDetect.HmacSha3_384Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA3-384",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_384");
-        }
-        if (FeatureDetect.HmacSha3_512Enabled()) {
-            put("SecretKeyFactory.PBKDF2WithHmacSHA3-512",
-                "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_512");
+        if (FeatureDetect.Pbkdf2Enabled()) {
+            if (FeatureDetect.HmacShaEnabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA1",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA1");
+            }
+            if (FeatureDetect.HmacSha224Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA224",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA224");
+            }
+            if (FeatureDetect.HmacSha256Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA256",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA256");
+            }
+            if (FeatureDetect.HmacSha384Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA384",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA384");
+            }
+            if (FeatureDetect.HmacSha512Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA512",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA512");
+            }
+            if (FeatureDetect.HmacSha3_224Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA3-224",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_224");
+            }
+            if (FeatureDetect.HmacSha3_256Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA3-256",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_256");
+            }
+            if (FeatureDetect.HmacSha3_384Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA3-384",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_384");
+            }
+            if (FeatureDetect.HmacSha3_512Enabled()) {
+                put("SecretKeyFactory.PBKDF2WithHmacSHA3-512",
+                    "com.wolfssl.provider.jce.WolfCryptSecretKeyFactory$wcPBKDF2WithHmacSHA3_512");
+            }
         }
 
         /* If using a FIPS version of wolfCrypt, allow private key to be

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -617,7 +617,7 @@ public class WolfCryptSignature extends SignatureSpi {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected void finalize() throws Throwable {
+    protected synchronized void finalize() throws Throwable {
         try {
             /* free native digest objects */
             if (this.md5 != null)

--- a/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
@@ -500,7 +500,9 @@ public class Ecc extends NativeStruct {
         synchronized (stateLock) {
             if (state == WolfCryptState.READY) {
                 synchronized (pointerLock) {
-                    signature = wc_ecc_sign_hash(hash, rng);
+                    synchronized (rngLock) {
+                        signature = wc_ecc_sign_hash(hash, rng);
+                    }
                 }
             } else {
                 throw new IllegalStateException(

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import javax.crypto.KeyAgreement;

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -29,10 +29,12 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.ShortBufferException;
@@ -537,8 +539,17 @@ public class WolfCryptKeyAgreementTest {
         int numThreads = 10;
         ExecutorService service = Executors.newFixedThreadPool(numThreads);
         final CountDownLatch latch = new CountDownLatch(numThreads);
-        final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
         final String currentAlgo = algo;
+
+        /* Used to detect timeout of CountDownLatch, don't run indefinitely
+         * if threads are stalled out or deadlocked */
+        boolean returnWithoutTimeout = true;
+
+        /* Keep track of failure and success count */
+        final AtomicIntegerArray failures = new AtomicIntegerArray(1);
+        final AtomicIntegerArray success = new AtomicIntegerArray(1);
+        failures.set(0, 0);
+        success.set(0, 0);
 
         /* DH Tests */
         AlgorithmParameterGenerator paramGen =
@@ -552,7 +563,6 @@ public class WolfCryptKeyAgreementTest {
             service.submit(new Runnable() {
                 @Override public void run() {
 
-                    int failed = 0;
                     KeyPairGenerator keyGen = null;
                     KeyAgreement aKeyAgree = null;
                     KeyAgreement bKeyAgree = null;
@@ -603,53 +613,56 @@ public class WolfCryptKeyAgreementTest {
                         byte secretB[] = bKeyAgree.generateSecret();
 
                         if (!Arrays.equals(secretA, secretB)) {
-                            failed = 1;
+                            throw new Exception(
+                                "Secrets A and B to not match");
                         }
 
-                        if (failed == 0) {
-                            cKeyAgree = KeyAgreement.getInstance(
-                                currentAlgo, "wolfJCE");
-                            cPair = keyGen.generateKeyPair();
-                            cKeyAgree.init(cPair.getPrivate());
+                        cKeyAgree = KeyAgreement.getInstance(
+                            currentAlgo, "wolfJCE");
+                        cPair = keyGen.generateKeyPair();
+                        cKeyAgree.init(cPair.getPrivate());
 
-                            aKeyAgree.doPhase(cPair.getPublic(), true);
-                            cKeyAgree.doPhase(aPair.getPublic(), true);
+                        aKeyAgree.doPhase(cPair.getPublic(), true);
+                        cKeyAgree.doPhase(aPair.getPublic(), true);
 
-                            byte secretA2[] = aKeyAgree.generateSecret();
-                            byte secretC[]  = cKeyAgree.generateSecret();
+                        byte secretA2[] = aKeyAgree.generateSecret();
+                        byte secretC[]  = cKeyAgree.generateSecret();
 
-                            if (!Arrays.equals(secretA2, secretC)) {
-                                failed = 1;
-                            }
+                        if (!Arrays.equals(secretA2, secretC)) {
+                            throw new Exception(
+                                "Secrets A2 and C do not match");
                         }
+
+                        /* Log success */
+                        success.incrementAndGet(0);
 
                     } catch (Exception e) {
                         e.printStackTrace();
-                        failed = 1;
+
+                        /* Log failure */
+                        failures.incrementAndGet(0);
 
                     } finally {
                         latch.countDown();
-                    }
-
-                    if (failed == 1) {
-                        results.add(1);
-                    }
-                    else {
-                        results.add(0);
                     }
                 }
             });
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        returnWithoutTimeout = latch.await(10, TimeUnit.SECONDS);
+        service.shutdown();
 
-        /* Look for any failures that happened */
-        Iterator<Integer> listIterator = results.iterator();
-        while (listIterator.hasNext()) {
-            Integer cur = listIterator.next();
-            if (cur == 1) {
-                fail("Threading error in KeyAgreement thread test");
+        /* Check failure count and success count against thread count */
+        if ((failures.get(0) != 0) ||
+            (success.get(0) != numThreads)) {
+            if (returnWithoutTimeout == true) {
+                fail("KeyAgreement test threading error: " +
+                    failures.get(0) + " failures, " +
+                    success.get(0) + " success, " +
+                    numThreads + " num threads total");
+            } else {
+                fail("KeyAgreement test threading error, threads timed out");
             }
         }
     }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
@@ -63,6 +63,7 @@ import java.security.cert.CertStore;
 import java.security.cert.CollectionCertStoreParameters;
 import java.lang.IllegalArgumentException;
 
+import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 
 public class WolfCryptPKIXCertPathValidatorTest {
@@ -387,6 +388,13 @@ public class WolfCryptPKIXCertPathValidatorTest {
         CertStore crlStore = null;
         Collection<CRL> crls = null;
         List<CertStore> certStores = null;
+
+        if (!WolfCrypt.CrlEnabled()) {
+            /* Native CRL not enabled, skip CRL test */
+            System.out.println("CertPathValidator CRL test skipped, " +
+                "CRL not compiled in");
+            return;
+        }
 
         /* Use example KeyStore that verifies server-cert.der */
         store = createKeyStoreFromFile(jksCaServerRSA2048, keyStorePass);

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -71,9 +71,14 @@ public class RsaTest {
     @Test
     public void testMakeKey() {
 
-        Rsa key = new Rsa();
-        key.makeKey(1024, 65537, rng);
-        key.releaseNativeStruct();
+        Rsa key = null;
+
+        /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
+        if (Fips.enabled && Fips.fipsVersion < 5) {
+            key = new Rsa();
+            key.makeKey(1024, 65537, rng);
+            key.releaseNativeStruct();
+        }
 
         key = new Rsa();
         key.makeKey(2048, 65537, rng);
@@ -218,6 +223,12 @@ public class RsaTest {
               + "37e32da3750d1e4d2134d557705c89bf72ec4a6e68d5cd187433"
               + "4e8c3a458fe69640eb63f919863a51dd894bb0f3f99f5d289538"
               + "be35abca5ce7935334a1455d1339654246a19fcdf5bf");
+
+        /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
+        if (Fips.enabled && Fips.fipsVersion >= 5) {
+            /* skip */
+            return;
+        }
 
         /* Test that exception is thrown without private key available */
         try {


### PR DESCRIPTION
This PR preps for the 1.6 release, and includes the following changes:
- Moves ChangeLog from `README.md` to `ChangeLog.md`, updates with 1.6 notes
- Bumps library version to 1.6 in `build.xml`, `pom.xml`, and `WolfCryptProvider.java`
- Updates Windows Visual Studio project file
- Fixes native JNI feature detection for HMAC-SHA224
- Adds native feature check for `PBKDF2` in `WolfCryptProvider.java` before broadcasting support for `SecretKeyFactory`
- Fixes Facebook Infer warnings about thread safety in `WolfCryptSignature` class
- Make RNG used in Signature class a class variable, so it is only initialized once instead of each sign() operation
- Refactor `Signature` threaded test to use AtomicIntegerArray
- Only runs `CertPathValidator(PKIX)` CRL test if native CRL has been compiled in
- Adjusts build instructions to recommend using `./configure --enable-jni` for Java build consistency across JNI/JCE/JSSE
- Add synchronization to public methods of `WolfCryptKeyPairGenerator`
- Correctly return `JNI_TRUE/JNI_FALSE` from `wc_ecc_verify_hash()` wrapper
- Reduce extra WolfCryptRng object creations from Signature and KeyPairGenerator classes
- Call `wc_RunAllCast_fips()` when used with FIPS 140-3 pilot submission code