### PR TITLE
Set keytool path correctly in system-cacerts-to-wks.sh

### DIFF
--- a/examples/certs/systemcerts/system-cacerts-to-wks.sh
+++ b/examples/certs/systemcerts/system-cacerts-to-wks.sh
@@ -29,9 +29,9 @@ export DYLD_LIBRARY_PATH=../../../lib:$DYLD_LIBRARY_PATH
 
 OUTDIR=`pwd`
 
-# ARGS: <input-keystore-name> <output-keystore-name> <in-password> <out-password>
+# ARGS: <input-keystore-name> <output-keystore-name> <in-password> <out-password> <java home>
 jks_to_wks() {
-    keytool -importkeystore -srckeystore ${1} -destkeystore ${2}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "$3" -deststorepass "$3" -deststorepass "$4" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath ../../../lib/wolfcrypt-jni.jar &> /dev/null
+    ${5}/bin/keytool -importkeystore -srckeystore ${1} -destkeystore ${2}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "$3" -deststorepass "$3" -deststorepass "$4" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath ../../../lib/wolfcrypt-jni.jar &> /dev/null
     if [ $? -ne 0 ]; then
         printf "Failed to convert JKS to WKS!"
         exit 1
@@ -98,7 +98,7 @@ if [ -f "$javaHome/$CACERTS_JDK9" ]; then
     if [ -f $OUTDIR/cacerts.wks ]; then
         rm $OUTDIR/cacerts.wks
     fi
-    jks_to_wks "$javaHome/$CACERTS_JDK9" "$OUTDIR/cacerts" "changeit" "changeitchangeit"
+    jks_to_wks "$javaHome/$CACERTS_JDK9" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
 fi
 
 if [ -f "$javaHome/$CACERTS_JDK8" ]; then
@@ -110,7 +110,7 @@ if [ -f "$javaHome/$CACERTS_JDK8" ]; then
     if [ -f $OUTDIR/cacerts.wks ]; then
         rm $OUTDIR/cacerts.wks
     fi
-    jks_to_wks "$javaHome/$CACERTS_JDK8" "$OUTDIR/cacerts" "changeit" "changeitchangeit"
+    jks_to_wks "$javaHome/$CACERTS_JDK8" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
 fi
 
 if [ -f "$javaHome/$JSSECERTS_JDK9" ]; then
@@ -122,7 +122,7 @@ if [ -f "$javaHome/$JSSECERTS_JDK9" ]; then
     if [ -f $OUTDIR/jssecacerts.wks ]; then
         rm $OUTDIR/jssecacerts.wks
     fi
-    jks_to_wks "$javaHome/$JSSECACERTS_JDK9" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit"
+    jks_to_wks "$javaHome/$JSSECACERTS_JDK9" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
 fi
 
 if [ -f "$javaHome/$JSSECERTS_JDK8" ]; then
@@ -134,7 +134,7 @@ if [ -f "$javaHome/$JSSECERTS_JDK8" ]; then
     if [ -f $OUTDIR/jssecacerts.wks ]; then
         rm $OUTDIR/jssecacerts.wks
     fi
-    jks_to_wks "$javaHome/$JSSECACERTS_JDK8" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit"
+    jks_to_wks "$javaHome/$JSSECACERTS_JDK8" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
 fi
 
 echo ""


### PR DESCRIPTION
This PR sets the path to the Java `keytool` command correctly based on the detected `JAVA_HOME` location.

This should fix the following failing nightly Jenkins test: `nightly-wolfcrypt-jni-ant-test-v2`