### PR TITLE
JCE: Implements PBKDF2 benchmarks

### DIFF
--- a/examples/provider/CryptoBenchmark.sh
+++ b/examples/provider/CryptoBenchmark.sh
@@ -78,7 +78,7 @@ else
 fi
 
 # Run the benchmark
-java -classpath $CLASSPATH -Dsun.boot.library.path=../../../lib/ CryptoBenchmark $@
+java -XX:-TieredCompilation -XX:ReservedCodeCacheSize=1024m -classpath $CLASSPATH -Dsun.boot.library.path=../../../lib/ CryptoBenchmark $@
 
 # Always prompt for cleanup after benchmark completion if Bouncy Castle files exist
 if [ -f "../../../lib/bcprov-jdk18on-1.79.jar" ] && [ -f "../../../lib/bctls-jdk18on-1.79.jar" ]; then

--- a/examples/provider/CryptoBenchmark.sh
+++ b/examples/provider/CryptoBenchmark.sh
@@ -3,37 +3,60 @@
 # Flag to track if we downloaded BC during this session
 BC_DOWNLOADED=false
 
-# Function to download Bouncy Castle JARs
-download_bc_jars() {
-  local bc_version="1.79"
-  local lib_dir="../../../lib"
-  local bc_url="https://downloads.bouncycastle.org/java"
-
-  echo -n "Downloading Bouncy Castle JARs... "
-
-  # Create lib directory if it doesn't exist
-  mkdir -p "$lib_dir" 2>/dev/null
-
-  # Download both required JARs
-  if command -v wget >/dev/null; then
-    wget -q -P "$lib_dir" "$bc_url/bcprov-jdk18on-$bc_version.jar" 2>/dev/null &&
-      wget -q -P "$lib_dir" "$bc_url/bctls-jdk18on-$bc_version.jar" 2>/dev/null || return 1
-  elif command -v curl >/dev/null; then
-    curl -s -L -o "$lib_dir/bcprov-jdk18on-$bc_version.jar" "$bc_url/bcprov-jdk18on-$bc_version.jar" 2>/dev/null &&
-      curl -s -L -o "$lib_dir/bctls-jdk18on-$bc_version.jar" "$bc_url/bctls-jdk18on-$bc_version.jar" 2>/dev/null || return 1
+# Function to get the latest Bouncy Castle version from Maven Central
+get_latest_version() {
+  local metadata_url="https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/maven-metadata.xml"
+  if command -v curl >/dev/null; then
+    curl -s "$metadata_url" | grep '<latest>' | sed -e 's/.*<latest>\(.*\)<\/latest>.*/\1/'
+  elif command -v wget >/dev/null; then
+    wget -q -O - "$metadata_url" | grep '<latest>' | sed -e 's/.*<latest>\(.*\)<\/latest>.*/\1/'
   else
-    echo "failed"
-    echo "Error: Neither wget nor curl is available. Please install either wget or curl."
+    echo "Error: Neither curl nor wget is installed. Please install one to fetch the latest version."
+    exit 1
+  fi
+}
+
+# Function to download Bouncy Castle JARs with the latest version
+download_bc_jars() {
+  local bc_version=$(get_latest_version)
+  local lib_dir="../../../lib"
+  local bc_url="https://repo1.maven.org/maven2/org/bouncycastle"
+
+  if [ -z "$bc_version" ]; then
+    echo "failed (could not determine latest version)"
     return 1
   fi
 
-  # Verify downloads were successful
+  echo -n "Downloading Bouncy Castle JARs (version $bc_version)... "
+  mkdir -p "$lib_dir" || {
+    echo "failed (cannot create $lib_dir)"
+    return 1
+  }
+
+  if command -v wget >/dev/null; then
+    wget -P "$lib_dir" "$bc_url/bcprov-jdk18on/$bc_version/bcprov-jdk18on-$bc_version.jar" &&
+      wget -P "$lib_dir" "$bc_url/bctls-jdk18on/$bc_version/bctls-jdk18on-$bc_version.jar" || {
+      echo "failed (wget error: check URL or network)"
+      return 1
+    }
+  elif command -v curl >/dev/null; then
+    curl -L -o "$lib_dir/bcprov-jdk18on-$bc_version.jar" "$bc_url/bcprov-jdk18on/$bc_version/bcprov-jdk18on-$bc_version.jar" &&
+      curl -L -o "$lib_dir/bctls-jdk18on-$bc_version.jar" "$bc_url/bctls-jdk18on/$bc_version/bctls-jdk18on-$bc_version.jar" || {
+      echo "failed (curl error: check URL or network)"
+      return 1
+    }
+  else
+    echo "failed (neither wget nor curl installed)"
+    echo "Please install wget or curl."
+    return 1
+  fi
+
   if [ -f "$lib_dir/bcprov-jdk18on-$bc_version.jar" ] && [ -f "$lib_dir/bctls-jdk18on-$bc_version.jar" ]; then
     echo "done"
     BC_DOWNLOADED=true
     return 0
   else
-    echo "failed"
+    echo "failed (downloaded files not found)"
     return 1
   fi
 }
@@ -42,33 +65,32 @@ download_bc_jars() {
 cleanup_bc_jars() {
   local lib_dir="../../../lib"
   echo -n "Removing Bouncy Castle JARs... "
-  rm -f "$lib_dir/bcprov-jdk18on-1.79.jar" "$lib_dir/bctls-jdk18on-1.79.jar" 2>/dev/null
-  if [ $? -eq 0 ]; then
-    echo "done"
-    return 0
-  else
-    echo "failed"
-    return 1
-  fi
+  rm -f "$lib_dir/bcprov-jdk18on-"*".jar" "$lib_dir/bctls-jdk18on-"*".jar" && echo "done" || echo "failed"
 }
 
-cd ./examples/build/provider
+cd ./examples/build/provider || {
+  echo "Error: Cannot change to ./examples/build/provider"
+  exit 1
+}
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib:/usr/local/lib
 CLASSPATH="../../../lib/wolfcrypt-jni.jar:."
 
-if [ -f "../../../lib/bcprov-jdk18on-1.79.jar" ] && [ -f "../../../lib/bctls-jdk18on-1.79.jar" ]; then
-  echo "Running crypto benchmark with Bouncy Castle"
-  CLASSPATH="$CLASSPATH:../../../lib/bcprov-jdk18on-1.79.jar:../../../lib/bctls-jdk18on-1.79.jar"
+# Check for existing Bouncy Castle JARs (any version)
+if ls "../../../lib/bcprov-jdk18on-"*".jar" "../../../lib/bctls-jdk18on-"*".jar" 2>/dev/null; then
+  latest_bc_jar=$(ls -t "../../../lib/bcprov-jdk18on-"*".jar" | head -n 1)
+  bc_version=$(basename "$latest_bc_jar" | sed -e 's/bcprov-jdk18on-//' -e 's/.jar$//')
+  echo "Running crypto benchmark with Bouncy Castle (version $bc_version)"
+  CLASSPATH="$CLASSPATH:$latest_bc_jar:../../../lib/bctls-jdk18on-$bc_version.jar"
 else
   echo "Bouncy Castle JARs not found in lib directory"
   read -p "Would you like to download Bouncy Castle JARs? (y/n) " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     if download_bc_jars; then
-      echo "Running crypto benchmark with Bouncy Castle"
-      CLASSPATH="$CLASSPATH:../../../lib/bcprov-jdk18on-1.79.jar:../../../lib/bctls-jdk18on-1.79.jar"
+      bc_version=$(get_latest_version)
+      echo "Running crypto benchmark with Bouncy Castle (version $bc_version)"
+      CLASSPATH="$CLASSPATH:../../../lib/bcprov-jdk18on-$bc_version.jar:../../../lib/bctls-jdk18on-$bc_version.jar"
     else
       echo "Running crypto benchmark without Bouncy Castle due to download failure"
     fi
@@ -77,11 +99,9 @@ else
   fi
 fi
 
-# Run the benchmark
-java -XX:-TieredCompilation -XX:ReservedCodeCacheSize=1024m -classpath $CLASSPATH -Dsun.boot.library.path=../../../lib/ CryptoBenchmark $@
+java -XX:-TieredCompilation -XX:ReservedCodeCacheSize=1024m -classpath "$CLASSPATH" -Dsun.boot.library.path=../../../lib/ CryptoBenchmark "$@"
 
-# Always prompt for cleanup after benchmark completion if Bouncy Castle files exist
-if [ -f "../../../lib/bcprov-jdk18on-1.79.jar" ] && [ -f "../../../lib/bctls-jdk18on-1.79.jar" ]; then
+if ls "../../../lib/bcprov-jdk18on-"*".jar" "../../../lib/bctls-jdk18on-"*".jar" 2>/dev/null; then
   echo
   read -p "Would you like to remove the Bouncy Castle JARs? (y/n) " -n 1 -r
   echo


### PR DESCRIPTION
This PR adds PBKDF2 benchmarks for all JCE providers. Sun had a the following missing:
```
PBKDF2WithHmacSHA3-224
PBKDF2WithHmacSHA3-256
PBKDF2WithHmacSHA3-384
PBKDF2WithHmacSHA3-512
```
 The bash script had to be changed to increase the code cache in order to avoid the following warning:
` OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.`

