### PR TITLE
JCE: fix Cipher.getOutputSize() for AES/GCM/NoPadding in DECRYPT mode

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -303,12 +303,19 @@ public class WolfCryptCipher extends CipherSpi {
                 if (paddingType == PaddingType.WC_NONE) {
                     if (cipherMode == CipherMode.WC_GCM) {
                         /* In AES-GCM mode we append the authentication tag
-                         * to the end of ciphertext */
-                        size = inputLen + this.gcmTagLen;
+                         * to the end of ciphertext, When decrypting, output
+                         * size will have it taken off. */
+                        if (this.direction == OpMode.WC_ENCRYPT) {
+                            size = inputLen + this.gcmTagLen;
+                        }
+                        else {
+                            size = inputLen - this.gcmTagLen;
+                        }
+                        size = Math.max(size, 0);
                     }
                     else {
-                        /* wolfCrypt expects input to be padded by application to
-                         * block size, thus output is same size as input */
+                        /* wolfCrypt expects input to be padded by application
+                         * to block size, thus output is same size as input */
                         size = inputLen;
                     }
                 }


### PR DESCRIPTION
This PR fixes `Cipher(AES/GCM/NoPadding)` behavior for `getOutputSize(int inputLen)` to correctly strip off the tag length from the expected output size when in DECRYPT mode.

Adds JUnit tests to prevent regression.

We should revisit other algos/modes to see if they need similar adjustments. That will be part of follow up PRs if needed.

ZD 19367