### PR TITLE
Prep for 1.8 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,24 @@
+### wolfCrypt JNI Release 1.8.0 (01/23/2025)
+
+Release 1.8.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
+
+**New JCE Functionality:**
+- Add Java security property support for mapping JKS/PKCS12 to WKS type (PR 83)
+
+**JNI and JCE Changes:**
+- Run FIPS CASTs once up front to prevent threaded app errors (PR 84, 91)
+
+**Example Changes:**
+- Define `WOLFSSL_CUSTOM_CONFIG` in Android Studio project builds (PR 85)
+- Add basic JCE cryptography benchmark app (PR 88, 89, 93, 94)
+
+**Testing Changes:**
+- Add GitHub Action testing Maven (pom.xml) build on macOS and Linux (PR 82)
+
+The wolfCrypt JNI/JCE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
+instructions and more details comments, please check the manual.
+
 ### wolfCrypt JNI Release 1.7.0 (11/11/2024)
 
 Release 1.7.0 of wolfCrypt JNI and JCE has bug fixes and new features including:

--- a/IDE/Android/app/src/main/cpp/CMakeLists.txt
+++ b/IDE/Android/app/src/main/cpp/CMakeLists.txt
@@ -87,14 +87,14 @@ if ("${WOLFSSL_PKG_TYPE}" MATCHES "normal")
 elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         # The wolfCrypt FIPS In Core Integrity checksum will vary with compiler
         # versions, runtime library versions, target hardware, and build type.
-        # Anytime the module is shifted up or down in memory or loaded from a
-        # new memory location the hash will change. This is expected during
-        # normal development cycles but should be stable in a production
-        # deployment. The verifyCore[] hash can be manually updated in
+        # Anytime the module is shifted up or down in memory or loaded from a new
+        # memory location the hash will change. This is expected during normal
+        # development cycles but should be stable in a production deployment.
+        # The verifyCore[] hash can be manually updated in
         # 'wolfcrypt/src/fips_test.c' and the app recompiled. Or, the define
         # WOLFCRYPT_FIPS_CORE_HASH_VALUE can be set below, which is helpful
-        # for Android Studio, which builds for all these architectures in the
-        # same build.
+        # for Android Studio, which builds for all these architectures in the same
+        # build.
         #
         # The hash values below are only for reference and will need to
         # be updated to match your build. To update this value:
@@ -102,17 +102,17 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         #  1. Build and install your app which contains wolfCrypt FIPS
         #  2. Run your app on each architecture, looking at the logcat output
         #     to see the expected verifyCore[] hash value.
-        #  3. Copy the expected hash value from logcat to the proper
-        #     architecture section below.
+        #  3. Copy the expected hash value from logcat to the proper architecture
+        #     section below.
         #  4. Re-build your application now that the expected hash value has
         #     been set.
         #  5. Re-install and re-run your application on each architecture to
         #     confirm the hash is stable and application runs as expected.
         #
         # NOTE: If using wolfSSL FIPS Ready or FIPS proper with this sample
-        # application and run into the scenario where the verifyCore[] hash
-        # output at runtime is empty, consider checking/increasing the size of
-        # the MAX_FIPS_DATA_SZ define in 'wolfcrypt/src/fips_test.c'.
+        # application and run into the scenario where the verifyCore[] hash output
+        # at runtime is empty, consider checking/increasing the size of the
+        # MAX_FIPS_DATA_SZ define in 'wolfcrypt/src/fips_test.c'.
 
         if("${ANDROID_ABI}" MATCHES "arm64-v8a")
                 # https://developer.android.com/ndk/guides/abis#arm64-v8a
@@ -129,44 +129,64 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         endif()
 
         # Add preprocessor defines to CFLAGS, these match those placed into
-        # wolfssl/options.h by configure if using: "./configure" on a Unix/Linux
-        # platform. The options below have been chosen to match a FIPS Ready
-        # build, and are based on the example user_settings.h file located here:
-        # https://github.com/wolfSSL/wolfssl/blob/master/examples/configs/user_settings_fipsv5.h
+        # wolfssl/options.h by configure if using the following configure on a Unix/Linux
+        # platform with a wolfSSL FIPS Ready GPLv3 bundle:
+        #
+        # ./configure --enable-fips=ready --enable-jni
+        #
         # This list may be configurable depending on use case and desired
