### PR TITLE
JNI/JSSE: detect RSA_MIN_SIZE in tests, add Rsa.RSA_MIN_SIZE helper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,25 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # ------------------ RSA 1024 min size sanity check -------------------
+  # Only check one Linux and Mac JDK version as a sanity check. Using Zulu,
+  # but this can be expanded if needed.
+  # wolfSSL ./configure:
+  #     --enable-jni CFLAGS="-DRSA_MIN_SIZE=1024
+  linux-zulu-rsa-min-size:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [ '--enable-jni CFLAGS="-DRSA_MIN_SIZE=1024"' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
   # ------------------ Facebook Infer static analysis -------------------
   # Run Facebook infer over PR code, only running on Linux with one
   # JDK/version for now.

--- a/jni/include/com_wolfssl_wolfcrypt_Rsa.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Rsa.h
@@ -171,6 +171,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSSL_1Verify
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Rsa
+ * Method:    rsaMinSize
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Rsa_rsaMinSize
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Rsa
  * Method:    getDefaultRsaExponent
  * Signature: ()J
  */

--- a/jni/jni_rsa.c
+++ b/jni/jni_rsa.c
@@ -81,6 +81,15 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Rsa_getDefaultRsaExponent
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Rsa_rsaMinSize
+  (JNIEnv *env, jclass jcl)
+{
+    (void)env;
+    (void)jcl;
+
+    return (jint)RSA_MIN_SIZE;
+}
+
 JNIEXPORT void JNICALL
 Java_com_wolfssl_wolfcrypt_Rsa_MakeRsaKey(
     JNIEnv *env, jobject this, jint size, jlong e, jobject rng_object)

--- a/src/main/java/com/wolfssl/wolfcrypt/Rsa.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Rsa.java
@@ -32,6 +32,8 @@ public class Rsa extends NativeStruct {
     private boolean hasPrivateKey = false;
     private Rng rng;
 
+    public static final int RSA_MIN_SIZE = Rsa.rsaMinSize();
+
     /** Lock around object state */
     protected final Object stateLock = new Object();
 
@@ -92,6 +94,7 @@ public class Rsa extends NativeStruct {
             throws WolfCryptException;
     private native byte[] wc_RsaSSL_Verify(byte[] data)
             throws WolfCryptException;
+    private static native int rsaMinSize();
 
     /**
      * Create new Rsa object

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -115,7 +115,8 @@ public class WolfCryptKeyPairGeneratorTest {
         new ArrayList<Integer>();
 
     /* Test generation of these RSA key sizes */
-    private static int testedRSAKeySizes[] = null;
+    private static ArrayList<Integer> testedRSAKeySizes =
+        new ArrayList<Integer>();
 
     /* DH test params */
     private static byte[] prime = Util.h2b(
@@ -149,16 +150,19 @@ public class WolfCryptKeyPairGeneratorTest {
         Provider p = Security.getProvider("wolfJCE");
         assertNotNull(p);
 
-        if (Fips.enabled && Fips.fipsVersion >= 5) {
-            /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
-            testedRSAKeySizes = new int[] {
-                2048, 3072, 4096
-            };
+        /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
+        if ((!Fips.enabled || Fips.fipsVersion < 5) &&
+            (Rsa.RSA_MIN_SIZE <= 1024)) {
+            testedRSAKeySizes.add(Integer.valueOf(1024));
         }
-        else {
-            testedRSAKeySizes = new int[] {
-                1024, 2048, 3072, 4096
-            };
+        if (Rsa.RSA_MIN_SIZE <= 2048) {
+            testedRSAKeySizes.add(Integer.valueOf(2048));
+        }
+        if (Rsa.RSA_MIN_SIZE <= 3072) {
+            testedRSAKeySizes.add(Integer.valueOf(3072));
+        }
+        if (Rsa.RSA_MIN_SIZE <= 4096) {
+            testedRSAKeySizes.add(Integer.valueOf(4096));
         }
 
         /* build list of enabled curves and key sizes,
@@ -211,13 +215,13 @@ public class WolfCryptKeyPairGeneratorTest {
                InvalidAlgorithmParameterException {
 
         /* try initializing KPG for all tested key sizes */
-        for (int i = 0; i < testedRSAKeySizes.length; i++) {
+        for (int i = 0; i < testedRSAKeySizes.size(); i++) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
             RSAKeyGenParameterSpec rsaSpec =
-                new RSAKeyGenParameterSpec(testedRSAKeySizes[i],
+                new RSAKeyGenParameterSpec(testedRSAKeySizes.get(i),
                         BigInteger.valueOf(Rsa.getDefaultRsaExponent()));
             kpg.initialize(rsaSpec);
 
@@ -236,12 +240,12 @@ public class WolfCryptKeyPairGeneratorTest {
                InvalidAlgorithmParameterException {
 
         /* try initializing KPG for all tested key sizes */
-        for (int i = 0; i < testedRSAKeySizes.length; i++) {
+        for (int i = 0; i < testedRSAKeySizes.size(); i++) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
-            kpg.initialize(testedRSAKeySizes[i]);
+            kpg.initialize(testedRSAKeySizes.get(i));
 
             /* bad key size should fail */
             try {
@@ -256,13 +260,13 @@ public class WolfCryptKeyPairGeneratorTest {
                InvalidAlgorithmParameterException {
 
         /* try generating keys for all tested sizes */
-        for (int i = 0; i < testedRSAKeySizes.length; i++) {
+        for (int i = 0; i < testedRSAKeySizes.size(); i++) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
             RSAKeyGenParameterSpec rsaSpec =
-                new RSAKeyGenParameterSpec(testedRSAKeySizes[i],
+                new RSAKeyGenParameterSpec(testedRSAKeySizes.get(i),
                         BigInteger.valueOf(Rsa.getDefaultRsaExponent()));
             kpg.initialize(rsaSpec);
 
@@ -275,13 +279,13 @@ public class WolfCryptKeyPairGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
 
-        if (testedRSAKeySizes.length > 0) {
+        if (testedRSAKeySizes.size() > 0) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
             RSAKeyGenParameterSpec rsaSpec =
-                new RSAKeyGenParameterSpec(testedRSAKeySizes[0],
+                new RSAKeyGenParameterSpec(testedRSAKeySizes.get(0),
                         BigInteger.valueOf(Rsa.getDefaultRsaExponent()));
 
             kpg.initialize(rsaSpec);
@@ -294,13 +298,13 @@ public class WolfCryptKeyPairGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
 
-        if (testedRSAKeySizes.length > 0) {
+        if (testedRSAKeySizes.size() > 0) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
             RSAKeyGenParameterSpec rsaSpec =
-                new RSAKeyGenParameterSpec(testedRSAKeySizes[0],
+                new RSAKeyGenParameterSpec(testedRSAKeySizes.get(0),
                         BigInteger.valueOf(Rsa.getDefaultRsaExponent()));
             kpg.initialize(rsaSpec);
 
@@ -314,13 +318,13 @@ public class WolfCryptKeyPairGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException, InvalidKeySpecException {
 
-        if (testedRSAKeySizes.length > 0) {
+        if (testedRSAKeySizes.size() > 0) {
 
             KeyPairGenerator kpg =
                 KeyPairGenerator.getInstance("RSA", "wolfJCE");
 
             RSAKeyGenParameterSpec rsaSpec =
-                new RSAKeyGenParameterSpec(testedRSAKeySizes[0],
+                new RSAKeyGenParameterSpec(testedRSAKeySizes.get(0),
                         BigInteger.valueOf(Rsa.getDefaultRsaExponent()));
             kpg.initialize(rsaSpec);
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -81,12 +81,20 @@ public class RsaTest {
     }
 
     @Test
+    public void testGetMinRsaSize() {
+
+        int minRsaSize = Rsa.RSA_MIN_SIZE;
+        assertTrue(minRsaSize > 0);
+    }
+
+    @Test
     public void testMakeKey() {
 
         Rsa key = null;
 
         /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
-        if (Fips.enabled && Fips.fipsVersion < 5) {
+        if ((Fips.enabled && Fips.fipsVersion < 5) ||
+            (!Fips.enabled && Rsa.RSA_MIN_SIZE <= 1024)) {
             key = new Rsa();
             key.makeKey(1024, 65537, rng);
             key.releaseNativeStruct();
@@ -237,7 +245,8 @@ public class RsaTest {
               + "be35abca5ce7935334a1455d1339654246a19fcdf5bf");
 
         /* FIPS after 2425 doesn't allow 1024-bit RSA key gen */
-        if (Fips.enabled && Fips.fipsVersion >= 5) {
+        if ((Fips.enabled && Fips.fipsVersion >= 5) ||
+            (Rsa.RSA_MIN_SIZE > 1024)) {
             /* skip */
             return;
         }


### PR DESCRIPTION
This PR detects the native `RSA_MIN_SIZE` value for use in JUnit tests. It also adds a static helper variable to `com.wolfssl.wolfcrypt.Rsa` called `RSA_MIN_SIZE` to easily use that value from Java.

This should fix failing Jenkins test: `nightly-wolfcrypt-jni-ant-test-v2`, which started failing after https://github.com/wolfSSL/wolfssl/pull/7923 was merged.