### PR TITLE
JCE: add KeyGenerator implementation for AES and HMAC

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -127,6 +127,13 @@ The JCE provider currently supports the following algorithms:
         DH
         ECDH
 
+    KeyGenerator
+        AES
+        HmacSHA1
+        HmacSHA256
+        HmacSHA384
+        HmacSHA512
+
     KeyPairGenerator Class
         RSA
         EC

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -65,6 +65,7 @@ infer --fail-on-issue run -- javac \
     src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java \
@@ -90,8 +91,10 @@ if [ "$RETVAL" == '0' ] && [ "$KEEP" == 'no' ]; then
     rm -r ./infer-out
 fi
 
-if [ "$RETVAL" == '2' ]; then
+if [ "$RETVAL" == '1' ] || [ "$RETVAL" == '2' ]; then
     # GitHub Actions expects return of 1 to mark step as failure
     exit 1
 fi
+
+exit 0
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
@@ -1,0 +1,304 @@
+/* WolfCryptKeyGenerator.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jce;
+
+import com.wolfssl.wolfcrypt.Fips;
+import com.wolfssl.wolfcrypt.Aes;
+import com.wolfssl.wolfcrypt.Sha256;
+import com.wolfssl.wolfcrypt.Sha384;
+import com.wolfssl.wolfcrypt.Sha512;
+import javax.crypto.KeyGeneratorSpi;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.InvalidParameterException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * wolfCrypt JCE KeyGenerator implementation.
+ */
+public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
+
+    enum AlgoType {
+        WC_INVALID,
+        WC_AES,
+        WC_HMAC_SHA1,
+        WC_HMAC_SHA256,
+        WC_HMAC_SHA384,
+        WC_HMAC_SHA512
+    }
+
+    private AlgoType algoType = AlgoType.WC_INVALID;
+    private String algString = null;
+
+    private int keySizeBits = 0;
+    private AlgorithmParameterSpec algoParams = null;
+    private SecureRandom random = null;
+
+    /**
+     * Internal private constructor for WolfCryptKeyGenerator.
+     *
+     * Default key sizes are set up to match the defaults of SunJCE.
+     *
+     * @param type algorithm type, from AlgoType enum.
+     */
+    private WolfCryptKeyGenerator(AlgoType type) {
+        switch (type) {
+            case WC_AES:
+                this.algString = "AES";
+                this.keySizeBits = (Aes.BLOCK_SIZE * 8);
+                break;
+            case WC_HMAC_SHA1:
+                this.algString = "HmacSHA1";
+                /* SunJCE default key size for HmacSHA1 is 64 bytes */
+                this.keySizeBits = (Sha512.DIGEST_SIZE * 8);
+                break;
+            case WC_HMAC_SHA256:
+                this.algString = "HmacSHA256";
+                this.keySizeBits = (Sha256.DIGEST_SIZE * 8);
+                break;
+            case WC_HMAC_SHA384:
+                this.algString = "HmacSHA384";
+                this.keySizeBits = (Sha384.DIGEST_SIZE * 8);
+                break;
+            case WC_HMAC_SHA512:
+                this.algString = "HmacSHA512";
+                this.keySizeBits = (Sha512.DIGEST_SIZE * 8);
+                break;
+        }
+
+        log("created KeyGenerator(" + this.algString + ")");
+        this.algoType = type;
+    }
+
+    /*
+     * Log debug messages, if debug is enabled.
+     *
+     * @param msg Message string to log
+     */
+    private void log(String msg) {
+        WolfCryptDebug.print("[KeyGenerator, " + algString + "] " + msg);
+    }
+
+    /**
+     * Sanitize key size depending on algorithm type.
+     *
+     * @param keysize key size used for key generation, provided in bits.
+     *
+     * @throws InvalidParameterException if key size is invalid for this
+     *         algorithm.
+     */
+    private void sanitizeKeySize(int keysize)
+        throws InvalidParameterException {
+
+        if (this.algoType == AlgoType.WC_AES) {
+            if (keysize != 128 && keysize != 192 && keysize != 256) {
+                throw new InvalidParameterException(
+                    "Invalid AES key size: " + keysize + " bits");
+            }
+        }
+    }
+
+    /**
+     * Sanitize SecureRandom object if in FIPS mode to ensure we are
+     * using wolfCrypt FIPS DRBG.
+     *
+     * @param random SecureRandom object used for key generation.
+     *
+     * @throws InvalidParameterException if on top of wolfCrypt FIPS
+     *         and SecureRandom provider is not wolfJCE.
+     */
+    private void sanitizeSecureRandom(SecureRandom random)
+        throws InvalidParameterException {
+
+        if (Fips.enabled && (random != null)) {
+            String randomProvider = random.getProvider().getName();
+            if (!randomProvider.equals("wolfJCE")) {
+                throw new InvalidParameterException(
+                    "SecureRandom provider must be wolfJCE if " +
+                    "using wolfCrypt FIPS, current = " + randomProvider);
+            }
+        }
+    }
+
+    /**
+     * Initialize the KeyGenerator.
+     *
+     * @param random SecureRandom object used for key generation.
+     */
+    @Override
+    protected void engineInit(SecureRandom random) {
+        this.random = random;
+    }
+
+    /**
+     * Initialize the KeyGenerator with given AlgorithmParameterSpec and
+     * SecureRandom object.
+     *
+     * @param params AlgorithmParameterSpec object used for key generation.
+     * @param random SecureRandom object used for key generation.
+     *
+     * @throws InvalidAlgorithmParameterException if params is invalid or
+     *        not supported by this KeyGenerator.
+     */
+    @Override
+    protected void engineInit(AlgorithmParameterSpec params,
+        SecureRandom random) throws InvalidAlgorithmParameterException {
+
+        throw new InvalidAlgorithmParameterException(
+            "Key generation (" + algString + ") does not support " +
+            "AlgorithmParameterSpec");
+    }
+
+    /**
+     * Initialize the KeyGenerator with given key size and SecureRandom object.
+     *
+     * @param keysize key size used for key generation, provided in bits.
+     * @param random SecureRandom object used for key generation.
+     *
+     * @throws InvalidParameterException if key size is invalid or
+     *         not supported.
+     */
+    @Override
+    protected void engineInit(int keysize, SecureRandom random)
+        throws InvalidParameterException {
+
+        /* Sanitize key size, will throw exception if invalid for algo */
+        sanitizeKeySize(keysize);
+
+        /* If using wolfCrypt FIPS, make sure this is our SecureRandom */
+        sanitizeSecureRandom(random);
+
+        this.keySizeBits = keysize;
+        this.random = random;
+    }
+
+    /**
+     * Generate a secret key.
+     *
+     * @return newly generated SecretKey object.
+     */
+    @Override
+    protected SecretKey engineGenerateKey() {
+
+        byte[] keyArr = null;
+
+        try {
+            if (this.random == null) {
+                this.random = SecureRandom.getInstance("HashDRBG", "wolfJCE");
+            }
+        } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            log("Failed to get wolfJCE SecureRandom(HashDRBG)");
+            return null;
+        }
+
+        keyArr = new byte[(this.keySizeBits + 7) / 8];
+        this.random.nextBytes(keyArr);
+
+        log("Generating key: " + keyArr.length + " bytes");
+
+        switch (this.algoType) {
+            case WC_AES:
+            case WC_HMAC_SHA1:
+            case WC_HMAC_SHA256:
+            case WC_HMAC_SHA384:
+            case WC_HMAC_SHA512:
+                return new SecretKeySpec(keyArr, this.algString);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * KeyGenerator(AES) class, called by WolfCryptProvider.
+     */
+    public static final class wcAESKeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcAESKeyGenerator.
+         */
+        public wcAESKeyGenerator() {
+            super(AlgoType.WC_AES);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA1) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha1KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha1KeyGenerator.
+         */
+        public wcHMACSha1KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA1);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA256) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha256KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha256KeyGenerator.
+         */
+        public wcHMACSha256KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA256);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA384) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha384KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha384KeyGenerator.
+         */
+        public wcHMACSha384KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA384);
+        }
+    }
+
+    /**
+     * Key Generator(HmacSHA512) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha512KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha512KeyGenerator.
+         */
+        public wcHMACSha512KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA512);
+        }
+    }
+}
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -186,6 +186,18 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfCryptKeyAgreement$wcECDH");
         }
 