-        # optimizations, being careful not to break FIPS compatibility if
-        # targeting FIPS proper in the future.
-        add_definitions(-DHAVE_FIPS -DHAVE_FIPS_VERSION=5 -DHAVE_FIPS_VERSION_MINOR=3
-                -DHAVE_HASHDRBG -DHAVE_THREAD_LS -DHAVE_REPRODUCIBLE_BUILD
-                -DFP_MAX_BITS=16384 -DSP_INT_BITS=8192 -DWOLFSSL_PUBLIC_MP
-                -DTFM_TIMING_RESISTANT -DECC_TIMING_RESISTANT -DWC_RSA_BLINDING
-                -DWC_RNG_SEED_CB -DWOLFSSL_VALIDATE_ECC_IMPORT
-                -DWOLFSSL_VALIDATE_ECC_KEYGEN -DWOLFSSL_VALIDATE_FFC_IMPORT
-                -DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_ENCRYPT_THEN_MAC
-                -DHAVE_SUPPORTED_CURVES -DHAVE_EXTENDED_MASTER -DHAVE_ONE_TIME_AUTH
-                -DHAVE_SECURE_RENEGOTIATION -DHAVE_SERVER_RENEGOTIATION_INFO -DHAVE_SESSION_TICKET
-                -DWOLFSSL_USE_ALIGN -DWOLFSSL_BASE64_ENCODE -DHAVE_CRL
-                -DHAVE_EXT_CACHE -DWOLFSSL_VERIFY_CB_ALL_CERTS -DWOLFSSL_ALWAYS_VERIFY_CB
-                -DWOLFSSL_DH_EXTRA -DWOLFSSL_WOLFSSH -DOPENSSL_EXTRA -DOPENSSL_ALL
-                -DHAVE_FFDHE_Q -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096
-                -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DHAVE_DH_DEFAULT_PARAMS  -DHAVE_PUBLIC_FFDHE
-                -DHAVE_ECC -DTFM_ECC256 -DECC_SHAMIR -DHAVE_ECC_CDH -DECC_USER_CURVES
-                -DHAVE_ECC256 -DHAVE_ECC384 -DHAVE_ECC521 -DWOLFSSL_ECDSA_SET_K
-                -DWC_RSA_PSS -DWOLFSSL_KEY_GEN -DWC_RSA_NO_PADDING
-                -DWOLFSSL_AES_COUNTER -DHAVE_AESCCM -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT
-                -DWOLFSSL_AES_OFB -DHAVE_AESGCM -DGCM_TABLE_4BIT -DWOLFSSL_CMAC
-                -DWOLFSSL_SHA224 -DWOLFSSL_SHA512 -DWOLFSSL_SHA384 -DWOLFSSL_NO_SHAKE256
-                -DWOLFSSL_NOSHA512_224 -DWOLFSSL_NOSHA512_256 -DWOLFSSL_SHA3 -DHAVE_HKDF
-                -DNO_OLD_TLS -DNO_PSK -DNO_DO178
-                -DNO_RC4 -DNO_MD4 -DNO_MD5 -DNO_DES3 -DNO_DSA -DNO_RABBIT
+        # optimizations, being careful not to break FIPS compatibility if targeting
+        # FIPS proper in the future. Please contact support@wolfssl.com for assistance
+        # properly compiling for use with wolfCrypt FIPS variants.
+        add_definitions(
+                -DWOLFSSL_FIPS_READY -DHAVE_FIPS -DHAVE_FIPS_VERSION=7
+                -DHAVE_FIPS_VERSION_MAJOR=7 -DHAVE_FIPS_VERSION_MINOR=0
+                -DHAVE_FIPS_VERSION_PATCH=0 -DWC_RNG_SEED_CB -DHAVE_THREAD_LS
 
-                -DWOLFSSL_JNI -DHAVE_EX_DATA -DHAVE_OCSP -DHAVE_CRL_MONITOR
-                -DWOLFSSL_CERT_EXT -DWOLFSSL_CERT_GEN -DHAVE_SNI -DHAVE_ALPN
-                -DWOLFSSL_ENCRYPTED_KEYS -DNO_ERROR_QUEUE -DWOLFSSL_EITHER_SIDE
-                -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_TICKET_HAVE_ID
-                -DWOLFSSL_ERROR_CODE_OPENSSL -DWOLFSSL_EXTRA_ALERTS
-                -DWOLFSSL_FORCE_CACHE_ON_TICKET -DWOLFSSL_AKID_NAME -DHAVE_CTS
-                -DKEEP_PEER_CERT -DSESSION_CERTS
+                -DWOLFSSL_WOLFSSH -DNO_DO178 -DHAVE_REPRODUCIBLE_BUILD -DWC_NO_ASYNC_THREADING
+                -DNO_OLD_TLS -DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_SNI
+                -DHAVE_KEYING_MATERIAL -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES
+                -DHAVE_EXTENDED_MASTER -DHAVE_ENCRYPT_THEN_MAC -DWOLFSSL_JNI -DHAVE_EX_DATA
+                -DKEEP_PEER_CERT -DWOLFSSL_ALWAYS_VERIFY_CB -DWOLFSSL_DTLS -DOPENSSL_EXTRA
+                -DOPENSSL_ALL -DWOLFSSL_ERROR_CODE_OPENSSL -DHAVE_CRL -DHAVE_CRL_MONITOR
+                -DHAVE_OCSP -DPERSIST_SESSION_CACHE -DPERSIST_CERT_CACHE -DATOMIC_USER
+                -DWOLFSSL_CERT_EXT -DWOLFSSL_CERT_GEN -DWOLFSSL_CERT_REQ -DWOLFSSL_KEY_GEN
+                -DHAVE_ALPN -DWOLFSSL_ALT_CERT_CHAINS -DSESSION_CERTS -DWOLFSSL_ENCRYPTED_KEYS
+                -DWOLFSSL_SYS_CA_CERTS -DWOLFSSL_ALT_NAMES -DWOLFSSL_EITHER_SIDE
+                -DWOLFSSL_TICKET_HAVE_ID -DWOLFSSL_CERT_NAME_ALL
+                -DHAVE_SERVER_RENEGOTIATION_INFO -DWOLFSSL_ASN_TEMPLATE -DWOLFSSL_ASN_PRINT
+                -DWOLFSSL_BASE64_ENCODE -DERROR_QUEUE_PER_THREAD -DNO_ERROR_QUEUE
+                -DTFM_TIMING_RESISTANT -DECC_TIMING_RESISTANT -DWOLFSSL_USE_ALIGN
+                -DWOLFSSL_PUBLIC_MP
+
+                -DWC_RSA_BLINDING -DWC_RSA_PSS -DWOLFSSL_PSS_LONG_SALT -DWC_RSA_NO_PADDING
+
+                -DHAVE_ECC -DTFM_ECC256 -DECC_SHAMIR -DECC_MIN_KEY_SZ=192 -DHAVE_ECC_CDH
+                -DECC_USER_CURVES -DHAVE_ECC192 -DHAVE_ECC224 -DHAVE_ECC256 -DHAVE_ECC384
+                -DHAVE_ECC521 -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_VALIDATE_ECC_IMPORT
+                -DWOLFSSL_VALIDATE_ECC_KEYGEN
+
+                -DWOLFSSL_VALIDATE_FFC_IMPORT -DHAVE_FFDHE_Q -DHAVE_FFDHE_2048
+                -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192
+                -DHAVE_DH_DEFAULT_PARAMS
+
+                -DHAVE_HKDF -DHAVE_PBKDF2 -DHAVE_HASHDRBG -DWC_SRTP_KDF -DWOLFSSL_SRTP
+
+                -DHAVE_AESGCM -DGCM_TABLE_4BIT -DWOLFSSL_AESGCM_STREAM -DHAVE_AESCCM
+                -DWOLFSSL_AES_COUNTER -DWOLFSSL_CMAC -DWOLFSSL_AES_OFB -DWOLFSSL_AES_CFB
+                -DWOLFSSL_AES_XTS -DWOLFSSL_AESXTS_STREAM -DWOLFSSL_AES_DIRECT
+                -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP -DWOLFSSL_AES_XTS -DHAVE_AES_KEYWRAP
+
+                -DHAVE_ED25519 -DHAVE_ED25519_KEY_IMPORT -DHAVE_ED448 -DHAVE_ED448_KEY_IMPORT
+                -DWOLFSSL_ED448_STREAMING_VERIFY
+
+                -DHAVE_CURVE25519 -DHAVE_CURVE448
+
+                -DWOLFSSL_SHA224 -DWOLFSSL_SHA384 -DWOLFSSL_SHA512 -DWOLFSSL_NOSHA512_224
+                -DWOLFSSL_NOSHA512_256 -DWOLFSSL_SHA3 -DWOLFSSL_SHAKE128 -DWOLFSSL_SHAKE256
+
+                -DNO_DSA -DNO_RC4 -DNO_MD4 -DNO_DES3 -DNO_DES3_TLS_SUITES
+
                 -DSIZEOF_LONG=4 -DSIZEOF_LONG_LONG=8 -DWOLFSSL_CUSTOM_CONFIG
 
                 # For gethostbyname()
@@ -175,12 +195,11 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
                 # Enable below options for wolfSSL debug logging
                 #-DDEBUG_WOLFSSL -DWOLFSSL_ANDROID_DEBUG
 
-                # Below options are added only for wolfCrypt test and benchmark
-                # applications. These can be left off / removed when integrating
-                # into a real-world application. Add -DNO_FILESYSTEM to disable
-                # file system use for wolfCrypt test, but make sure to remove
-                # this define in production applications as filesystem access
-                # is required for wolfJCE use.
+                # Below options are added only for wolfCrypt test and benchmark applications.
+                # These can be left off / removed when integrating into a real-world application.
+                # Add -DNO_FILESYSTEM to disable file system use for wolfCrypt test, but make sure
+                # to remove this define in production applications as filesystem access is required
+                # for wolfJSSE use.
                 -DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256
                 -DNO_WRITE_TEMP_FILES -DNO_MAIN_DRIVER
         )
@@ -196,7 +215,8 @@ elseif("${WOLFSSL_MATH_LIB}" MATCHES "spmath")
                 -DWOLFSSL_HAVE_SP_RSA -DWOLFSSL_SP_4096
                 -DWOLFSSL_HAVE_SP_DH
                 -DWOLFSSL_HAVE_SP_ECC -DWOLFSSL_SP_384 -DWOLFSSL_SP_521
-                -DWOLFSSL_SP_LARGE_CODE)
+                -DWOLFSSL_SP_LARGE_CODE
+                -DFP_MAX_BITS=16384 -DSP_INT_BITS=8192)
 
         # SP Math architecture-specific settings (ex: assembly optimizations)
         if("${ANDROID_ABI}" MATCHES "arm64-v8a")
