### PR TITLE
JNI/JCE: fix pointer use in JNI X509CheckPrivateKey()

### DIFF
--- a/jni/jni_jce_wolfsslkeystore.c
+++ b/jni/jni_jce_wolfsslkeystore.c
@@ -42,6 +42,7 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
     int keyDerSz = 0;
     byte* certDer = NULL;
     byte* keyDer = NULL;
+    byte* pkcs8KeyDer = NULL;
     WOLFSSL_X509* x509 = NULL;
     WOLFSSL_EVP_PKEY* key = NULL;
     WOLFSSL_PKCS8_PRIV_KEY_INFO* keyInfo = NULL;
@@ -58,6 +59,9 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
 
     keyDer = (byte*)(*env)->GetByteArrayElements(env, pkcs8KeyDerArr, NULL);
     keyDerSz = (*env)->GetArrayLength(env, pkcs8KeyDerArr);
+    /* Keep original keyDer pointer for free later, wolfSSL_d2i_PKCS8_PKEY
+     * will change/advance the pointer. */
+    pkcs8KeyDer = keyDer;
 
     if (certDer == NULL || certDerSz <= 0 || keyDer == NULL || keyDerSz <= 0) {
         fprintf(stderr, "Native X509CheckPrivateKey() bad args");
@@ -75,7 +79,8 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        keyInfo = wolfSSL_d2i_PKCS8_PKEY(NULL, (const byte**)&keyDer, keyDerSz);
+        keyInfo = wolfSSL_d2i_PKCS8_PKEY(NULL, (const byte**)&pkcs8KeyDer,
+                                         keyDerSz);
         if (keyInfo == NULL) {
             fprintf(stderr, "Native wolfSSL_d2i_PKCS8_PKEY() failed");
             ret = WOLFSSL_FAILURE;


### PR DESCRIPTION
This PR fixes the native JNI `X509CheckPrivateKey()` function to operate on a copy of the pointer to `pkcs8KeyDerArr`. 

Recent changes in native wolfSSL as of https://github.com/wolfSSL/wolfssl/commit/901384e704#diff-34d62efe7620eac9235c878aafc6716d1ef20a2246a35fac977f34bacce0481cR7315 caused the wolfSSL API `wolfSSL_d2i_PKCS8_PKEY()` to advance the input key buffer pointer.

Since the pointer can now be advanced, that can cause a crash in JNI when calling `ReleaseByteArrayElements()` on that pointer.

Fixes https://cloud.wolfssl-test.com/jenkins/job/wolfSSL/job/nightly-FIPSv2-wolfcrypt-jni-ant-test-v2