### PR TITLE
JNI/JCE: fix warnings reported by Cursor/VSCode

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -26,7 +26,6 @@ import javax.crypto.KeyAgreementSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.DHParameterSpec;
-import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.DESKeySpec;
 import javax.crypto.spec.DESedeKeySpec;
@@ -47,8 +46,6 @@ import java.security.interfaces.ECPrivateKey;
 
 import com.wolfssl.wolfcrypt.Dh;
 import com.wolfssl.wolfcrypt.Ecc;
-
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE Key Agreement wrapper
@@ -236,9 +233,7 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
     protected int engineGenerateSecret(byte[] sharedSecret, int offset)
         throws IllegalStateException, ShortBufferException {
 
-        int  ret   = 0;
         byte tmp[] = null;
-        long sz[]  = null;
 
         if (this.state != EngineState.WC_PUBKEY_DONE)
             throw new IllegalStateException(
@@ -355,7 +350,6 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
     private void wcInitDHParams(Key key, AlgorithmParameterSpec params)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
 
-        int ret = 0;
         byte paramP[] = null;
         byte paramG[] = null;
         byte dhPriv[] = null;
@@ -432,8 +426,6 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
 
     private void getCurveFromSpec(AlgorithmParameterSpec spec)
         throws InvalidAlgorithmParameterException {
-
-        int fieldSz = 0;
 
         if (spec instanceof ECGenParameterSpec) {
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -28,18 +28,13 @@ import java.security.KeyPair;
 import java.security.InvalidAlgorithmParameterException;
 
 import java.security.SecureRandom;
-import java.security.AlgorithmParameters;
 import java.security.spec.AlgorithmParameterSpec;
-import java.security.Key;
-import java.security.KeyPair;
 import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
-import java.security.spec.InvalidKeySpecException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.interfaces.ECPrivateKey;
@@ -55,8 +50,6 @@ import com.wolfssl.wolfcrypt.Rsa;
 import com.wolfssl.wolfcrypt.Ecc;
 import com.wolfssl.wolfcrypt.Dh;
 import com.wolfssl.wolfcrypt.Rng;
-
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE KeyPairGenerator wrapper class

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
@@ -29,15 +29,12 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.SecretKey;
 
-import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.Md5;
 import com.wolfssl.wolfcrypt.Sha;
 import com.wolfssl.wolfcrypt.Sha256;
 import com.wolfssl.wolfcrypt.Sha384;
 import com.wolfssl.wolfcrypt.Sha512;
 import com.wolfssl.wolfcrypt.Hmac;
-
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE Mac wrapper
@@ -53,7 +50,6 @@ public class WolfCryptMac extends MacSpi {
     }
 
     private Hmac hmac = null;
-    private HmacType hmacType = null;
     private int nativeHmacType = 0;
     private int digestSize = 0;
 
@@ -63,7 +59,6 @@ public class WolfCryptMac extends MacSpi {
     private WolfCryptMac(HmacType type)
         throws NoSuchAlgorithmException {
 
-        this.hmacType = type;
         hmac = new Hmac();
 
         switch (type) {
@@ -125,7 +120,6 @@ public class WolfCryptMac extends MacSpi {
     protected void engineInit(Key key, AlgorithmParameterSpec params)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
 
-        int ret = 0;
         byte[] encodedKey;
 
         /* key must be of type SecretKey */

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -21,12 +21,10 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
 import java.security.MessageDigestSpi;
 import javax.crypto.ShortBufferException;
 
 import com.wolfssl.wolfcrypt.Md5;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE MD5 MessageDigest wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -21,12 +21,10 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
 import java.security.MessageDigestSpi;
 import javax.crypto.ShortBufferException;
 
 import com.wolfssl.wolfcrypt.Sha;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE SHA-1 MessageDigest wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -21,12 +21,10 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
 import java.security.MessageDigestSpi;
 import javax.crypto.ShortBufferException;
 
 import com.wolfssl.wolfcrypt.Sha256;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE SHA2-256 MessageDigest wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -21,12 +21,10 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
 import java.security.MessageDigestSpi;
 import javax.crypto.ShortBufferException;
 
 import com.wolfssl.wolfcrypt.Sha384;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE SHA2-384 MessageDigest wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -21,12 +21,10 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
 import java.security.MessageDigestSpi;
 import javax.crypto.ShortBufferException;
 
 import com.wolfssl.wolfcrypt.Sha512;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE SHA2-512 MessageDigest wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
@@ -23,13 +23,12 @@ package com.wolfssl.provider.jce;
 
 import java.util.Arrays;
 import java.security.spec.InvalidKeySpecException;
-import javax.security.auth.Destroyable;
 import javax.crypto.interfaces.PBEKey;
 
 /**
  * wolfCrypt PBEKey implementation.
  */
-public class WolfCryptPBEKey implements PBEKey, Destroyable {
+public class WolfCryptPBEKey implements PBEKey {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -46,14 +46,12 @@ import java.security.cert.PKIXCertPathValidatorResult;
 import java.security.cert.CRL;
 import java.security.cert.X509CRL;
 import java.security.cert.X509CRLSelector;
-import java.security.InvalidAlgorithmParameterException;
 import javax.security.auth.x500.X500Principal;
 
 import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.WolfSSLCertManager;
 import com.wolfssl.wolfcrypt.WolfCryptException;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfJCE implementation of CertPathValidator for PKIX (X.509)
@@ -265,7 +263,6 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
 
         int i = 0;
         List<PKIXCertPathChecker> pathCheckers = null;
-        PKIXCertPathChecker checker = null;
 
         if (cert == null || params == null) {
             throw new CertPathValidatorException(

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.security.SecureRandomSpi;
 
 import com.wolfssl.wolfcrypt.Rng;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE RNG/SecureRandom wrapper

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
@@ -36,7 +36,6 @@ import java.security.spec.InvalidKeySpecException;
 
 import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.Pwdbased;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE SecretKeyFactory implementation.
@@ -434,12 +433,6 @@ public class WolfCryptSecretKeyFactory extends SecretKeyFactorySpi {
     @Override
     protected synchronized KeySpec engineGetKeySpec(SecretKey key,
         Class<?> keySpec) throws InvalidKeySpecException {
-
-        PBEKey pKey = null;
-        int iterations = 0;
-        char[] password = null;
-        byte[] salt = null;
-        byte[] encoded = null;
 
         log("returning KeySpec from SecretKey in requested type");
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.provider.jce;
 
-import java.util.Arrays;
-
 import java.security.SignatureSpi;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -38,7 +36,6 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.ShortBufferException;
 
-import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.Asn;
 import com.wolfssl.wolfcrypt.Md5;
 import com.wolfssl.wolfcrypt.Sha;
@@ -49,8 +46,6 @@ import com.wolfssl.wolfcrypt.Rsa;
 import com.wolfssl.wolfcrypt.Ecc;
 import com.wolfssl.wolfcrypt.Rng;
 import com.wolfssl.wolfcrypt.WolfCryptException;
-
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfCrypt JCE Signature wrapper
@@ -76,9 +71,6 @@ public class WolfCryptSignature extends SignatureSpi {
     private int SHA256h = 414;
     private int SHA384h = 415;
     private int SHA512h = 416;
-
-    /* internal asn object */
-    private Asn asn = null;
 
     /* internal key objects */
     private Rsa rsa = null;
@@ -120,9 +112,6 @@ public class WolfCryptSignature extends SignatureSpi {
             this.rng = new Rng();
             this.rng.init();
         }
-
-        /* init asn object */
-        asn = new Asn();
 
         /* init hash type */
         switch (dtype) {
@@ -179,9 +168,6 @@ public class WolfCryptSignature extends SignatureSpi {
     private void wolfCryptInitPrivateKey(PrivateKey key, byte[] encodedKey)
         throws InvalidKeyException {
 
-        int ret;
-        long[] idx = {0};
-
         switch (this.keyType) {
 
             case WC_RSA:
@@ -203,9 +189,6 @@ public class WolfCryptSignature extends SignatureSpi {
     private void wolfCryptInitPublicKey(PublicKey key, byte[] encodedKey)
         throws InvalidKeyException {
 
-        int ret;
-        long[] idx = {0};
-
         switch(this.keyType) {
 
             case WC_RSA:
@@ -226,7 +209,6 @@ public class WolfCryptSignature extends SignatureSpi {
     protected synchronized void engineInitSign(PrivateKey privateKey)
         throws InvalidKeyException {
 
-        int    ret;
         byte[] encodedKey;
 
         if (this.keyType == KeyType.WC_RSA &&
@@ -293,9 +275,7 @@ public class WolfCryptSignature extends SignatureSpi {
     protected synchronized void engineInitVerify(PublicKey publicKey)
         throws InvalidKeyException {
 
-        int    ret;
         byte[] encodedKey;
-        long[] idx = {0};
 
         if (this.keyType == KeyType.WC_RSA &&
                 !(publicKey instanceof RSAPublicKey)) {
@@ -369,7 +349,6 @@ public class WolfCryptSignature extends SignatureSpi {
     @Override
     protected synchronized byte[] engineSign() throws SignatureException {
 
-        int ret = 0;
         int encodedSz = 0;
 
         byte[] digest    = new byte[this.digestSz];
@@ -493,7 +472,6 @@ public class WolfCryptSignature extends SignatureSpi {
     protected synchronized boolean engineVerify(byte[] sigBytes)
         throws SignatureException {
 
-        int    ret = 0;
         long   encodedSz = 0;
         boolean verified = true;
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
@@ -33,7 +32,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.Key;
 import java.security.KeyStoreSpi;
 import java.security.PrivateKey;
@@ -42,7 +40,6 @@ import java.security.KeyFactory;
 import java.security.Security;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.security.UnrecoverableEntryException;
 import java.security.KeyStoreException;
 import java.security.NoSuchProviderException;
 import java.security.InvalidKeyException;
@@ -57,7 +54,6 @@ import java.security.cert.CertificateEncodingException;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -72,7 +68,6 @@ import com.wolfssl.wolfcrypt.Pwdbased;
 import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.WolfSSLCertManager;
 import com.wolfssl.wolfcrypt.WolfCryptException;
-import com.wolfssl.provider.jce.WolfCryptDebug;
 
 /**
  * wolfSSL KeyStore implementation (WKS).
@@ -638,7 +633,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         KeyFactory keyFact = null;
 
         SecretKey sKey = null;
-        SecretKeySpec skSpec = null;
 
         log("returning Key entry for alias: " + alias);
 
@@ -1640,7 +1634,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         int saltLen = 0;
         int hmacLen = 0;
         int iterations = 0;
-        byte[] streamBytes = null;
         byte[] encodedEntry = null;
         byte[] salt = null;
         byte[] hmac = null;
@@ -1861,9 +1854,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         Certificate[] chain;    /* cert chain matching this private key */
         Date creationDate;      /* creation date for this object */
         byte[] hmacSha512;      /* HMAC calculated over members and lengths */
-
-        protected WKSPrivateKey() {
-        }
 
         /**
          * Create new WKSPrivateKey from plaintext key and certificate chain,
@@ -2336,7 +2326,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         protected WKSCertificate(byte[] encoded)
             throws IOException, CertificateException {
 
-            int i;
             int tmp = 0;
             byte[] tmpArr = null;
             String tmpStr = null;
@@ -2344,7 +2333,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
             ByteArrayInputStream certStream = null;
             DataInputStream dis = null;
             CertificateFactory cf = null;
-            Certificate tmpCert = null;
 
             if (encoded == null || encoded.length == 0) {
                 throw new IllegalArgumentException(
@@ -2406,7 +2394,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         protected synchronized byte[] getEncoded()
             throws IOException, CertificateEncodingException {
 
-            int i;
             byte[] out = null;
             ByteArrayOutputStream bos = null;
             DataOutputStream dos = null;
@@ -2471,9 +2458,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         String keyAlgo = null;      /* SecretKey.getAlgorithm() */
         Date creationDate = null;   /* creation date for this object */
         byte[] hmacSha512 = null;   /* HMAC over members and lengths */
-
-        protected WKSSecretKey() {
-        }
 
         /**
          * Create new WKSSecretKey from plaintext key, encrypt/protect using
@@ -2595,12 +2579,8 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         protected WKSSecretKey(byte[] encoded)
             throws IOException, CertificateException {
 
-            int i = 0;
             int tmp = 0;
-            byte[] tmpArr = null;
-            String tmpStr = null;
             ByteArrayInputStream bis = null;
-            ByteArrayInputStream certStream = null;
             DataInputStream dis = null;
 
             if (encoded == null || encoded.length == 0) {
@@ -2711,7 +2691,6 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
         protected synchronized byte[] getEncoded(boolean withHMAC)
             throws IOException, CertificateEncodingException {
 
-            int i;
             byte[] out = null;
             ByteArrayOutputStream bos = null;
             DataOutputStream dos = null;

--- a/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import java.security.InvalidAlgorithmParameterException;
-
 /**
  * Wrapper for the native WolfCrypt ChaCha implementation.
  */

--- a/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Curve25519.java
@@ -21,11 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import java.security.InvalidAlgorithmParameterException;
-import java.security.spec.EllipticCurve;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECFieldFp;
-
 /**
  * Wrapper for the native WolfCrypt Curve25519 implementation.
  */

--- a/src/main/java/com/wolfssl/wolfcrypt/Dh.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Dh.java
@@ -311,8 +311,6 @@ public class Dh extends NativeStruct {
     public synchronized byte[] makeSharedSecret(Dh pubKey)
         throws WolfCryptException, IllegalStateException {
 
-        byte[] publicKey = null;
-
         if (pubKey == null) {
             throw new IllegalStateException(
                 "Provided public key is null");

--- a/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
@@ -26,8 +26,6 @@ import java.security.spec.EllipticCurve;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECFieldFp;
 
-import com.wolfssl.wolfcrypt.Rng;
-
 /**
  * Wrapper for the native WolfCrypt ECC implementation
  */

--- a/src/main/java/com/wolfssl/wolfcrypt/Ed25519.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ed25519.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import java.security.InvalidAlgorithmParameterException;
-
 /**
  * Wrapper for the native WolfCrypt Ed25519 implementation
  */

--- a/src/main/java/com/wolfssl/wolfcrypt/Fips.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Fips.java
@@ -22,7 +22,6 @@
 package com.wolfssl.wolfcrypt;
 
 import java.nio.ByteBuffer;
-import com.wolfssl.wolfcrypt.Aes;
 
 /**
  * Thin JNI wrapper for the native WolfCrypt FIPS 140-2/3 specific APIs.

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import com.wolfssl.wolfcrypt.WolfCrypt;
-import com.wolfssl.wolfcrypt.WolfCryptException;
 import java.nio.ByteBuffer;
 
 /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Pwdbased.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Pwdbased.java
@@ -21,15 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import java.util.Enumeration;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-import java.security.cert.X509CRL;
-import java.security.cert.CRLException;
-import java.security.cert.CertificateEncodingException;
-
 /**
  * Password based key derivation class with wraps native wolfCrypt
  * pwdbased.c/h APIs.

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCryptException.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCryptException.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import com.wolfssl.wolfcrypt.WolfCryptError;
-
 /**
  * wolfCrypt exception class
  */

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfObject.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl.wolfcrypt;
 
-import com.wolfssl.wolfcrypt.Fips;
-
 /**
  * Loader for the native WolfCrypt implementation.
  * All classes in this package must inherit from it.

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
@@ -188,7 +188,6 @@ public class WolfSSLCertManager {
     public synchronized void CertManagerLoadCAKeyStore(KeyStore ks)
         throws IllegalStateException, WolfCryptException {
 
-        int ret = 0;
         int loadedCerts = 0;
 
         confirmObjectIsActive();

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -60,7 +60,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
 
-import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.provider.jce.WolfCryptProvider;
@@ -116,8 +115,7 @@ public class WolfCryptCipherTest {
         /* populate enabledJCEAlgos to test */
         for (int i = 0; i < supportedJCEAlgos.length; i++) {
             try {
-                Cipher c = Cipher.getInstance(
-                    supportedJCEAlgos[i], jceProvider);
+                Cipher.getInstance(supportedJCEAlgos[i], jceProvider);
                 enabledJCEAlgos.add(supportedJCEAlgos[i]);
 
             } catch (NoSuchAlgorithmException e) {
@@ -146,17 +144,15 @@ public class WolfCryptCipherTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                NoSuchPaddingException {
 
-        Cipher cipher;
-
         /* try to get all available options we expect to have */
         for (int i = 0; i < enabledJCEAlgos.size(); i++) {
-            cipher = Cipher.getInstance(enabledJCEAlgos.get(i), jceProvider);
+            Cipher.getInstance(enabledJCEAlgos.get(i), jceProvider);
         }
 
         /* getting a garbage algorithm should throw
          * a NoSuchAlgorithmException */
         try {
-            cipher = Cipher.getInstance("NotValid", jceProvider);
+            Cipher.getInstance("NotValid", jceProvider);
 
             fail("Cipher.getInstance should throw NoSuchAlgorithmException " +
                  "when given bad algorithm value");
@@ -2792,8 +2788,6 @@ public class WolfCryptCipherTest {
                BadPaddingException {
 
         byte[] tmp = null;
-        byte[] ciphertext = null;
-        byte[] plaintext = null;
 
         byte[] inputA = new byte[2048];
         byte[] inputB = new byte[100];
@@ -2824,7 +2818,7 @@ public class WolfCryptCipherTest {
         assertEquals(tmp.length, 0);
 
         try {
-            ciphertext = ciph.doFinal();
+            ciph.doFinal();
             fail("Cipher.doFinal should throw exception when data " +
                  "is larger than RSA key size");
         } catch (WolfCryptException | IllegalBlockSizeException e) {
@@ -2843,7 +2837,7 @@ public class WolfCryptCipherTest {
         assertEquals(tmp.length, 0);
 
         try {
-            plaintext = ciph.doFinal();
+            ciph.doFinal();
             fail("Cipher.doFinal should throw exception when data " +
                  "is larger than RSA key size");
         } catch (WolfCryptException | IllegalBlockSizeException e) {
@@ -2862,7 +2856,7 @@ public class WolfCryptCipherTest {
         assertEquals(tmp.length, 0);
 
         try {
-            ciphertext = ciph.doFinal();
+            ciph.doFinal();
             fail("Cipher.doFinal should throw exception when data " +
                  "is larger than RSA key size");
         } catch (WolfCryptException | IllegalBlockSizeException e) {
@@ -2881,7 +2875,7 @@ public class WolfCryptCipherTest {
         assertEquals(tmp.length, 0);
 
         try {
-            plaintext = ciph.doFinal();
+            ciph.doFinal();
             fail("Cipher.doFinal should throw exception when data " +
                  "is larger than RSA key size");
         } catch (WolfCryptException | IllegalBlockSizeException e) {
@@ -3030,30 +3024,6 @@ public class WolfCryptCipherTest {
             this.input = input;
             this.output = output;
             this.tag = tag;
-            this.aad = aad;
-        }
-
-        public void setKey(byte[] key) {
-            this.key = key;
-        }
-
-        public void setIV(byte[] iv) {
-            this.iv = iv;
-        }
-
-        public void setInput(byte[] input) {
-            this.input = input;
-        }
-
-        public void setOutput(byte[] output) {
-            this.output = output;
-        }
-
-        public void setTag(byte[] tag) {
-            this.tag = tag;
-        }
-
-        public void setAad(byte[] aad) {
             this.aad = aad;
         }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -31,8 +31,6 @@ import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Random;
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
@@ -108,7 +106,7 @@ public class WolfCryptKeyAgreementTest {
     /* One static SecureRandom to share */
     private static SecureRandom secureRandom = new SecureRandom();
 
-    private static void printDisabledCurves() {
+    /*private static void printDisabledCurves() {
 
         if (disabledCurves.size() > 0)
             System.out.print("KeyAgreement: skipping disabled ECC curves:\n\t");
@@ -123,7 +121,7 @@ public class WolfCryptKeyAgreementTest {
         }
 
         System.out.println("");
-    }
+    }*/
 
     @Rule(order = Integer.MIN_VALUE)
     public TestRule testWatcher = new TestWatcher() {
@@ -135,8 +133,6 @@ public class WolfCryptKeyAgreementTest {
     @BeforeClass
     public static void testProviderInstallationAtRuntime() {
 
-        int disabledCount = 0;
-
         System.out.println("JCE WolfCryptKeyAgreementTest Class");
 
         /* install wolfJCE provider at runtime */
@@ -147,10 +143,9 @@ public class WolfCryptKeyAgreementTest {
 
         /* build list of enabled curves and key sizes,
          * getCurveSizeFromName() will return 0 if curve not found */
-        Ecc tmp = new Ecc();
         for (int i = 0; i < supportedCurves.length; i++) {
 
-            int size = tmp.getCurveSizeFromName(
+            int size = Ecc.getCurveSizeFromName(
                         supportedCurves[i].toUpperCase());
 
             if (size > 0) {
@@ -160,7 +155,7 @@ public class WolfCryptKeyAgreementTest {
             }
         }
 
-        /* uncomment this line to print disabled curves */
+        /* uncomment this line and method above to print disabled curves */
         /* printDisabledCurves(); */
     }
 
@@ -168,16 +163,14 @@ public class WolfCryptKeyAgreementTest {
     public void testGetKeyAgreementFromProvider()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        KeyAgreement ka;
-
         /* try to get all available options we expect to have */
         for (int i = 0; i < wolfJCEAlgos.length; i++) {
-            ka = KeyAgreement.getInstance(wolfJCEAlgos[i], "wolfJCE");
+            KeyAgreement.getInstance(wolfJCEAlgos[i], "wolfJCE");
         }
 
         /* getting a garbage algorithm should throw an exception */
         try {
-            ka = KeyAgreement.getInstance("NotValid", "wolfJCE");
+            KeyAgreement.getInstance("NotValid", "wolfJCE");
 
             fail("KeyAgreement.getInstance should throw " +
                  "NoSuchAlgorithmException when given bad algorithm value");
@@ -272,6 +265,7 @@ public class WolfCryptKeyAgreementTest {
         int secretASz = aKeyAgree.generateSecret(secretA, 0);
         int secretBSz = bKeyAgree.generateSecret(secretB, 0);
 
+        assertEquals(secretASz, secretBSz);
         assertArrayEquals(secretA, secretB);
 
         /* now, try reusing the A object without calling init() again */
@@ -287,6 +281,7 @@ public class WolfCryptKeyAgreementTest {
         int secretA2Sz = aKeyAgree.generateSecret(secretA2, 0);
         int secretCSz  = cKeyAgree.generateSecret(secretC, 0);
 
+        assertEquals(secretA2Sz, secretCSz);
         assertArrayEquals(secretA2, secretC);
     }
 
@@ -392,14 +387,19 @@ public class WolfCryptKeyAgreementTest {
                 continue;
             }
 
-            KeyAgreement ka = KeyAgreement.getInstance("ECDH", "wolfJCE");
+            KeyAgreement ka =
+                KeyAgreement.getInstance("ECDH", "wolfJCE");
+
+            assertNotNull(ka);
         }
 
         /* Trying to use a bad curve should throw an exception */
         try {
             ecsp = new ECGenParameterSpec("invalidcurve");
             keyGen.initialize(ecsp);
-            KeyAgreement ka = KeyAgreement.getInstance("ECDH", "wolfJCE");
+            KeyAgreement ka =
+                KeyAgreement.getInstance("ECDH", "wolfJCE");
+            assertNotNull(ka);
 
             fail("Initializing KeyAgreement with invalid curve spec " +
                  "should throw exception");
@@ -478,6 +478,7 @@ public class WolfCryptKeyAgreementTest {
         int secretASz = aKeyAgree.generateSecret(secretA, 0);
         int secretBSz = bKeyAgree.generateSecret(secretB, 0);
 
+        assertEquals(secretASz, secretBSz);
         assertArrayEquals(secretA, secretB);
 
         /* now, try reusing the A object without calling init() again */
@@ -493,6 +494,7 @@ public class WolfCryptKeyAgreementTest {
         int secretA2Sz = aKeyAgree.generateSecret(secretA2, 0);
         int secretCSz  = cKeyAgree.generateSecret(secretC, 0);
 
+        assertEquals(secretA2Sz, secretCSz);
         assertArrayEquals(secretA2, secretC);
     }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -32,25 +32,18 @@ import org.junit.BeforeClass;
 import java.util.ArrayList;
 import java.math.BigInteger;
 
-import javax.crypto.KeyAgreement;
-import javax.crypto.ShortBufferException;
 import javax.crypto.spec.DHParameterSpec;
 
 import java.security.Security;
 import java.security.Provider;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
-import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.AlgorithmParameters;
-import java.security.AlgorithmParameterGenerator;
-import java.security.SecureRandom;
 import java.security.PublicKey;
 import java.security.PrivateKey;
 import java.security.KeyFactory;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.security.spec.ECGenParameterSpec;
@@ -167,7 +160,6 @@ public class WolfCryptKeyPairGeneratorTest {
 
         /* build list of enabled curves and key sizes,
          * getCurveSizeFromName() will return 0 if curve not found */
-        Ecc tmp = new Ecc();
         String[] curves = null;
 
         if (Fips.enabled && Fips.fipsVersion >= 5) {
@@ -178,7 +170,7 @@ public class WolfCryptKeyPairGeneratorTest {
 
         for (int i = 0; i < curves.length; i++) {
 
-            int size = tmp.getCurveSizeFromName(curves[i].toUpperCase());
+            int size = Ecc.getCurveSizeFromName(curves[i].toUpperCase());
 
             if (size > 0) {
                 enabledCurves.add(curves[i]);
@@ -196,8 +188,11 @@ public class WolfCryptKeyPairGeneratorTest {
 
         KeyPairGenerator kpg;
         kpg = KeyPairGenerator.getInstance("EC", "wolfJCE");
+        assertNotNull(kpg);
         kpg = KeyPairGenerator.getInstance("RSA", "wolfJCE");
+        assertNotNull(kpg);
         kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
+        assertNotNull(kpg);
 
         /* getting a garbage algorithm should throw an exception */
         try {
@@ -271,6 +266,7 @@ public class WolfCryptKeyPairGeneratorTest {
             kpg.initialize(rsaSpec);
 
             KeyPair kp = kpg.generateKeyPair();
+            assertNotNull(kp);
         }
     }
 
@@ -310,6 +306,8 @@ public class WolfCryptKeyPairGeneratorTest {
 
             KeyPair kp1 = kpg.generateKeyPair();
             KeyPair kp2 = kpg.generateKeyPair();
+            assertNotNull(kp1);
+            assertNotNull(kp2);
         }
     }
 
@@ -335,6 +333,8 @@ public class WolfCryptKeyPairGeneratorTest {
                         kp.getPublic().getEncoded()));
             PrivateKey priv = kf.generatePrivate(new PKCS8EncodedKeySpec(
                         kp.getPrivate().getEncoded()));
+            assertNotNull(pub);
+            assertNotNull(priv);
         }
     }
 
@@ -402,6 +402,7 @@ public class WolfCryptKeyPairGeneratorTest {
 
             try {
                 KeyPair kp = kpg.generateKeyPair();
+                assertNotNull(kp);
             } catch (Exception e) {
                 /* Some JDK versions' ECKeyFactory may not support all
                  * wolfCrypt's ECC curves */
@@ -446,6 +447,9 @@ public class WolfCryptKeyPairGeneratorTest {
 
             KeyPair kp1 = kpg.generateKeyPair();
             KeyPair kp2 = kpg.generateKeyPair();
+
+            assertNotNull(kp1);
+            assertNotNull(kp2);
         }
     }
 
@@ -470,6 +474,9 @@ public class WolfCryptKeyPairGeneratorTest {
                         kp.getPublic().getEncoded()));
             PrivateKey priv = kf.generatePrivate(new PKCS8EncodedKeySpec(
                         kp.getPrivate().getEncoded()));
+
+            assertNotNull(pub);
+            assertNotNull(priv);
         }
     }
 
@@ -492,6 +499,8 @@ public class WolfCryptKeyPairGeneratorTest {
 
             kpg.initialize(spec);
             KeyPair pair = kpg.generateKeyPair();
+
+            assertNotNull(pair);
         }
     }
 
@@ -540,6 +549,9 @@ public class WolfCryptKeyPairGeneratorTest {
 
         KeyPair kp1 = kpg.generateKeyPair();
         KeyPair kp2 = kpg.generateKeyPair();
+
+        assertNotNull(kp1);
+        assertNotNull(kp2);
     }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMacTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMacTest.java
@@ -32,7 +32,6 @@ import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Random;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
@@ -102,6 +101,7 @@ public class WolfCryptMacTest {
         for (int i = 0; i < wolfJCEAlgos.length; i++) {
             try {
                 mac = Mac.getInstance(wolfJCEAlgos[i], "wolfJCE");
+                assertNotNull(mac);
                 enabledAlgos.add(wolfJCEAlgos[i]);
                 enabledAlgoLengths.add(wolfJCEMacLengths[i]);
             } catch (NoSuchAlgorithmException e) {
@@ -119,6 +119,7 @@ public class WolfCryptMacTest {
         /* try to get all available options we expect to have */
         for (int i = 0; i < enabledAlgos.size(); i++) {
             mac = Mac.getInstance(enabledAlgos.get(i), "wolfJCE");
+            assertNotNull(mac);
         }
 
         /* getting a garbage algorithm should throw an exception */
@@ -961,18 +962,6 @@ public class WolfCryptMacTest {
         public HmacVector(byte[] key, byte[] input, byte[] output) {
             this.key = key;
             this.input = input;
-            this.output = output;
-        }
-
-        public void setKey(byte[] key) {
-            this.key = key;
-        }
-
-        public void setInput(byte[] input) {
-            this.input = input;
-        }
-
-        public void setOutput(byte[] output) {
             this.output = output;
         }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestMd5Test.java
@@ -72,6 +72,8 @@ public class WolfCryptMessageDigestMd5Test {
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5",
                                                           "wolfJCE");
+            assertNotNull(md5);
+
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.Md5Enabled() == false) {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha256Test.java
@@ -72,6 +72,8 @@ public class WolfCryptMessageDigestSha256Test {
         try {
             MessageDigest sha256 = MessageDigest.getInstance("SHA-256",
                                                              "wolfJCE");
+            assertNotNull(sha256);
+
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.Sha256Enabled() == false) {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha384Test.java
@@ -72,6 +72,8 @@ public class WolfCryptMessageDigestSha384Test {
         try {
             MessageDigest sha384 = MessageDigest.getInstance("SHA-384",
                                                              "wolfJCE");
+            assertNotNull(sha384);
+
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.Sha384Enabled() == false) {
@@ -84,40 +86,6 @@ public class WolfCryptMessageDigestSha384Test {
     @Test
     public void testSha384SingleUpdate()
         throws NoSuchProviderException, NoSuchAlgorithmException {
-
-        final String inputA = "abc";
-        final byte expectedA[] = new byte[] {
-            (byte)0xcb, (byte)0x00, (byte)0x75, (byte)0x3f,
-            (byte)0x45, (byte)0xa3, (byte)0x5e, (byte)0x8b,
-            (byte)0xb5, (byte)0xa0, (byte)0x3d, (byte)0x69,
-            (byte)0x9a, (byte)0xc6, (byte)0x50, (byte)0x07,
-            (byte)0x27, (byte)0x2c, (byte)0x32, (byte)0xab,
-            (byte)0x0e, (byte)0xde, (byte)0xd1, (byte)0x63,
-            (byte)0x1a, (byte)0x8b, (byte)0x60, (byte)0x5a,
-            (byte)0x43, (byte)0xff, (byte)0x5b, (byte)0xed,
-            (byte)0x80, (byte)0x86, (byte)0x07, (byte)0x2b,
-            (byte)0xa1, (byte)0xe7, (byte)0xcc, (byte)0x23,
-            (byte)0x58, (byte)0xba, (byte)0xec, (byte)0xa1,
-            (byte)0x34, (byte)0xc8, (byte)0x25, (byte)0xa7
-        };
-
-        final String inputB = "abcdefghbcdefghicdefghijdefghijkefgh" +
-                              "ijklfghijklmghijklmnhijklmnoijklmnop" +
-                              "jklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
-        final byte expectedB[] = new byte[] {
-            (byte)0x09, (byte)0x33, (byte)0x0c, (byte)0x33,
-            (byte)0xf7, (byte)0x11, (byte)0x47, (byte)0xe8,
-            (byte)0x3d, (byte)0x19, (byte)0x2f, (byte)0xc7,
-            (byte)0x82, (byte)0xcd, (byte)0x1b, (byte)0x47,
-            (byte)0x53, (byte)0x11, (byte)0x1b, (byte)0x17,
-            (byte)0x3b, (byte)0x3b, (byte)0x05, (byte)0xd2,
-            (byte)0x2f, (byte)0xa0, (byte)0x80, (byte)0x86,
-            (byte)0xe3, (byte)0xb0, (byte)0xf7, (byte)0x12,
-            (byte)0xfc, (byte)0xc7, (byte)0xc7, (byte)0x1a,
-            (byte)0x55, (byte)0x7e, (byte)0x2d, (byte)0xb9,
-            (byte)0x66, (byte)0xc3, (byte)0xe9, (byte)0xfa,
-            (byte)0x91, (byte)0x74, (byte)0x60, (byte)0x39
-        };
 
         DigestVector vectors[] = new DigestVector[] {
             new DigestVector(

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestSha512Test.java
@@ -72,6 +72,8 @@ public class WolfCryptMessageDigestSha512Test {
         try {
             MessageDigest sha512 = MessageDigest.getInstance("SHA-512",
                                                              "wolfJCE");
+            assertNotNull(sha512);
+
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.Sha512Enabled() == false) {
@@ -84,48 +86,6 @@ public class WolfCryptMessageDigestSha512Test {
     @Test
     public void testSha512SingleUpdate()
         throws NoSuchProviderException, NoSuchAlgorithmException {
-
-        final String inputA = "abc";
-        final byte expectedA[] = new byte[] {
-            (byte)0xdd, (byte)0xaf, (byte)0x35, (byte)0xa1,
-            (byte)0x93, (byte)0x61, (byte)0x7a, (byte)0xba,
-            (byte)0xcc, (byte)0x41, (byte)0x73, (byte)0x49,
-            (byte)0xae, (byte)0x20, (byte)0x41, (byte)0x31,
-            (byte)0x12, (byte)0xe6, (byte)0xfa, (byte)0x4e,
-            (byte)0x89, (byte)0xa9, (byte)0x7e, (byte)0xa2,
-            (byte)0x0a, (byte)0x9e, (byte)0xee, (byte)0xe6,
-            (byte)0x4b, (byte)0x55, (byte)0xd3, (byte)0x9a,
-            (byte)0x21, (byte)0x92, (byte)0x99, (byte)0x2a,
-            (byte)0x27, (byte)0x4f, (byte)0xc1, (byte)0xa8,
-            (byte)0x36, (byte)0xba, (byte)0x3c, (byte)0x23,
-            (byte)0xa3, (byte)0xfe, (byte)0xeb, (byte)0xbd,
-            (byte)0x45, (byte)0x4d, (byte)0x44, (byte)0x23,
-            (byte)0x64, (byte)0x3c, (byte)0xe8, (byte)0x0e,
-            (byte)0x2a, (byte)0x9a, (byte)0xc9, (byte)0x4f,
-            (byte)0xa5, (byte)0x4c, (byte)0xa4, (byte)0x9f
-        };
-
-        final String inputB = "abcdefghbcdefghicdefghijdefghijkefgh" +
-                              "ijklfghijklmghijklmnhijklmnoijklmnop" +
-                              "jklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
-        final byte expectedB[] = new byte[] {
-            (byte)0x8e, (byte)0x95, (byte)0x9b, (byte)0x75,
-            (byte)0xda, (byte)0xe3, (byte)0x13, (byte)0xda,
-            (byte)0x8c, (byte)0xf4, (byte)0xf7, (byte)0x28,
-            (byte)0x14, (byte)0xfc, (byte)0x14, (byte)0x3f,
-            (byte)0x8f, (byte)0x77, (byte)0x79, (byte)0xc6,
-            (byte)0xeb, (byte)0x9f, (byte)0x7f, (byte)0xa1,
-            (byte)0x72, (byte)0x99, (byte)0xae, (byte)0xad,
-            (byte)0xb6, (byte)0x88, (byte)0x90, (byte)0x18,
-            (byte)0x50, (byte)0x1d, (byte)0x28, (byte)0x9e,
-            (byte)0x49, (byte)0x00, (byte)0xf7, (byte)0xe4,
-            (byte)0x33, (byte)0x1b, (byte)0x99, (byte)0xde,
-            (byte)0xc4, (byte)0xb5, (byte)0x43, (byte)0x3a,
-            (byte)0xc7, (byte)0xd3, (byte)0x29, (byte)0xee,
-            (byte)0xb6, (byte)0xdd, (byte)0x26, (byte)0x54,
-            (byte)0x5e, (byte)0x96, (byte)0xe5, (byte)0x5b,
-            (byte)0x87, (byte)0x4b, (byte)0xe9, (byte)0x09
-        };
 
         DigestVector vectors[] = new DigestVector[] {
             new DigestVector(

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMessageDigestShaTest.java
@@ -74,12 +74,16 @@ public class WolfCryptMessageDigestShaTest {
             /* Try "SHA" and "SHA1" cipher strings, for SUN interop */
             MessageDigest sha = MessageDigest.getInstance("SHA",
                                                           "wolfJCE");
+            assertNotNull(sha);
 
             MessageDigest sha1 = MessageDigest.getInstance("SHA1",
                                                           "wolfJCE");
+            assertNotNull(sha1);
 
             MessageDigest shaDash1 = MessageDigest.getInstance("SHA-1",
                                                                "wolfJCE");
+            assertNotNull(shaDash1);
+
         } catch (NoSuchAlgorithmException e) {
             /* if we also detect algo is compiled out, skip tests */
             if (FeatureDetect.ShaEnabled() == false) {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
@@ -27,11 +27,9 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.Test;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import java.util.List;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -54,13 +52,11 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorResult;
-import java.security.cert.CertPathParameters;
 import java.security.cert.PKIXParameters;
 import java.security.cert.PKIXCertPathValidatorResult;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.TrustAnchor;
-import java.security.cert.PolicyNode;
 import java.security.cert.X509CertSelector;
 import java.security.cert.CRL;
 import java.security.cert.CertStore;
@@ -232,7 +228,6 @@ public class WolfCryptPKIXCertPathValidatorTest {
 
         PKIXCertPathValidatorResult pResult = null;
         TrustAnchor anchor = null;
-        PolicyNode policyTree = null;
         PublicKey pubKey = null;
 
         /* Check not null and of type PKIXCertPathValidatorResult */
@@ -247,6 +242,7 @@ public class WolfCryptPKIXCertPathValidatorTest {
         assertEquals(anchor.getTrustedCert(), expectedAnchor);
 
         /* Check PolicyTree matches expected - TODO */
+        //PolicyNode policyTree = null;
         //policyTree = pResult.getPolicyTree();
         //assertNotNull(policyTree);
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptRandomTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptRandomTest.java
@@ -74,9 +74,11 @@ public class WolfCryptRandomTest {
 
         /* HashDRBG */
         rand = SecureRandom.getInstance("HashDRBG", "wolfJCE");
+        assertNotNull(rand);
 
         /* DEFAULT */
         rand = SecureRandom.getInstance("DEFAULT", "wolfJCE");
+        assertNotNull(rand);
     }
 
     @Test
@@ -214,11 +216,9 @@ public class WolfCryptRandomTest {
         byte[] valuesA = new byte[128];
         byte[] valuesB = new byte[128];
 
-        SecureRandom rand = SecureRandom.getInstance("HashDRBG", "wolfJCE");
-
-        valuesA = rand.getSeed(valuesA.length);
+        valuesA = SecureRandom.getSeed(valuesA.length);
         for (int i = 0; i < 10; i++) {
-            valuesB = rand.getSeed(valuesB.length);
+            valuesB = SecureRandom.getSeed(valuesB.length);
 
             if(Arrays.equals(valuesA, valuesB))
                 fail("SecureRandom generated two equal consecutive arrays");
@@ -236,8 +236,6 @@ public class WolfCryptRandomTest {
         ExecutorService service = Executors.newFixedThreadPool(numThreads);
         final CountDownLatch latch = new CountDownLatch(numThreads);
         final LinkedBlockingQueue<byte[]> results = new LinkedBlockingQueue<>();
-        final SecureRandom rand = SecureRandom.getInstance(
-                                        "HashDRBG", "wolfJCE");
 
         for (int i = 0; i < numThreads; i++) {
             service.submit(new Runnable() {
@@ -246,7 +244,7 @@ public class WolfCryptRandomTest {
 
                     /* generate 1000 random arrays per thread */
                     for (int j = 0; j < 1000; j++) {
-                        tmp = rand.getSeed(tmp.length);
+                        tmp = SecureRandom.getSeed(tmp.length);
                         results.add(tmp.clone());
                     }
                     latch.countDown();

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
@@ -104,6 +104,7 @@ public class WolfCryptSecretKeyFactoryTest {
         for (int i = 0; i < wolfJCEAlgos.length; i++) {
             try {
                 kf = SecretKeyFactory.getInstance(wolfJCEAlgos[i], provider);
+                assertNotNull(kf);
                 enabledAlgos.add(wolfJCEAlgos[i]);
             } catch (NoSuchAlgorithmException e) {
                 /* algo not compiled in */
@@ -125,6 +126,7 @@ public class WolfCryptSecretKeyFactoryTest {
         /* getting a garbage algorithm should throw an exception */
         try {
             kf = SecretKeyFactory.getInstance("NotValid", provider);
+            assertNotNull(kf);
 
             fail("SecretKeyFactory.getInstance should throw " +
                  "NoSuchAlgorithmException when given bad algorithm value");
@@ -617,16 +619,8 @@ public class WolfCryptSecretKeyFactoryTest {
         throws NoSuchAlgorithmException, InvalidKeySpecException,
                NoSuchProviderException {
 
-        char[] pass = "passwordpassword".toCharArray();
-        byte[] salt = {
-            (byte)0x78, (byte)0x57, (byte)0x8E, (byte)0x5a,
-            (byte)0x5d, (byte)0x63, (byte)0xcb, (byte)0x06
-        };
-        int iterations = 2048;
-        int kLen = 192;
         PBEKeySpec spec = null;
         SecretKeyFactory sf = null;
-        SecretKey key = null;
 
         if (!FeatureDetect.Pbkdf2Enabled() ||
             !FeatureDetect.HmacSha256Enabled() ||
@@ -640,7 +634,7 @@ public class WolfCryptSecretKeyFactoryTest {
 
         /* null KeySpec should throw exception */
         try {
-            key = sf.generateSecret(spec);
+            sf.generateSecret(spec);
             fail("generateSecret() should fail with null KeySpec");
         } catch (InvalidKeySpecException e) {
             /* expected */

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
@@ -29,15 +29,11 @@ import org.junit.runner.Description;
 import org.junit.Test;
 import org.junit.BeforeClass;
 
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Random;
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import java.security.Security;
@@ -103,6 +99,7 @@ public class WolfCryptSignatureTest {
         for (int i = 0; i < wolfJCEAlgos.length; i++) {
             try {
                 sig = Signature.getInstance(wolfJCEAlgos[i], "wolfJCE");
+                assertNotNull(sig);
                 enabledAlgos.add(wolfJCEAlgos[i]);
             } catch (NoSuchAlgorithmException e) {
                 /* algo not compiled in */
@@ -119,6 +116,7 @@ public class WolfCryptSignatureTest {
         /* try to get all available options we expect to have */
         for (int i = 0; i < enabledAlgos.size(); i++) {
             sig = Signature.getInstance(enabledAlgos.get(i), "wolfJCE");
+            assertNotNull(sig);
         }
 
         /* asking for a bad algo should throw an exception */

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -66,17 +66,11 @@ import java.security.spec.InvalidKeySpecException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
-
 import com.wolfssl.provider.jce.WolfCryptProvider;
 
 public class WolfSSLKeyStoreTest {
 
     private final String storeType = "WKS";
-    private final String jksExt = ".wks";
     private static final String storeProvider = "wolfJCE";
     /* Example pass is "wolfsslpassword" instead of normal
      * "wolfSSL test" because with wolfCrypt FIPS the HMAC minimum key
@@ -957,12 +951,8 @@ public class WolfSSLKeyStoreTest {
                UnrecoverableKeyException {
 
         KeyStore store = null;
-        PrivateKey keyOut = null;
-        Certificate certOut = null;
-        Certificate[] chainOut = null;
         KeyGenerator kg = null;
         SecretKey aesKey = null;
-        SecretKey sKeyOut = null;
 
         store = KeyStore.getInstance(storeType, storeProvider);
         store.load(null, storePass.toCharArray());
@@ -1684,7 +1674,6 @@ public class WolfSSLKeyStoreTest {
             service.submit(new Runnable() {
                 @Override public void run() {
 
-                    int ret = 0;
                     KeyStore store = null;
                     PrivateKey keyOut = null;
                     Certificate certOut = null;

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
@@ -30,9 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
-import javax.crypto.ShortBufferException;
-import java.nio.ByteBuffer;
-import javax.crypto.ShortBufferException;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -255,7 +252,7 @@ public class AesGcmTest {
     @Test
     public void deprecatedConstructorThrows() {
         try {
-            AesGcm aes = new AesGcm(new byte[] {0x0});
+            new AesGcm(new byte[] {0x0});
             fail("Failed to throw expected exception");
         } catch (WolfCryptException e) {
             /* expected */
@@ -857,7 +854,6 @@ public class AesGcmTest {
             service.submit(new Runnable() {
                 @Override public void run() {
 
-                    int ret = 0;
                     AesGcm enc = new AesGcm();
                     AesGcm dec = new AesGcm();
                     byte[] cipher = new byte[2048];
@@ -929,7 +925,6 @@ public class AesGcmTest {
             service.submit(new Runnable() {
                 @Override public void run() {
 
-                    int ret = 0;
                     AesGcm enc = new AesGcm();
                     AesGcm dec = new AesGcm();
                     byte[] cipher = new byte[2048];
@@ -1000,7 +995,6 @@ public class AesGcmTest {
             service.submit(new Runnable() {
                 @Override public void run() {
 
-                    int ret = 0;
                     AesGcm enc = new AesGcm();
                     AesGcm dec = new AesGcm();
                     byte[] cipher = new byte[2048];

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 import java.nio.ByteBuffer;
-import javax.crypto.ShortBufferException;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -81,7 +80,7 @@ public class AesTest {
     @Test
     public void deprecatedConstructorThrows() {
         try {
-            Aes aes = new Aes(null, null, Aes.ENCRYPT_MODE);
+            new Aes(null, null, Aes.ENCRYPT_MODE);
             fail("Failed to throw expected exception");
         } catch (WolfCryptException e) {
             /* expected */

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ChachaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ChachaTest.java
@@ -23,10 +23,7 @@ package com.wolfssl.wolfcrypt.test;
 
 import static org.junit.Assert.*;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import javax.crypto.ShortBufferException;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -331,7 +328,6 @@ public class ChachaTest {
         };
 
         int CHACHA_BIG_TEST_SIZE = 1305;
-        byte cipher_big[] = new byte[CHACHA_BIG_TEST_SIZE];
         byte plain_big[] = new byte[CHACHA_BIG_TEST_SIZE];
         byte input_big[] = new byte[CHACHA_BIG_TEST_SIZE];
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
@@ -76,7 +76,7 @@ public class Des3Test {
     @Test
     public void deprecatedConstructorThrows() {
         try {
-            Des3 des = new Des3(null, null, Des3.ENCRYPT_MODE);
+            new Des3(null, null, Des3.ENCRYPT_MODE);
             fail("Failed to throw expected exception");
         } catch (WolfCryptException e) {
             /* expected */

--- a/src/test/java/com/wolfssl/wolfcrypt/test/DhTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/DhTest.java
@@ -32,8 +32,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.util.Arrays;
-import java.util.Random;
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -32,7 +32,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
@@ -162,7 +161,6 @@ public class EccTest {
 
     @Test
     public void eccCurveSizeFromName() {
-        Ecc alice = new Ecc();
         int size = 0;
 
         /* valid case */
@@ -204,7 +202,6 @@ public class EccTest {
     public void eccPrivateToPkcs8() {
         Ecc alice = new Ecc();
         byte[] pkcs8;
-        int size;
 
         byte[] prvKey = Util.h2b("30770201010420F8CF92"
                 + "6BBD1E28F1A8ABA1234F3274188850AD7EC7EC92"

--- a/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
@@ -34,8 +34,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Random;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
@@ -62,6 +62,7 @@ public class Md5Test {
     public static void checkMd5IsAvailable() {
         try {
             Md5 md5 = new Md5();
+            assertNotNull(md5);
             System.out.println("JNI Md5 Class");
         } catch (WolfCryptException e) {
             if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -34,7 +34,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
@@ -83,14 +82,14 @@ public class RsaTest {
     @Test
     public void deprecatedConstructorThrows() {
         try {
-            Rsa rsa = new Rsa( new byte[] {0x00} );
+            new Rsa( new byte[] {0x00} );
             fail("Failed to throw expected exception");
         } catch (WolfCryptException e) {
             /* expected */
         }
 
         try {
-            Rsa rsa = new Rsa( new byte[] {0x00}, new byte[] {0x00} );
+            new Rsa( new byte[] {0x00}, new byte[] {0x00} );
             fail("Failed to throw expected exception");
         } catch (WolfCryptException e) {
             /* expected */
@@ -163,7 +162,6 @@ public class RsaTest {
     public void rsaPrivateToPkcs8() {
         Rsa key = new Rsa();
         byte[] pkcs8;
-        int size;
         byte[] prvKey = Util.h2b(
                 "308204a40201000282010100c303d12bfe39a432453b53c8842b2a7c"
               + "749abdaa2a520747d6a636b207328ed0ba697bc6c3449ed48148"

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
@@ -62,6 +62,7 @@ public class Sha256Test {
     public static void checkSha256IsAvailable() {
         try {
             Sha256 sha = new Sha256();
+            assertNotNull(sha);
             System.out.println("JNI Sha256 Class");
         } catch (WolfCryptException e) {
             if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
@@ -62,6 +62,7 @@ public class Sha384Test {
     public static void checkSha384IsAvailable() {
         try {
             Sha384 sha = new Sha384();
+            assertNotNull(sha);
             System.out.println("JNI Sha384 Class");
         } catch (WolfCryptException e) {
             if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
@@ -62,6 +62,7 @@ public class Sha512Test {
     public static void checkSha512IsAvailable() {
         try {
             Sha512 sha = new Sha512();
+            assertNotNull(sha);
             System.out.println("JNI Sha512 Class");
         } catch (WolfCryptException e) {
             if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
@@ -62,6 +62,7 @@ public class ShaTest {
     public static void checkShaIsAvailable() {
         try {
             Sha sha = new Sha();
+            assertNotNull(sha);
             System.out.println("JNI Sha Class");
         } catch (WolfCryptException e) {
             if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/RsaFipsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/RsaFipsTest.java
@@ -47,10 +47,6 @@ public class RsaFipsTest extends FipsTest {
             .allocateDirect(WolfCrypt.SIZE_OF_2048_BITS);
     private ByteBuffer plain = ByteBuffer
             .allocateDirect(WolfCrypt.SIZE_OF_1024_BITS);
-    private ByteBuffer n = ByteBuffer
-            .allocateDirect(WolfCrypt.SIZE_OF_2048_BITS);
-    private ByteBuffer e = ByteBuffer
-            .allocateDirect(WolfCrypt.SIZE_OF_2048_BITS);
     private ByteBuffer message = ByteBuffer
             .allocateDirect(WolfCrypt.SIZE_OF_1024_BITS);
     private ByteBuffer signature = ByteBuffer


### PR DESCRIPTION
This PR fixes "Problems" reported by Cursor IDE / VSCode. Mostly around unused imports and unused variables.