@@ -250,16 +270,21 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wolfcrypt_first.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/hmac.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/random.c)
-        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha256.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/kdf.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/rsa.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ecc.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/aes.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha256.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha512.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha3.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/dh.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/cmac.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/curve448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ed448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/curve25519.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ed25519.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pwdbased.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fips.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fips_test.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wolfcrypt_last.c)
@@ -283,9 +308,18 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/memory.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/asn.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/coding.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/md5.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pwdbased.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pkcs12.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/tfm.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_lms.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_lms_impl.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_xmss.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_xmss_impl.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fe_operations.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ge_operations.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fe_448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ge_448.c)
 endif()
 
 # wolfSSL will be compiled as a SHARED library

--- a/README.md
+++ b/README.md
@@ -35,7 +35,16 @@ $ make check
 $ sudo make install
 ```
 
-**wolfSSL FIPSv2 Build**:
+**wolfSSL FIPSv2 (FIPS 140-2 Cert 3389) Build**:
+
+```
+$ cd wolfssl-x.x.x-commercial-fips
+$ ./configure --enable-fips=v2 --enable-jni
+$ make check
+$ sudo make install
+```
+
+**wolfSSL FIPSv5 (FIPS 140-3 Cert 4718) Build**:
 
 ```
 $ cd wolfssl-x.x.x-commercial-fips
