### PR TITLE
Prep for 1.7 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,27 @@
+### wolfCrypt JNI Release 1.7.0 (11/11/2024)
+
+Release 1.7.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
+
+**New JCE Functionality:**
+- New WolfSSLKeyStore (WKS) KeyStore implementation for FIPS 140-2/3 compliance (PR 67)
+
+**JNI and JCE Changes:**
+- Remove call to BigInteger.longValueExact(), not available on some Java versions (PR 76)
+- Detect `RSA_MIN_SIZE` in tests, add `Rsa.RSA_MIN_SIZE` helper (PR 77)
+- Fix pointer use in native `X509CheckPrivateKey()` (PR 80)
+
+**Example Changes:**
+- Set keytool path correctly in `system-cacerts-to-wks.sh` (PR 78)
+- Add example Android Studio project (IDE/Android) (PR 79)
+
+**Testing Changes:**
+- Run Facebook Infer on pull requests with GitHub Actions (PR 74)
+- Add Android Gradle build with GitHub Actions to run on all pull requests (PR 79)
+
+The wolfCrypt JNI/JCE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
+instructions and more details comments, please check the manual.
+
 ### wolfCrypt JNI Release 1.6.0 (4/17/2024)
 
 Release 1.6.0 of wolfCrypt JNI and JCE has bug fixes and new features including:

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -137,7 +137,11 @@ section titled `/* Configuration */`:
 ```
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
+#define OPENSSL_ALL
 ```
+
+If also building wolfSSL JNI/JSSE, additional defines may be needed. Please
+reference the Windows build documentation for wolfSSL JNI/JSSE if so.
 
 After editing and saving the `user_settings.h` file, select one of the following
 DLL Library configurations and build the wolfSSL library solution:
@@ -204,7 +208,11 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 ```
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
+#define OPENSSL_ALL
 ```
+
+If also building wolfSSL JNI/JSSE, additional defines may be needed. Please
+reference the Windows build documentation for wolfSSL JNI/JSSE if so.
 
 6. Build the `wolfssl-fips` project, which will create a DLL in one of the
 following locations:
@@ -230,19 +238,20 @@ in the wolfCrypt tests successfully running.
 See the FIPS User Guide for more details on the FIPS verifyCore hash, or
 email support@wolfssl.com.
 
-## wolfSSL FIPS 140-3 (Upcoming)
+## wolfSSL FIPS 140-3 (Certificate #4718)
 
-To build a version of wolfSSL that has been submitted for FIPS 140-3, use
-the Visual Studio solution file under the `IDE\WIN10` directory inside the
-wolfSSL package:
+To build a wolfSSL FIPS 140-3 variant for use with FIPS 140-3 certificate
+#4718, use the Visual Studio solution file located in the `IDE/WIN10`
+directory inside the wolfSSL package:
 
 ```
 <wolfssl>\IDE\WIN10\wolfssl-fips.sln
 ```
 
 Follow instructions in the above section for 140-2 / 3389, except use the
-following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
-`HAVE_FIPS_VERSION_MINOR` in `user_settings.h`:
+following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`,
+`HAVE_FIPS_VERSION_MAJOR`, `HAVE_FIPS_VERSION_MINOR`, and
+`HAVE_FIPS_VERSION_PATCH` in `user_settings.h`:
 
 ```
 #if 1
@@ -250,8 +259,12 @@ following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define HAVE_FIPS
 #undef HAVE_FIPS_VERSION
 #define HAVE_FIPS_VERSION 5
+#undef HAVE_FIPS_VERSION_MAJOR
+#define HAVE_FIPS_VERSION_MAJOR 5
 #undef HAVE_FIPS_VERSION_MINOR
