### PR TITLE
Add GitHub Actions PRB tests for FIPS ready/v2/v5/v6

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -1,0 +1,155 @@
+name: wolfSSL FIPS Ready Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      jdk_distro:
+        required: true
+        type: string
+      jdk_version:
+        required: true
+        type: string
+      wolfssl_configure:
+        required: true
+        type: string
+      fips_check_variant:
+        required: true
+        type: string
+    secrets:
+      fips_repo_ssh_key:
+        required: true
+
+jobs:
+  build_wolfcryptjni:
+    runs-on: ${{ inputs.os }}
+    steps:
+      # Add SSH key for fips repo access
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.fips_repo_ssh_key }}
+
+      # Clone wolfcryptjni
+      - uses: actions/checkout@v4
+
+      # Clone wolfssl
+      - uses: actions/checkout@v4
+        with:
+          repository: wolfssl/wolfssl
+          ref: master
+          fetch-depth: 1
+          path: wolfssl
+
+      # Install dependencies (automake, libtool)
+      - shell: bash
+        if: runner.os == 'macOS'
+        run: brew install automake libtool
+
+      # Get junit/hamcrest jars
+      - name: Download junit-4.13.2.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+      - name: Download hamcrest-all-1.3.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+
+      # Run autogen.sh
+      - shell: bash
+        working-directory: wolfssl
+        run: ./autogen.sh
+
+      # Build FIPS Ready directory
+      - shell: bash
+        working-directory: wolfssl
+        run: ./fips-check.sh ${{ inputs.fips_check_variant }} keep
+
+      # Configure wolfssl
+      - shell: bash
+        working-directory: wolfssl/XXX-fips-test
+        run: ./configure --prefix=$GITHUB_WORKSPACE/build-dir ${{ inputs.wolfssl_configure }}
+
+      # make wolfssl
+      - shell: bash
+        working-directory: wolfssl/XXX-fips-test
+        run: make
+
+      # update verifyCore[] in fips_test.c
+      - shell: bash
+        working-directory: wolfssl/XXX-fips-test
+        run: ./fips-hash.sh
+
+      # re-make/check wolfssl with new hash
+      - shell: bash
+        working-directory: wolfssl/XXX-fips-test
+        run: make check
+
+      # install wolfssl
+      - shell: bash
+        working-directory: wolfssl/XXX-fips-test
+        run: make install
+
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ inputs.jdk_distro }}
+          java-version: ${{ inputs.jdk_version }}
+
+      - name: Set JUNIT_HOME
+        run: |
+          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
+      - name: Set LD_LIBRARY_PATH
+        run: |
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
+
+      # Only copy appropriate makefile for platform currently being tested
+      - name: Copy makefile
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              cp makefile.linux makefile
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+              cp makefile.macosx makefile
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Build JNI library
+        run: PREFIX=$GITHUB_WORKSPACE/build-dir make
+
+      # ant build-jni-debug
+      - name: Build jce-debug JAR (ant build-jni-debug)
+        run: ant build-jni-debug
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jni-release
+      - name: Build jce-debug JAR (ant build-jni-release)
+        run: ant build-jni-release
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jce-debug
+      - name: Build jce-debug JAR (ant build-jce-debug)
+        run: ant build-jce-debug
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      # ant build-jce-release
+      - name: Build jce-debug JAR (ant build-jce-release)
+        run: ant build-jce-release
+      - name: Run Java tests (ant test)
+        run: ant test
+      - name: Clean JAR
+        run: ant clean
+
+      - name: Show logs on failure
+        if: failure() || cancelled()
+        run: |
+          cat build/reports/*.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,3 +171,76 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # --------------------- FIPS build tests ------------------------------
+  # Build wolfcryptjni against wolfSSL FIPS Ready, v2, v5, v6
+  # Only testing one Linux for starters, with one JDK/version
+  # Once fips_check.sh script gets modified to work with bash < 4, which
+  # is the default for MacOS, MacOS targets will be added here.
+  fips-ready-build:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        jdk_version: [ '21' ]
+        wolfssl_configure: [ '--enable-fips=ready --enable-jni' ]
+    name: FIPS Ready Build (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
+    uses: ./.github/workflows/fips.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+      fips_check_variant: "fips-ready"
+    secrets:
+      fips_repo_ssh_key: ${{ secrets.FIPS_REPO_SSH_KEY }}
+
+  fipsv2-build:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        jdk_version: [ '21' ]
+        wolfssl_configure: [ '--enable-fips=v2 --enable-jni' ]
+    name: FIPSv2 Build (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
+    uses: ./.github/workflows/fips.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+      fips_check_variant: "linuxv2"
+    secrets:
+      fips_repo_ssh_key: ${{ secrets.FIPS_REPO_SSH_KEY }}
+
+  fipsv5-build:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        jdk_version: [ '21' ]
+        wolfssl_configure: [ '--enable-fips=v5 --enable-jni' ]
+    name: FIPSv5 Build (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
+    uses: ./.github/workflows/fips.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+      fips_check_variant: "linuxv5"
+    secrets:
+      fips_repo_ssh_key: ${{ secrets.FIPS_REPO_SSH_KEY }}
+
+  fipsv6-build:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        jdk_version: [ '21' ]
+        wolfssl_configure: [ '--enable-fips=v6 --enable-jni' ]
+    name: FIPSv6 Build (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
+    uses: ./.github/workflows/fips.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+      fips_check_variant: "v6.0.0"
+    secrets:
+      fips_repo_ssh_key: ${{ secrets.FIPS_REPO_SSH_KEY }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [ 'master', 'main', 'release/**' ]
+    branches: [ 'none' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ 'none' ]
 
 jobs:
   # Oracle JDK (Linux, Mac)

--- a/.github/workflows/preFips.yml
+++ b/.github/workflows/preFips.yml
@@ -1,11 +1,45 @@
-name: PR Target Test
+name: Build FIPS zips
 
 on:
   pull_request_target
 
 jobs:
-  pr_target:
+  buildFIPSReady:
+    name: Build wolfSSL FIPS Ready ZIP
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Hello from PR Target Test"
+
+      # Set up SSH key so fips-check.sh can clone from fips repo
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.FIPS_REPO_SSH_KEY }}
+
+      # Clone wolfssl
+      - uses: actions/checkout@v4
+        with:
+          repository: wolfssl/wolfssl
+          ref: master
+          fetch-depth: 1
+          path: wolfssl
+
+      # Install dependencies (automake, libtool)
+      - shell: bash
+        if: runner.os == 'macOS'
+        run: brew install automake libtool
+
+      # Build FIPS Ready directory
+      - shell: bash
+        working-directory: wolfssl
+        run: ./fips-check.sh fips-ready keep noautogen
+
+      # zip newly generated FIPS directory
+      - shell: bash
+        run: zip -r wolfssl-master-fips-ready.zip XXX-fips-test
+
+      # Upload artifact to make it available to later workflows
+      - name: Upload wolfssl-master-fips-ready.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolfssl-master-fips-ready.zip
+          path: wolfssl-master-fips-ready.zip
 

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -190,7 +190,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1runAllCast_1fips
 #endif
 
 #if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION >= 7)
+    (HAVE_FIPS_VERSION >= 6)
 
     failCount = wc_RunAllCast_fips();
     if (failCount != 0) {


### PR DESCRIPTION
This PR adds PRB GitHub Actions tests for FIPS ready/v2/v5/v6. This uses the `fips-check.sh` script to generate the FIPS bundles, then runs ant tests on top of each of those builds.

Currently only testing FIPS builds on Linux latest runners, until https://github.com/wolfSSL/wolfssl/pull/8291 gets merged, which will fix MacOS compatibility with `fips-check.sh`.

This also adjusts `jni_fips.c` to call `wc_RunAllCast_fips()` for `HAVE_FIPS_VERSION` >= 6.  v6 has a few more CASTs than previous versions, and calling the RunAllCast function will make sure we run those up front.