@@ -62,7 +71,7 @@ on building with Maven. Continue reading here for instructions to build with
 ant.
 
 1) Compile the native wolfCrypt JNI object files. Two makefiles are distributed,
-one for Linux (`makefile.linux`) and one for Mac OSX (`makefile.macosx`). First
+one for Linux (`makefile.linux`) and one for macOS (`makefile.macosx`). First
 copy the makefile for your platform to a file called `makefile`:
 
 ```
@@ -208,7 +217,7 @@ on the current release):
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfcrypt-jni</artifactId>
-            <version>1.7.0-SNAPSHOT</version>
+            <version>1.8.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/README_JCE.md
+++ b/README_JCE.md
@@ -292,11 +292,15 @@ The example can then be run using:
 ```
 $ ./examples/provider/ProviderTest.sh
 ```
+
 **CryptoBenchmark**
 
-This example benchmarks the performance of cryptographic operations using the wolfJCE provider. It tests AES-CBC with 256-bit key encryption/decryption operations.
+This example benchmarks the performance of cryptographic operations using the
+wolfJCE provider. It tests AES-CBC with 256-bit key encryption/decryption
+operations.
 
 Build and run:
+
 ```
 # From wolfcrypt-jni root directory
 make                      # Build native library
@@ -305,7 +309,8 @@ ant build-jce-release     # Build JCE JAR
 # Run benchmark
 ./examples/provider/CryptoBenchmark.sh
 ```
-This script requires for JAVA_HOME to be set.
+
+This script requires for `JAVA_HOME` to be set.
 
 For Bouncy Castle comparison testing:
 
@@ -314,17 +319,24 @@ CryptoBenchmark.sh will prompt with the following:
 ```
 Would you like to download Bouncy Castle JARs? (y/n)
 ```
-If you respond with 'y', the script will download the Bouncy Castle JARs and run the benchmark with Bouncy Castle. At the end of the benchmark, the script will prompt whether or not to remove the Bouncy Castle JAR files.
+
+If you respond with 'y', the script will download the Bouncy Castle JARs and
+run the benchmark with Bouncy Castle. At the end of the benchmark, the script
+will prompt whether or not to remove the Bouncy Castle JAR files.
 
 If you prefer to download the JARs manually, follow the instructions below:
 
 Visit [bouncy-castle-java](https://www.bouncycastle.org/download/bouncy-castle-java/)
+
 Download:
+
 ```
 bcprov-jdk18on-1.79.jar # Bouncy Castle Provider
 bctls-jdk18on-1.79.jar  # Bouncy Castle DTLS/TLS API/JSSE Provider
 ```
+
 Copy jar files to wolfcrypt-jni/lib/:
+
 ```
 cp bcprov-jdk18on-1.79.jar wolfcrypt-jni/lib
 cp bctls-jdk18on-1.79.jar wolfcrypt-jni/lib

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.7" />
+    <property name="implementation.version" value="1.8" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.7.0-SNAPSHOT</version>
+	<version>1.8.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
     <url>https://www.wolfssl.com</url>

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -37,7 +37,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.7, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.8, "wolfCrypt JCE Provider");
         registerServices();
     }
 

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
@@ -64,14 +64,14 @@ public class WolfObject {
         /* Load wolfcryptjni library */
         System.loadLibrary("wolfcryptjni");
 
+        /* initialize native wolfCrypt library */
+        init();
+
         /* Run FIPS CAST if we are in FIPS mode. Will only forcefully
          * be run once - Fips class keeps track of a successful run. */
         if (Fips.enabled) {
             Fips.runAllCast_fips();
         }
-
-        /* initialize native wolfCrypt library */
-        init();
     }
 
     /**


### PR DESCRIPTION
This PR includes prep work for the wolfCrypt JNI/JCE 1.8 release:

- Update ChangeLog with 1.8 release notes
- Update Android Studio CMakeLists.txt with proper build config for latest wolfSSL FIPS Ready
- Update README.md with note about FIPSv5
- Bump version to 1.8

Tested against release cycle items, including:

- wolfSSL master, 5.7.6, FIPSv2, FIPSv5, FIPS Ready
- Java 8, 11, 17, 20, 22, 23
- Facebook Infer (Mac)
- Android Studio IDE project
- Windows Visual Studio build