+        /* KeyGenerator */
+        put("KeyGenerator.AES",
+            "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcAESKeyGenerator");
+        put("KeyGenerator.HmacSHA1",
+            "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha1KeyGenerator");
+        put("KeyGenerator.HmacSHA256",
+            "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha256KeyGenerator");
+        put("KeyGenerator.HmacSHA384",
+            "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha384KeyGenerator");
+        put("KeyGenerator.HmacSHA512",
+            "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha512KeyGenerator");
+
         /* KeyPairGenerator */
         if (FeatureDetect.RsaKeyGenEnabled()) {
             put("KeyPairGenerator.RSA",

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyGeneratorTest.java
@@ -1,0 +1,286 @@
+/* wolfCryptKeyGeneratorTest.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jce.test;
+
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.Test;
+import org.junit.BeforeClass;
+
+import java.security.Security;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.InvalidParameterException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchProviderException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import com.wolfssl.wolfcrypt.Fips;
+import com.wolfssl.wolfcrypt.Aes;
+import com.wolfssl.wolfcrypt.Sha256;
+import com.wolfssl.wolfcrypt.Sha384;
+import com.wolfssl.wolfcrypt.Sha512;
+import com.wolfssl.provider.jce.WolfCryptProvider;
+
+public class WolfCryptKeyGeneratorTest {
+
+    private static String[] keyAlgorithms = {
+        "AES",
+        "HmacSHA1",
+        "HmacSHA256",
+        "HmacSHA384",
+        "HmacSHA512"
+    };
+
+    private static int[] aesKeySizes = { 128, 192, 256 };
+    private static SecureRandom rand = null;
+
+    @Rule(order = Integer.MIN_VALUE)
+    public TestRule testWatcher = new TestWatcher() {
+        protected void starting(Description desc) {
+            System.out.println("\t" + desc.getMethodName());
+        }
+    };
+
+    @BeforeClass
+    public static void testProviderInstallationAtRuntime()
+        throws NoSuchAlgorithmException, NoSuchProviderException {
+
+        System.out.println("JCE WolfCryptKeyGeneratorTest Class");
+
+        /* install wolfJCE provider at runtime */
+        Security.insertProviderAt(new WolfCryptProvider(), 1);
+
+        Provider p = Security.getProvider("wolfJCE");
+        assertNotNull(p);
+
+        /* Get single static SecureRandom for use in this class */
+        rand = SecureRandom.getInstance("DEFAULT");
+    }
+
+    @Test
+    public void testGetKeyGeneratorFromProvider()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        KeyGenerator kg;
+
+        for (String alg : keyAlgorithms) {
+            kg = KeyGenerator.getInstance(alg, "wolfJCE");
+            assertNotNull(kg);
+        }
+
+        /* getting a garbage algorithm should throw an exception */
+        try {
+            kg = KeyGenerator.getInstance("NotValid", "wolfJCE");
+
+            fail("KeyGenerator.getInstance should throw " +
+                 "NoSuchAlgorithmException when given bad algorithm value");
+
+        } catch (NoSuchAlgorithmException e) { }
+    }
+
+    @Test
+    public void testAESKeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        testKeyGeneration("AES", aesKeySizes);
+        testKeyGenerationDefaultKeySize("AES", Aes.BLOCK_SIZE * 8);
+    }
+
+    @Test
+    public void testHmacSHA1KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        testKeyGeneration("HmacSHA1", new int[] { 160 });
+        /* SunJCE default key size for HmacSHA1 is 64 bytes, we match theirs */
+        testKeyGenerationDefaultKeySize("HmacSHA1", Sha512.DIGEST_SIZE * 8);
+    }
+
+    @Test
+    public void testHmacSHA256KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        testKeyGeneration("HmacSHA256", new int[] { 256 });
+        testKeyGenerationDefaultKeySize("HmacSHA256", Sha256.DIGEST_SIZE * 8);
+    }
+
+    @Test
+    public void testHmacSHA384KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        testKeyGeneration("HmacSHA384", new int[] { 384 });
+        testKeyGenerationDefaultKeySize("HmacSHA384", Sha384.DIGEST_SIZE * 8);
+    }
+
+    @Test
+    public void testHmacSHA512KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        testKeyGeneration("HmacSHA512", new int[] { 512 });
+        testKeyGenerationDefaultKeySize("HmacSHA512", Sha512.DIGEST_SIZE * 8);
+    }
+
+    /**
+     * Test that KeyGenerator generates expected default sized keys when
+     * no size is explicitly given.
+     */
+    private void testKeyGenerationDefaultKeySize(String algorithm,
+        int expectedSize) throws NoSuchProviderException,
+        NoSuchAlgorithmException {
+
+        KeyGenerator kg = null;
+        SecretKey key = null;
+
+        kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+        assertNotNull(kg);
+
+        key = kg.generateKey();
+        assertNotNull(key);
+        assertEquals(expectedSize, key.getEncoded().length * 8);
+    }
+
+    private void testKeyGeneration(String algorithm, int[] keySizes)
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        KeyGenerator kg = null;
+        SecretKey key = null;
+
+        /* Testing generation with init(int keysize) */
+        for (int size : keySizes) {
+            kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+            assertNotNull(kg);
+
+            kg.init(size);
+            key = kg.generateKey();
+
+            assertNotNull(key);
+            assertEquals(size / 8, key.getEncoded().length);
+        }
+
+        /* Testing generation with init(int keysize, SecureRandom random) */
+        for (int size : keySizes) {
+            kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+            assertNotNull(kg);
+
+            kg.init(size, rand);
+            key = kg.generateKey();
+
+            assertNotNull(key);
+            assertEquals(size / 8, key.getEncoded().length);
+        }
+
+        /* Test invalid AES size */
+        if (algorithm.equals("AES")) {
+            kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+            assertNotNull(kg);
+            try {
+                kg.init(0);
+                fail("KeyGenerator.init should throw " +
+                     "InvalidParameterException when given invalid key size");
+            } catch (InvalidParameterException e) {
+                /* expected */
+            }
+        }
+
+        /* If running under wolfCrypt FIPS, we should fail if SecureRandom is
+         * not wolfJCE */
+        if (Fips.enabled) {
+            try {
+                rand = SecureRandom.getInstance("SHA1PRNG", "SUN");
+            } catch (NoSuchProviderException e) {
+                /* skip, SUN provider not available */
+                return;
+            }
+
+            kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+            assertNotNull(kg);
+            try {
+                kg.init(keySizes[0], rand);
+                fail("KeyGenerator.init should throw " +
+                     "InvalidParameterException when given non-FIPS wolfJCE " +
+                     "SecureRandom when in FIPS mode");
+            } catch (InvalidParameterException e) {
+                /* expected */
+            }
+
+            /* Reset SecureRandom to our own (or default) */
+            rand = SecureRandom.getInstance("DEFAULT");
+        }
+
+        /* Test that we fail if given null AlgorithmParameters */
+        kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+        assertNotNull(kg);
+        try {
+            kg.init((AlgorithmParameterSpec)null);
+            fail("KeyGenerator.init should throw InvalidParameterException " +
+                 "when given AlgorithmParameters");
+        } catch (InvalidAlgorithmParameterException e) {
+            /* expected */
+        }
+
+        try {
+            kg.init(null, rand);
+            fail("KeyGenerator.init should throw InvalidParameterException " +
+                 "when given null AlgorithmParameters and SecureRandom");
+        } catch (InvalidAlgorithmParameterException e) {
+            /* expected */
+        }
+
+        /* Test that we fail if given valid non-null AlgorithmParameters */
+        kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+        assertNotNull(kg);
+        try {
+            AlgorithmParameterSpec ap = new AlgorithmParameterSpec() {};
+            kg.init(ap);
+            fail("KeyGenerator.init should throw InvalidParameterException " +
+                 "when given AlgorithmParameters");
+        } catch (InvalidAlgorithmParameterException e) {
+            /* expected */
+        }
+
+        /* Generate 10 keys and make sure they are different, sanity check */
+        kg = KeyGenerator.getInstance(algorithm, "wolfJCE");
+        assertNotNull(kg);
+        kg.init(keySizes[0], rand);
+
+        SecretKey[] keys = new SecretKey[10];
+        for (int i = 0; i < 10; i++) {
+            keys[i] = kg.generateKey();
+            assertNotNull(keys[i]);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            for (int j = i + 1; j < keys.length; j++) {
+                assertFalse(keys[i].equals(keys[j]));
+                assertFalse(java.util.Arrays.equals(keys[i].getEncoded(),
+                                                    keys[j].getEncoded()));
+            }
+        }
+    }
+}
+

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfJCETestSuite.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfJCETestSuite.java
@@ -38,6 +38,7 @@ import org.junit.runners.Suite.SuiteClasses;
     WolfCryptMacTest.class,
     WolfCryptCipherTest.class,
     WolfCryptKeyAgreementTest.class,
+    WolfCryptKeyGeneratorTest.class,
     WolfCryptKeyPairGeneratorTest.class,
     WolfCryptPKIXCertPathValidatorTest.class,
     WolfSSLKeyStoreTest.class


### PR DESCRIPTION
This PR implements `KeyGenerator` support in wolfJCE for the following algorithms:
- AES
- HmacSHA1
- HmacSHA256
- HmacSHA384
- HmacSHA512

This will use wolfJCE's `SecureRandom` internally, which if using wolfCrypt FIPS 140-2/3 will use the validated `Hash_DRBG` implementation. This implementation includes a sanity check that if running in FIPS mode and `SecureRandom` is not provided by `wolfJCE`, an exception is thrown when trying to create the `KeyGenerator`.

Test code has been added in `src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyGeneratorTest.java`.