### PR TITLE
Android: define WOLFSSL_CUSTOM_CONFIG in example Android app

### DIFF
--- a/IDE/Android/app/src/main/cpp/CMakeLists.txt
+++ b/IDE/Android/app/src/main/cpp/CMakeLists.txt
@@ -65,6 +65,7 @@ if ("${WOLFSSL_PKG_TYPE}" MATCHES "normal")
                 -DWOLFSSL_AKID_NAME -DHAVE_CTS -DNO_DES3 -DGCM_TABLE_4BIT
                 -DTFM_TIMING_RESISTANT -DECC_TIMING_RESISTANT
                 -DHAVE_AESGCM -DSIZEOF_LONG=4 -DSIZEOF_LONG_LONG=8
+                -DWOLFSSL_CUSTOM_CONFIG
 
                 # For gethostbyname()
                 -DHAVE_NETDB_H
@@ -166,7 +167,7 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
                 -DWOLFSSL_ERROR_CODE_OPENSSL -DWOLFSSL_EXTRA_ALERTS
                 -DWOLFSSL_FORCE_CACHE_ON_TICKET -DWOLFSSL_AKID_NAME -DHAVE_CTS
                 -DKEEP_PEER_CERT -DSESSION_CERTS
-                -DSIZEOF_LONG=4 -DSIZEOF_LONG_LONG=8
+                -DSIZEOF_LONG=4 -DSIZEOF_LONG_LONG=8 -DWOLFSSL_CUSTOM_CONFIG
 
                 # For gethostbyname()
                 -DHAVE_NETDB_H


### PR DESCRIPTION
With wolfSSL PR https://github.com/wolfSSL/wolfssl/pull/8262, Android builds that use CMakeLists.txt now need to define `WOLFSSL_CUSTOM_CONFIG` since it is not using `options.h`.