### PR TITLE
Switch to Java Logging (`java.util.logging`)

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -1074,8 +1074,8 @@ public class WolfCryptCipher extends CipherSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[Cipher, " + algString + "-" +
-            algMode + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + algString + "-" + algMode + "] " + msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
@@ -21,9 +21,107 @@
 
 package com.wolfssl.provider.jce;
 
+import java.sql.Timestamp;
+import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.function.Supplier;
+
 class WolfCryptDebug {
 
+    private static final Logger jceLogger =
+        Logger.getLogger("com.wolfssl.provider.jce");
+
     public static boolean DEBUG = checkProperty();
+
+    /** Error level debug message */
+    public static final String ERROR = "ERROR";
+
+    /** Info level debug message */
+    public static final String INFO = "INFO";
+
+    static {
+        configureLoggers();
+    }
+
+    /**
+     * Custom handler that flushes after each log record
+     */
+    private static class FlushingStreamHandler extends StreamHandler {
+        public FlushingStreamHandler() {
+            super(System.err, new WolfCryptFormatter());
+        }
+
+        @Override
+        public synchronized void publish(LogRecord record) {
+            super.publish(record);
+            flush();
+        }
+    }
+
+    /**
+     * Configure loggers based on system properties
+     */
+    private static void configureLoggers() {
+        /* Remove any existing handlers */
+        for (Handler handler : jceLogger.getHandlers()) {
+            jceLogger.removeHandler(handler);
+        }
+
+        /* Only configure handlers if debug is enabled */
+        if (DEBUG) {
+            /* Create custom handler that flushes after each log record */
+            FlushingStreamHandler handler = new FlushingStreamHandler();
+            handler.setFormatter(new WolfCryptFormatter());
+            jceLogger.addHandler(handler);
+        }
+
+        /* Set log levels based on debug properties */
+        jceLogger.setLevel(DEBUG ? Level.ALL : Level.OFF);
+
+        /* Disable parent handlers to prevent double logging */
+        jceLogger.setUseParentHandlers(false);
+    }
+
+    /**
+     * Custom formatter for log records
+     */
+    private static class WolfCryptFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+            if (record == null) {
+                return "null record\n";
+            }
+
+            String sourceClass = record.getSourceClassName();
+            if (sourceClass == null) {
+                sourceClass = "";
+            } else {
+                /* Extract simple class name (after last dot) */
+                int lastDot = sourceClass.lastIndexOf('.');
+                if (lastDot != -1) {
+                    sourceClass = sourceClass.substring(lastDot + 1);
+                }
+            }
+
+            Level level = record.getLevel();
+            String levelStr = level != null ? level.getName() : "UNKNOWN";
+
+            long threadId = record.getThreadID();
+            String message = record.getMessage();
+            if (message == null) {
+                message = "";
+            }
+
+            return String.format("%s [%s %s: TID %d: %s] %s\n",
+                    new Timestamp(record.getMillis()),
+                    "wolfJCE",
+                    levelStr,
+                    threadId,
+                    sourceClass,
+                    message);
+        }
+    }
 
     private static boolean checkProperty() {
 
@@ -36,10 +134,61 @@ class WolfCryptDebug {
         return false;
     }
 
-    public static void print(String string) {
-        if (DEBUG) {
-            System.out.println("wolfJCE: " + string);
+    /**
+     * Refresh debug enabled/disabled flags based on current
+     * System properties.
+     */
+    public static synchronized void refreshDebugFlags() {
+        boolean oldDebug = DEBUG;
+
+        DEBUG = checkProperty();
+
+        /* Only reconfigure if debug state has changed */
+        if (oldDebug != DEBUG) {
+            configureLoggers();
         }
     }
-}
 
+    /**
+     * Print out debug message if debugging is enabled.
+     *
+     * @param <T> class type of cl
+     * @param cl class being called from to get debug info
+     * @param tag level of debug message, ie WolfCryptDebug.INFO
+     * @param messageSupplier supplier of message to be printed out
+     */
+    public static synchronized <T> void log(Class<T> cl, String tag,
+        Supplier<String> messageSupplier) {
+
+        log(cl, "wolfJCE", tag, 0, messageSupplier);
+    }
+
+    /**
+     * Print out debug message if debugging is enabled.
+     *
+     * @param <T> class type of cl
+     * @param cl class being called from to get debug info
+     * @param component component name, ie "wolfJCE"
+     * @param tag level of debug message, ie WolfCryptDebug.INFO
+     * @param nativePtr native pointer
+     * @param messageSupplier supplier of message to be printed out
+     */
+    public static synchronized <T> void log(Class<T> cl, String component,
+        String tag, long nativePtr, Supplier<String> messageSupplier) {
+
+        if (!DEBUG) {
+            return;
+        }
+
+        Level level = tag.equals(ERROR) ? Level.SEVERE : Level.INFO;
+
+        String className = cl.getSimpleName();
+        if (nativePtr != 0) {
+            className = className + ": " + nativePtr;
+        }
+
+        LogRecord record = new LogRecord(level, messageSupplier.get());
+        record.setSourceClassName(cl.getName());
+        jceLogger.log(record);
+    }
+}

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -554,7 +554,8 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[KeyAgreement, " + algString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + algString + "] " + msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
@@ -104,7 +104,8 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
      * @param msg Message string to log
      */
     private void log(String msg) {
-        WolfCryptDebug.print("[KeyGenerator, " + algString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + this.algString + "] " + msg);
     }
 
     /**

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -407,7 +407,8 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[KeyPairGenerator, " + algString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + algString + "] " + msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
@@ -215,7 +215,8 @@ public class WolfCryptMac extends MacSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[Mac, " + algString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + algString + "] " + msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -100,7 +100,8 @@ public final class WolfCryptMessageDigestMd5
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, MD5] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[MD5] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -100,7 +100,8 @@ public final class WolfCryptMessageDigestSha
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha224.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha224.java
@@ -105,7 +105,8 @@ public final class WolfCryptMessageDigestSha224
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA224] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA224] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -105,7 +105,8 @@ public final class WolfCryptMessageDigestSha256
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA256] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA256] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
@@ -116,7 +116,8 @@ public class WolfCryptMessageDigestSha3
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA-3] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA-3] " + msg);
     }
 
     @Override
@@ -157,7 +158,7 @@ public class WolfCryptMessageDigestSha3
     public static final class wcSHA3_256 extends WolfCryptMessageDigestSha3 {
         /**
          * Create new wcSHA3_256 object
-         * 
+         *
          * @throws NoSuchAlgorithmException if digest type is not
          *         available in native wolfCrypt library
          */
@@ -184,7 +185,7 @@ public class WolfCryptMessageDigestSha3
     /**
      * wolfJCE SHA3-512 message digest class
      */
-    public static final class wcSHA3_512 extends WolfCryptMessageDigestSha3 {   
+    public static final class wcSHA3_512 extends WolfCryptMessageDigestSha3 {
         /**
          * Create new wcSHA3_512 object
          *

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -105,7 +105,8 @@ public final class WolfCryptMessageDigestSha384
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA384] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA384] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -105,7 +105,8 @@ public final class WolfCryptMessageDigestSha512
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[MessageDigest, SHA512] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[SHA512] " + msg);
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -716,7 +716,7 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
      * @param msg Log message to be printed
      */
     private void log(String msg) {
-        WolfCryptDebug.print("[CertPathValidator] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO, () -> msg);
     }
 }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
@@ -70,7 +70,7 @@ public final class WolfCryptRandom extends SecureRandomSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[Random] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO, () -> msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
@@ -121,7 +121,8 @@ public class WolfCryptSecretKeyFactory extends SecretKeyFactorySpi {
      * @param msg message to be logged
      */
     private void log(String msg) {
-        WolfCryptDebug.print("[SecretKeyFactory, " + typeString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + typeString + "] " + msg);
     }
 
     /**

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -699,8 +699,8 @@ public class WolfCryptSignature extends SignatureSpi {
     }
 
     private void log(String msg) {
-        WolfCryptDebug.print("[Signature, " + keyString + "-" +
-            digestString + "] " + msg);
+        WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO,
+            () -> "[" + keyString + "-" + digestString + "] " + msg);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
@@ -1815,7 +1815,8 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
      * @param msg message to be logged
      */
     private static synchronized void log(String msg) {
-        WolfCryptDebug.print("[WolfSSLKeyStore] " + msg);
+        WolfCryptDebug.log(WolfSSLKeyStore.class, WolfCryptDebug.INFO,
+            () -> msg);
     }
 
     /**


### PR DESCRIPTION
This PR switches wolfcrypt-jni to use the Java Logging (`java.util.logging`) framework instead of using plain `System.out.println()` statements.

Using `System.out.println()` is not ideal for performance nor memory usage, since Strings are always allocated even if debug logging is disabled. Using Java Logging, and switching debug calls to use lambda style defers String allocation/creation until the debug log is actually used/printed.