-#define HAVE_FIPS_VERSION_MINOR 1
+#define HAVE_FIPS_VERSION_MINOR 2
+#undef HAVE_FIPS_VERSION_PATCH
+#define HAVE_FIPS_VERSION_PATCH 0
 #endif
 ```
 
@@ -261,7 +274,11 @@ The following additional defines will also need to be added to
 ```
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
+#define OPENSSL_ALL
 ```
+
+If also building wolfSSL JNI/JSSE, additional defines may be needed. Please
+reference the Windows build documentation for wolfSSL JNI/JSSE if so.
 
 For additional help, contact support@wolfssl.com.
 

--- a/IDE/WIN/wolfcryptjni.vcxproj
+++ b/IDE/WIN/wolfcryptjni.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\jni\jni_feature_detect.c" />
     <ClCompile Include="..\..\jni\jni_fips.c" />
     <ClCompile Include="..\..\jni\jni_hmac.c" />
+    <ClCompile Include="..\..\jni\jni_jce_wolfsslkeystore.c" />
     <ClCompile Include="..\..\jni\jni_logging.c" />
     <ClCompile Include="..\..\jni\jni_md5.c" />
     <ClCompile Include="..\..\jni\jni_native_struct.c" />

--- a/IDE/WIN/wolfcryptjni.vcxproj.filters
+++ b/IDE/WIN/wolfcryptjni.vcxproj.filters
@@ -170,5 +170,8 @@
     <ClCompile Include="..\..\jni\jni_wolfssl_cert_manager.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\jni\jni_jce_wolfsslkeystore.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ on the current release):
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfcrypt-jni</artifactId>
-            <version>1.6.0-SNAPSHOT</version>
+            <version>1.7.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.6" />
+    <property name="implementation.version" value="1.7" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/examples/WindowsConfig.bat
+++ b/examples/WindowsConfig.bat
@@ -9,7 +9,7 @@
 :: included by other example .bat files.
 
 :: wolfSSL Normal non-FIPS (DLL Debug x64)
-SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\IDE\WIN10\DLL Debug\x64
+SET WOLFSSL_DLL_DIR=..\..\..\wolfssl\DLL Debug\x64
 SET WOLFCRYPTJNI_DLL_DIR=..\..\IDE\WIN\DLL Debug\x64
 
 :: wolfSSL Normal non-FIPS (DLL Release x64)

--- a/examples/certs/systemcerts/system-cacerts-to-wks.sh
+++ b/examples/certs/systemcerts/system-cacerts-to-wks.sh
@@ -29,9 +29,19 @@ export DYLD_LIBRARY_PATH=../../../lib:$DYLD_LIBRARY_PATH
 
 OUTDIR=`pwd`
 
+# First argument can be passed in to represent path to
+# wolfcrypt-jni.jar provider JAR. If not given, use default.
+if [ -z "$1" ]; then
+    # default wolfcrypt-jni.jar path
+    PROVIDER_PATH="../../../lib/wolfcrypt-jni.jar"
+else
+    # use custom provider path
+    PROVIDER_PATH=$1
+fi
+
 # ARGS: <input-keystore-name> <output-keystore-name> <in-password> <out-password> <java home>
 jks_to_wks() {
-    ${5}/bin/keytool -importkeystore -srckeystore ${1} -destkeystore ${2}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "$3" -deststorepass "$3" -deststorepass "$4" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath ../../../lib/wolfcrypt-jni.jar &> /dev/null
+    ${5}/bin/keytool -importkeystore -srckeystore ${1} -destkeystore ${2}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "$3" -deststorepass "$3" -deststorepass "$4" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath "$PROVIDER_PATH"
     if [ $? -ne 0 ]; then
         printf "Failed to convert JKS to WKS!"
         exit 1
@@ -57,6 +67,8 @@ else
     echo "JAVA_HOME already set = $JAVA_HOME"
     javaHome="$JAVA_HOME"
 fi
+
+echo "PROVIDER_PATH: $PROVIDER_PATH"
 
 # Set up Java include and library paths for OS X and Linux
 # NOTE: you may need to modify these if your platform uses different locations

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -338,7 +338,9 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1export_1private(
     }
 
     if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_private_only(ecc, output, &outputSz);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret == 0) {
@@ -1054,7 +1056,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1private_1ke
     }
 
     if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_EccPrivateKeyToDer(ecc, derKey, derKeySz);
+        PRIVATE_KEY_LOCK();
         if (ret >= 0) {
             derKeySz = ret;
             ret = 0;

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -218,7 +218,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesSetKey_1fips__Lcom_wol
     if (!aes || !key)
         return BAD_FUNC_ARG;
 
+#if FIPS_VERSION_GT(5,0)
+    ret = wc_AesSetKey_fips(aes, key, (word32)size, iv, dir);
+#else
     ret = AesSetKey_fips(aes, key, (word32)size, iv, dir);
+#endif
 
     LogStr("AesSetKey_fips(aes=%p, key, iv, %s) = %d\n", aes,
         dir ? "dec" : "enc", ret);
@@ -253,8 +257,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesSetKey_1fips__Lcom_wol
     key = getByteArray(env, key_buffer);
     iv  = getByteArray(env, iv_buffer);
 
-    ret = (!aes || !key) ? BAD_FUNC_ARG
-                         : AesSetKey_fips(aes, key, (word32)size, iv, dir);
+    if (aes == NULL || key == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesSetKey_fips(aes, key, (word32)size, iv, dir);
+    #else
+        ret = AesSetKey_fips(aes, key, (word32)size, iv, dir);
+    #endif
+    }
 
     LogStr("AesSetKey_fips(aes=%p, key, iv, %s) = %d\n", aes,
         dir ? "dec" : "enc", ret);
@@ -294,7 +306,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmSetExtIV_1fips__Lco
         return BAD_FUNC_ARG;
     }
 
-    ret = AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #else
+        ret = AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #endif
 
     LogStr("AesGcmSetExtIV_fips(aes=%p, iv) = %d\n", aes, ret);
     LogStr("iv[%u]: [%p]\n", (word32)size, iv);
@@ -328,7 +344,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmSetExtIV_1fips__Lco
         return BAD_FUNC_ARG;
     }
 
-    ret = AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #else
+        ret = AesGcmSetExtIV_fips(aes, iv, (word32)size);
+    #endif
 
     LogStr("AesGcmSetExtIV_fips(aes=%p, iv) = %d\n", aes, ret);
     LogStr("iv[%u]: [%p]\n", (word32)size, iv);
@@ -362,7 +382,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesSetIV_1fips__Lcom_wolf
     if (!aes || !iv)
         return BAD_FUNC_ARG;
 
-    ret = AesSetIV_fips(aes, iv);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesSetIV_fips(aes, iv);
+    #else
+        ret = AesSetIV_fips(aes, iv);
+    #endif
 
     LogStr("AesSetIV_fips(aes=%p, iv) = %d\n", aes, ret);
     LogStr("iv[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, iv);
@@ -391,8 +415,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesSetIV_1fips__Lcom_wolf
 
     iv = getByteArray(env, iv_buffer);
 
-    ret = (!aes || !iv) ? BAD_FUNC_ARG
-                        : AesSetIV_fips(aes, iv);
+    if (aes == NULL || iv == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesSetIV_fips(aes, iv);
+    #else
+        ret = AesSetIV_fips(aes, iv);
+    #endif
+    }
 
     LogStr("AesSetIV_fips(aes=%p, iv) = %d\n", aes, ret);
     LogStr("iv[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, iv);
@@ -429,7 +461,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesCbcEncrypt_1fips__Lcom
     if (!aes || !out || !in)
         return BAD_FUNC_ARG;
 
-    ret = AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    #else
+        ret = AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    #endif
 
     LogStr("AesCbcEncrypt_fips(aes=%p, out, in) = %d\n", aes, ret);
     LogStr("in[%u]: [%p]\n", (word32)size, in);
@@ -463,9 +499,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesCbcEncrypt_1fips__Lcom
     out = getByteArray(env, out_buffer);
     in  = getByteArray(env, in_buffer);
 
-    ret = (!aes || !out || !in)
-        ? BAD_FUNC_ARG
-        : AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    #else
+        ret = AesCbcEncrypt_fips(aes, out, in, (word32) size);
+    #endif
+    }
 
     LogStr("AesCbcEncrypt_fips(aes=%p, out, in) = %d\n", aes, ret);
     LogStr("in[%u]: [%p]\n", (word32)size, in);
@@ -505,7 +548,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesCbcDecrypt_1fips__Lcom
     if (!aes || !out || !in)
         return BAD_FUNC_ARG;
 
-    ret = AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    #else
+        ret = AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    #endif
 
     LogStr("AesCbcDecrypt_fips(aes=%p, out, in) = %d\n", aes, ret);
     LogStr("in[%u]: [%p]\n", (word32)size, in);
@@ -539,9 +586,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesCbcDecrypt_1fips__Lcom
     out = getByteArray(env, out_buffer);
     in  = getByteArray(env, in_buffer);
 
-    ret = (!aes || !out || !in)
-        ? BAD_FUNC_ARG
-        : AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    #else
+        ret = AesCbcDecrypt_fips(aes, out, in, (word32) size);
+    #endif
+    }
 
     LogStr("AesCbcDecrypt_fips(aes=%p, out, in) = %d\n", aes, ret);
     LogStr("in[%u]: [%p]\n", (word32)size, in);
@@ -579,7 +633,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmSetKey_1fips__Lcom_
     if (!aes || !key)
         return BAD_FUNC_ARG;
 
-    ret = AesGcmSetKey_fips(aes, key, (word32)size);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmSetKey_fips(aes, key, (word32)size);
+    #else
+        ret = AesGcmSetKey_fips(aes, key, (word32)size);
+    #endif
 
     LogStr("AesGcmSetKey_fips(aes=%p, key) = %d\n", aes, ret);
     LogStr("key[%u]: [%p]\n", (word32)size, key);
@@ -609,8 +667,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmSetKey_1fips__Lcom_
 
     key = getByteArray(env, key_buffer);
 
-    ret = (!aes || !key) ? BAD_FUNC_ARG
-                         : AesGcmSetKey_fips(aes, key, (word32)size);
+    if (aes == NULL || key == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmSetKey_fips(aes, key, (word32)size);
+    #else
+        ret = AesGcmSetKey_fips(aes, key, (word32)size);
+    #endif
+    }
 
     LogStr("AesGcmSetKey_fips(aes=%p, key) = %d\n", aes, ret);
     LogStr("key[%u]: [%p]\n", (word32)size, key);
@@ -657,8 +723,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmEncrypt_1fips__Lcom
         return BAD_FUNC_ARG;
     }
 
-    ret = AesGcmEncrypt_fips(aes, out, in, (word32) size, iv, (word32) ivSz,
-        authTag, (word32) authTagSz, authIn, (word32) authInSz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmEncrypt_fips(aes, out, in, (word32)size, iv,
+            (word32) ivSz, authTag, (word32)authTagSz, authIn,
+            (word32)authInSz);
+    #else
+        ret = AesGcmEncrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
+            authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #endif
 
     LogStr(
         "AesGcmEncrypt_fips(aes=%p, out, in, iv, authTag, authIn) = %d\n",
@@ -714,8 +786,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmEncrypt_1fips__Lcom
 
     }
     else {
-        ret = AesGcmEncrypt_fips(aes, out, in, (word32) size, iv, (word32) ivSz,
-            authTag, (word32) authTagSz, authIn, (word32) authInSz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmEncrypt_fips(aes, out, in, (word32)size, iv,
+            (word32)ivSz, authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #else
+        ret = AesGcmEncrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
+            authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #endif
     }
 
     LogStr(
@@ -776,8 +853,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmDecrypt_1fips__Lcom
         || (!authIn && authInSz))
         return BAD_FUNC_ARG;
 
-    ret = AesGcmDecrypt_fips(aes, out, in, (word32) size, iv, (word32) ivSz,
-        authTag, (word32) authTagSz, authIn, (word32) authInSz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmDecrypt_fips(aes, out, in, (word32)size, iv,
+            (word32)ivSz, authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #else
+        ret = AesGcmDecrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
+            authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #endif
 
     LogStr(
         "AesGcmDecrypt_fips(aes=%p, out, in, iv, authTag, authIn) = %d\n",
@@ -828,11 +910,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_AesGcmDecrypt_1fips__Lcom
     authIn  = getByteArray(env, authIn_buffer);
 
     if (!aes || !out || !in || (!iv && ivSz) || (!authTag && authTagSz)
-        || (!authIn && authInSz))
+        || (!authIn && authInSz)) {
         ret = BAD_FUNC_ARG;
-    else
-        ret = AesGcmDecrypt_fips(aes, out, in, (word32) size, iv, (word32) ivSz,
-            authTag, (word32) authTagSz, authIn, (word32) authInSz);
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_AesGcmDecrypt_fips(aes, out, in, (word32)size, iv,
+            (word32)ivSz, authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #else
+        ret = AesGcmDecrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
+            authTag, (word32)authTagSz, authIn, (word32)authInSz);
+    #endif
+    }
 
     LogStr(
         "AesGcmDecrypt_fips(aes=%p, out, in, iv, authTag, authIn) = %d\n",
@@ -1196,7 +1285,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacSetKey_1fips__Lcom_wo
     if (!hmac || !key)
         return BAD_FUNC_ARG;
 
-    ret = HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    #else
+        ret = HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    #endif
 
     LogStr("HmacSetKey_fips(hmac=%p, type=%d, key, keySz) = %d\n", hmac, type,
         ret);
@@ -1227,8 +1320,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacSetKey_1fips__Lcom_wo
 
     key = getByteArray(env, key_buffer);
 
-    ret = (!hmac || !key) ? BAD_FUNC_ARG
-                          : HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    if (hmac == NULL || key == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    #else
+        ret = HmacSetKey_fips(hmac, type, key, (word32)keySz);
+    #endif
+    }
 
     LogStr("HmacSetKey_fips(hmac=%p, type=%d, key, keySz) = %d\n", hmac, type,
         ret);
@@ -1264,7 +1365,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacUpdate_1fips__Lcom_wo
     if (!hmac || !data)
         return BAD_FUNC_ARG;
 
-    ret = HmacUpdate_fips(hmac, data, (word32)len);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacUpdate_fips(hmac, data, (word32)len);
+    #else
+        ret = HmacUpdate_fips(hmac, data, (word32)len);
+    #endif
 
     LogStr("HmacUpdate_fips(hmac=%p, data, len) = %d\n", hmac, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -1294,8 +1399,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacUpdate_1fips__Lcom_wo
 
     data = getByteArray(env, data_buffer);
 
-    ret = (!hmac || !data) ? BAD_FUNC_ARG
-                           : HmacUpdate_fips(hmac, data, (word32)len);
+    if (hmac == NULL || data == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacUpdate_fips(hmac, data, (word32)len);
+    #else
+        ret = HmacUpdate_fips(hmac, data, (word32)len);
+    #endif
+    }
 
     LogStr("HmacUpdate_fips(hmac=%p, data, len) = %d\n", hmac, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -1329,7 +1442,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacFinal_1fips__Lcom_wol
     if (!hmac || !hash)
         return BAD_FUNC_ARG;
 
-    ret = HmacFinal_fips(hmac, hash);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacFinal_fips(hmac, hash);
+    #else
+        ret = HmacFinal_fips(hmac, hash);
+    #endif
 
     LogStr("HmacFinal_fips(hmac=%p, hash) = %d\n", hmac, ret);
 
@@ -1356,8 +1473,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_HmacFinal_1fips__Lcom_wol
 
     hash = getByteArray(env, hash_buffer);
 
-    ret = (!hmac || !hash) ? BAD_FUNC_ARG
-                           : HmacFinal_fips(hmac, hash);
+    if (hmac == NULL || hash == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_HmacFinal_fips(hmac, hash);
+    #else
+        ret = HmacFinal_fips(hmac, hash);
+    #endif
+    }
 
     LogStr("HmacFinal_fips(hmac=%p, hash) = %d\n", hmac, ret);
 
@@ -1387,7 +1512,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitRng_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = InitRng_fips(rng);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitRng_fips(rng);
+    #else
+        ret = InitRng_fips(rng);
+    #endif
 
     LogStr("InitRng_fips(rng=%p) = %d\n", rng, ret);
 
@@ -1409,7 +1538,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_FreeRng_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = FreeRng_fips(rng);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_FreeRng_fips(rng);
+    #else
+        ret = FreeRng_fips(rng);
+    #endif
 
     LogStr("FreeRng_fips(rng=%p) = %d\n", rng, ret);
 
@@ -1440,7 +1573,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RNG_1GenerateBlock_1fips_
     if (!rng || !buf)
         return BAD_FUNC_ARG;
 
-    ret = RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    #else
+        ret = RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    #endif
 
     LogStr("RNG_GenerateBlock_fips(rng=%p, buf, bufSz) = %d\n", rng, ret);
     LogStr("output[%u]: [%p]\n", (word32)bufSz, buf);
@@ -1470,8 +1607,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RNG_1GenerateBlock_1fips_
 
     buf = getByteArray(env, buf_buffer);
 
-    ret = (!rng || !buf) ? BAD_FUNC_ARG
-                         : RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    if (rng == NULL || buf == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    #else
+        ret = RNG_GenerateBlock_fips(rng, buf, (word32)bufSz);
+    #endif
+    }
 
     LogStr("RNG_GenerateBlock_fips(rng=%p, buf, bufSz) = %d\n", rng, ret);
     LogStr("output[%u]: [%p]\n", (word32)bufSz, buf);
@@ -1500,8 +1645,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RNG_1HealthTest_1fips__IL
     if (!entropyA || (reseed && !entropyB) || !output)
         return BAD_FUNC_ARG;
 
-    ret = RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz, entropyB,
-        (word32)entropyBSz, output, (word32)outputSz);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz,
+            entropyB, (word32)entropyBSz, output, (word32)outputSz);
+    #else
+        ret = RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz,
+            entropyB, (word32)entropyBSz, output, (word32)outputSz);
+    #endif
 
     LogStr("RNG_HealthTest_fips(reseed=%d, entropyA, entropyASz, "
         "entropyB, entropyBSz, output, outputSz) = %d\n", reseed, ret);
@@ -1530,10 +1680,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RNG_1HealthTest_1fips__I_
     const byte* entropyB = getByteArray(env, entropyB_object);
     byte* output = getByteArray(env, output_object);
 
-    ret = (!entropyA || (reseed && !entropyB) || !output)
-        ? BAD_FUNC_ARG
-        : RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz, entropyB,
-            (word32)entropyBSz, output, (word32)outputSz);
+    if (!entropyA || (reseed && !entropyB) || !output) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz,
+            entropyB, (word32)entropyBSz, output, (word32)outputSz);
+    #else
+        ret = RNG_HealthTest_fips(reseed, entropyA, (word32)entropyASz,
+            entropyB, (word32)entropyBSz, output, (word32)outputSz);
+    #endif
+    }
 
     LogStr("RNG_HealthTest_fips(reseed=%d, entropyA, entropyASz, "
         "entropyB, entropyBSz, output, outputSz) = %d\n", reseed, ret);
@@ -1577,7 +1735,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitRsaKey_1fips(
 
     heap = getDirectBufferAddress(env, heap_object);
 
-    ret = InitRsaKey_fips(key, heap);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitRsaKey_fips(key, heap);
+    #else
+        ret = InitRsaKey_fips(key, heap);
+    #endif
 
     LogStr("InitRsaKey_fips(key=%p, heap=%p) = %d\n", key, heap, ret);
 
@@ -1599,7 +1761,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_FreeRsaKey_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = FreeRsaKey_fips(key);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_FreeRsaKey_fips(key);
+    #else
+        ret = FreeRsaKey_fips(key);
+    #endif
 
     LogStr("FreeRsaKey_fips(key=%p) = %d\n", key, ret);
 
@@ -1643,7 +1809,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaSSL_1Sign_1fips__Ljava
     if (!in || !out)
         return BAD_FUNC_ARG;
 
-    ret = RsaSSL_Sign_fips(in, (word32)inLen, out, (word32)outLen, key, rng);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaSSL_Sign_fips(in, (word32)inLen, out, (word32)outLen,
+            key, rng);
+    #else
+        ret = RsaSSL_Sign_fips(in, (word32)inLen, out, (word32)outLen,
+            key, rng);
+    #endif
 
     LogStr("RsaSSL_Sign_fips(in, inLen, out, outLen, key=%p, rng=%p) = %d\n",
         key, rng, ret);
@@ -1699,8 +1871,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaSSL_1Sign_1fips___3BJ_
          * Providing an rng is optional. RNG_GenerateBlock will return
          * BAD_FUNC_ARG on a NULL rng if an RNG is needed by RsaPad.
          */
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaSSL_Sign_fips(in, (word32)inLen, out, (word32)outLen,
+                               key, rng);
+    #else
         ret = RsaSSL_Sign_fips(in, (word32)inLen, out, (word32)outLen,
                                key, rng);
+    #endif
     }
 
     LogStr("RsaSSL_Sign_fips(in, inLen, out, outLen, key=%p, rng=%p) = %d\n",
@@ -1748,7 +1925,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaSSL_1Verify_1fips__Lja
     if (!in || !out)
         return BAD_FUNC_ARG;
 
-    ret = RsaSSL_Verify_fips(in, (word32)inLen, out, (word32)outLen, key);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaSSL_Verify_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #else
+        ret = RsaSSL_Verify_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #endif
 
     LogStr("RsaSSL_Verify_fips(in, inLen, out, outLen, key=%p) = %d\n", key,
         ret);
@@ -1793,7 +1976,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaSSL_1Verify_1fips___3B
         ret = BAD_FUNC_ARG;
     }
     else {
-        ret = RsaSSL_Verify_fips(in, (word32)inLen, out, (word32)outLen, key);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaSSL_Verify_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #else
+        ret = RsaSSL_Verify_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #endif
 
         LogStr("RsaSSL_Verify_fips(in, inLen, out, outLen, key=%p) = %d\n",
                key, ret);
@@ -1824,7 +2013,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaEncryptSize_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = RsaEncryptSize_fips(key);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaEncryptSize_fips(key);
+    #else
+        ret = RsaEncryptSize_fips(key);
+    #endif
 
     LogStr("RsaEncryptSize_fips(key=%p) = %d\n", key, ret);
 
@@ -2045,7 +2238,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitSha_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = InitSha_fips(sha);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitSha_fips(sha);
+    #else
+        ret = InitSha_fips(sha);
+    #endif
 
 #endif
 
@@ -2072,7 +2269,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_ShaUpdate_1fips__Lcom_wol
     if (!data)
         return BAD_FUNC_ARG;
 
-    ret = ShaUpdate_fips(sha, data, (word32)len);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_ShaUpdate_fips(sha, data, (word32)len);
+    #else
+        ret = ShaUpdate_fips(sha, data, (word32)len);
+    #endif
 
     LogStr("ShaUpdate_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2101,8 +2302,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_ShaUpdate_1fips__Lcom_wol
 
     data = getByteArray(env, data_buffer);
 
-    ret = (!data) ? BAD_FUNC_ARG
-                  : ShaUpdate_fips(sha, data, (word32)len);
+    if (data == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_ShaUpdate_fips(sha, data, (word32)len);
+    #else
+        ret = ShaUpdate_fips(sha, data, (word32)len);
+    #endif
+    }
 
     LogStr("ShaUpdate_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2134,7 +2343,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_ShaFinal_1fips__Lcom_wolf
     if (!hash)
         return BAD_FUNC_ARG;
 
-    ret = ShaFinal_fips(sha, hash);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_ShaFinal_fips(sha, hash);
+    #else
+        ret = ShaFinal_fips(sha, hash);
+    #endif
 
     LogStr("ShaFinal_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash);
@@ -2162,8 +2375,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_ShaFinal_1fips__Lcom_wolf
 
     hash = getByteArray(env, hash_buffer);
 
-    ret = (!hash) ? BAD_FUNC_ARG
-                  : ShaFinal_fips(sha, hash);
+    if (hash == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_ShaFinal_fips(sha, hash);
+    #else
+        ret = ShaFinal_fips(sha, hash);
+    #endif
+    }
 
     LogStr("ShaFinal_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash);
@@ -2190,7 +2411,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitSha256_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = InitSha256_fips(sha);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitSha256_fips(sha);
+    #else
+        ret = InitSha256_fips(sha);
+    #endif
 
 #endif
 
@@ -2217,7 +2442,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha256Update_1fips__Lcom_
     if (!data)
         return BAD_FUNC_ARG;
 
-    ret = Sha256Update_fips(sha, data, (word32)len);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha256Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha256Update_fips(sha, data, (word32)len);
+    #endif
 
     LogStr("Sha256Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2246,8 +2475,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha256Update_1fips__Lcom_
 
     data = getByteArray(env, data_buffer);
 
-    ret = (!data) ? BAD_FUNC_ARG
-                  : Sha256Update_fips(sha, data, (word32)len);
+    if (data == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha256Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha256Update_fips(sha, data, (word32)len);
+    #endif
+    }
 
     LogStr("Sha256Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2279,7 +2516,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha256Final_1fips__Lcom_w
     if (!hash)
         return BAD_FUNC_ARG;
 
-    ret = Sha256Final_fips(sha, hash);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha256Final_fips(sha, hash);
+    #else
+        ret = Sha256Final_fips(sha, hash);
+    #endif
 
     LogStr("Sha256Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE, hash);
@@ -2306,8 +2547,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha256Final_1fips__Lcom_w
     }
 
     hash = getByteArray(env, hash_buffer);
-    ret = (!hash) ? BAD_FUNC_ARG
-                  : Sha256Final_fips(sha, hash);
+
+    if (hash == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha256Final_fips(sha, hash);
+    #else
+        ret = Sha256Final_fips(sha, hash);
+    #endif
+    }
 
     LogStr("Sha256Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE, hash);
@@ -2334,7 +2584,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitSha384_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = InitSha384_fips(sha);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitSha384_fips(sha);
+    #else
+        ret = InitSha384_fips(sha);
+    #endif
 
 #endif
 
@@ -2361,7 +2615,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha384Update_1fips__Lcom_
     if (!data)
         return BAD_FUNC_ARG;
 
-    ret = Sha384Update_fips(sha, data, (word32)len);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha384Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha384Update_fips(sha, data, (word32)len);
+    #endif
 
     LogStr("Sha384Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2389,8 +2647,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha384Update_1fips__Lcom_
     }
 
     data = getByteArray(env, data_buffer);
-    ret = (!data) ? BAD_FUNC_ARG
-                  : Sha384Update_fips(sha, data, (word32)len);
+
+    if (data == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha384Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha384Update_fips(sha, data, (word32)len);
+    #endif
+    }
 
     LogStr("Sha384Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2422,7 +2689,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha384Final_1fips__Lcom_w
     if (!hash)
         return BAD_FUNC_ARG;
 
-    ret = Sha384Final_fips(sha, hash);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha384Final_fips(sha, hash);
+    #else
+        ret = Sha384Final_fips(sha, hash);
+    #endif
 
     LogStr("Sha384Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE, hash);
@@ -2449,8 +2720,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha384Final_1fips__Lcom_w
     }
 
     hash = getByteArray(env, hash_buffer);
-    ret = (!hash) ? BAD_FUNC_ARG
-                  : Sha384Final_fips(sha, hash);
+
+    if (hash == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha384Final_fips(sha, hash);
+    #else
+        ret = Sha384Final_fips(sha, hash);
+    #endif
+    }
 
     LogStr("Sha384Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE, hash);
@@ -2477,7 +2757,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_InitSha512_1fips(
         return BAD_FUNC_ARG;
     }
 
-    ret = InitSha512_fips(sha);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_InitSha512_fips(sha);
+    #else
+        ret = InitSha512_fips(sha);
+    #endif
 
 #endif
 
@@ -2504,7 +2788,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha512Update_1fips__Lcom_
     if (!data)
         return BAD_FUNC_ARG;
 
-    ret = Sha512Update_fips(sha, data, (word32)len);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha512Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha512Update_fips(sha, data, (word32)len);
+    #endif
 
     LogStr("Sha512Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2532,8 +2820,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha512Update_1fips__Lcom_
     }
 
     data = getByteArray(env, data_buffer);
-    ret = (!data) ? BAD_FUNC_ARG
-                  : Sha512Update_fips(sha, data, (word32)len);
+
+    if (data == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha512Update_fips(sha, data, (word32)len);
+    #else
+        ret = Sha512Update_fips(sha, data, (word32)len);
+    #endif
+    }
 
     LogStr("Sha512Update_fips(sha=%p, data, len) = %d\n", sha, ret);
     LogStr("data[%u]: [%p]\n", (word32)len, data);
@@ -2565,7 +2862,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha512Final_1fips__Lcom_w
     if (!hash)
         return BAD_FUNC_ARG;
 
-    ret = Sha512Final_fips(sha, hash);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha512Final_fips(sha, hash);
+    #else
+        ret = Sha512Final_fips(sha, hash);
+    #endif
 
     LogStr("Sha512Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE, hash);
@@ -2592,8 +2893,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_Sha512Final_1fips__Lcom_w
     }
 
     hash = getByteArray(env, hash_buffer);
-    ret = (!hash) ? BAD_FUNC_ARG
-                  : Sha512Final_fips(sha, hash);
+
+    if (hash == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_Sha512Final_fips(sha, hash);
+    #else
+        ret = Sha512Final_fips(sha, hash);
+    #endif
+    }
 
     LogStr("Sha512Final_fips(sha=%p, hash) = %d\n", sha, ret);
     LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE, hash);
@@ -2671,8 +2981,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaPublicEncrypt_1fips__L
     if (!in || !out)
         return BAD_FUNC_ARG;
 
-    ret = RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
-                                key, rng);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
+                                    key, rng);
+    #else
+        ret = RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
+                                    key, rng);
+    #endif
 
     LogStr(
         "RsaPublicEncrypt_fips(in, inLen, out, outLen, key=%p, rng=%p) = %d\n",
@@ -2717,10 +3032,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaPublicEncrypt_1fips___
      * Providing an rng is optional. RNG_GenerateBlock will return BAD_FUNC_ARG
      * on a NULL rng if an RNG is needed by RsaPad.
      */
-    ret = (!in || !out)
-        ? BAD_FUNC_ARG
-        : RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
-                                key, rng);
+    if (in == NULL || out == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
+            key, rng);
+    #else
+        ret = RsaPublicEncrypt_fips(in, (word32)inLen, out, (word32)outLen,
+            key, rng);
+    #endif
+    }
 
     LogStr(
         "RsaPublicEncrypt_fips(in, inLen, out, outLen, key=%p, rng=%p) = %d\n",
@@ -2761,7 +3084,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaPrivateDecrypt_1fips__
     if (!in || !out)
         return BAD_FUNC_ARG;
 
-    ret = RsaPrivateDecrypt_fips(in, (word32)inLen, out, (word32)outLen, key);
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaPrivateDecrypt_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #else
+        ret = RsaPrivateDecrypt_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #endif
 
     LogStr("RsaPrivateDecrypt_fips(in, inLen, out, outLen, key=%p) = %d\n", key,
         ret);
@@ -2795,9 +3124,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_RsaPrivateDecrypt_1fips__
     in  = getByteArray(env, in_object);
     out = getByteArray(env, out_object);
 
-    ret = (!in || !out)
-        ? BAD_FUNC_ARG
-        : RsaPrivateDecrypt_fips(in, (word32)inLen, out, (word32)outLen, key);
+    if (in == NULL || out == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if FIPS_VERSION_GT(5,0)
+        ret = wc_RsaPrivateDecrypt_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #else
+        ret = RsaPrivateDecrypt_fips(in, (word32)inLen, out,
+            (word32)outLen, key);
+    #endif
+    }
 
     LogStr("RsaPrivateDecrypt_fips(in, inLen, out, outLen, key=%p) = %d\n", key,
         ret);

--- a/jni/jni_jce_wolfsslkeystore.c
+++ b/jni/jni_jce_wolfsslkeystore.c
@@ -96,9 +96,11 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
     }
 
     if (ret == WOLFSSL_SUCCESS) {
+        PRIVATE_KEY_UNLOCK();
         ret = wolfSSL_X509_check_private_key(x509, key);
+        PRIVATE_KEY_LOCK();
         if (ret != WOLFSSL_SUCCESS) {
-            fprintf(stderr, "Native wolfSSL_X509_check_private_key() failed");
+            fprintf(stderr, "Native wolfSSL_X509_check_private_key() failed: %d", ret);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 	</dependencies>
 
 	<build>
+        <sourceDirectory>./src/main/java</sourceDirectory>
+        <testSourceDirectory>./src/test/java</testSourceDirectory>
 		<plugins>
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
     <url>https://www.wolfssl.com</url>

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -77,7 +77,7 @@ infer --fail-on-issue run -- javac \
     src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java \
-    src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+    src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java \
     src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
 
 RETVAL=$?

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -36,7 +36,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.6, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.7, "wolfCrypt JCE Provider");
 
         /* MessageDigest */
         if (FeatureDetect.Md5Enabled()) {

--- a/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
@@ -150,10 +150,12 @@ public class Chacha extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_Chacha_setKey(Key);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_Chacha_setKey(Key);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
@@ -166,10 +166,12 @@ public class Curve25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_curve25519_make_key(rng, size);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_curve25519_make_key(rng, size);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -189,10 +191,12 @@ public class Curve25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_curve25519_make_key_ex(rng, size, endian);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_curve25519_make_key_ex(rng, size, endian);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -230,10 +234,12 @@ public class Curve25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_curve25519_import_private(privKey, xKey);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_curve25519_import_private(privKey, xKey);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -252,10 +258,12 @@ public class Curve25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_curve25519_import_private_only(privKey);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_curve25519_import_private_only(privKey);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -274,10 +282,12 @@ public class Curve25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_curve25519_import_public(pubKey);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_curve25519_import_public(pubKey);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Ed25519.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ed25519.java
@@ -165,10 +165,12 @@ public class Ed25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_ed25519_make_key(rng, size);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_ed25519_make_key(rng, size);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -208,10 +210,12 @@ public class Ed25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_ed25519_import_private(privKey, Key);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_ed25519_import_private(privKey, Key);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -230,10 +234,12 @@ public class Ed25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_ed25519_import_private_only(privKey);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_ed25519_import_private_only(privKey);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**
@@ -252,10 +258,12 @@ public class Ed25519 extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyExists();
 
-        synchronized (pointerLock) {
-            wc_ed25519_import_public(Key);
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                wc_ed25519_import_public(Key);
+            }
+            state = WolfCryptState.READY;
         }
-        state = WolfCryptState.READY;
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
@@ -341,8 +341,11 @@ public enum WolfCryptError {
     /** DH KAT failure */
     DH_KAT_FIPS_E        (-256),
 
+    /** Cannot export private key */
+    FIPS_PRIVATE_KEY_LOCKED_E (-287),
+
     /** Update this to indicate last error */
-    WC_LAST_E            (-256),
+    WC_LAST_E            (-299),
 
     /** errors -101 - -299 */
     MIN_CODE_E           (-300);

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -66,6 +66,11 @@ import java.security.spec.InvalidKeySpecException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 import com.wolfssl.provider.jce.WolfCryptProvider;
 
 public class WolfSSLKeyStoreTest {
@@ -1423,7 +1428,9 @@ public class WolfSSLKeyStoreTest {
         String scriptName = "system-cacerts-to-wks.sh";
         String cacertsWKS = "cacerts.wks";
         String jssecacertsWKS = "jssecacerts.wks";
-        String cmd = "cd " + userDir + scriptDir + " && /bin/sh " + scriptName;
+        String providerJARPath = "/lib/wolfcrypt-jni.jar";
+        String cmd = "cd " + userDir + scriptDir + " && /bin/sh " + scriptName +
+            " " + userDir + providerJARPath;
         KeyStore store = null;
         String cacertsPass = "changeitchangeit";
         File cacertFile = null;
@@ -1431,6 +1438,11 @@ public class WolfSSLKeyStoreTest {
         /* Skip running this test on Android, since directory structure
          * and cacert gen script won't be there. */
         Assume.assumeTrue(!isAndroid());
+
+        /* Skip of wolfcrypt-jni.jar does not exist. This can happen if we
+         * are running via 'mvn test' and the jar has not been created yet */
+        File jarFile = new File(userDir + providerJARPath);
+        Assume.assumeTrue(jarFile.exists());
 
         assertNotNull(userDir);
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -179,6 +179,17 @@ public class WolfSSLKeyStoreTest {
     }
 
     /**
+     * Test if this environment is Windows.
+     * @return true if Windows, otherwise false.
+     */
+    private static boolean isWindows() {
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Read in and convert DER private key into PrivateKey object.
      *
      * @param derFilePath file path to DER-encoded private key
@@ -1438,6 +1449,10 @@ public class WolfSSLKeyStoreTest {
         /* Skip running this test on Android, since directory structure
          * and cacert gen script won't be there. */
         Assume.assumeTrue(!isAndroid());
+
+        /* Skip running this test on Windows until portabiliy of running
+         * above script is figured out. */
+        Assume.assumeTrue(!isWindows());
 
         /* Skip of wolfcrypt-jni.jar does not exist. This can happen if we
          * are running via 'mvn test' and the jar has not been created yet */


### PR DESCRIPTION
This PR includes prep work for the wolfCrypt JNI/JCE 1.7 release:

- Adds source and test folders to Maven `pom.xml`
- Adjusts `WolfSSLKeyStoreTest.testLoadSystemCAKeyStore()` to skip with Maven or on Windows
- Fix build compatibility with latest FIPS 140-3 native wolfSSL builds
- Fix Facebook Infer warnings related to potential threading issues (OSX)
- Update Windows Visual Studio project file and README

Tested against release cycle items, including:

- wolfSSL master, 5.7.4, FIPSv2, FIPSv5, FIPS Ready
- Java 8, 11, 17, 20, 22, 23
- Facebook Infer (Mac)
- Android Studio IDE project
- Windows Visual Studio build