### PR TITLE
JCE: KeyPairGenerator: remove use of longValueExact()

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -150,10 +150,13 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                 RSAKeyGenParameterSpec rsaSpec = (RSAKeyGenParameterSpec)params;
                 this.keysize = rsaSpec.getKeysize();
 
-                try {
-                    this.publicExponent =
-                        rsaSpec.getPublicExponent().longValueExact();
-                } catch (ArithmeticException e) {
+                this.publicExponent =
+                    rsaSpec.getPublicExponent().longValue();
+
+                /* Double check longValue() converted correctly. Some platforms
+                 * do not have longValueExact() */
+                if (!BigInteger.valueOf(this.publicExponent).equals(
+                        rsaSpec.getPublicExponent())) {
                     throw new InvalidAlgorithmParameterException(
                         "RSA public exponent value larger than long");
                 }


### PR DESCRIPTION
This PR removes a call to `BigInteger.longValueExact()` since it's not available on some Java variants/versions.  For example this API is not available in Android API versions less than 31.