### PR TITLE
JNI/JCE: call wc_RunAllCast_fips() for HAVE_FIPS_VERSION >= 6

### DIFF
--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -190,7 +190,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1runAllCast_1fips
 #endif
 
 #if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION >= 7)
+    (HAVE_FIPS_VERSION >= 6)
 
     failCount = wc_RunAllCast_fips();
     if (failCount != 0) {


### PR DESCRIPTION
This PR adjusts `jni_fips.c` to call `wc_RunAllCast_fips()` for HAVE_FIPS_VERSION >= 6. v6 has a few more CASTs than previous versions, and calling the RunAllCast function will make sure we run those up front.

NOTE:
- Jenkins PRB tests have been added to this repo for FIPS v2, v5, v6, and Ready