### PR TITLE
Get ASN algorithm enum values dynamically

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Asn.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Asn.h
@@ -9,16 +9,46 @@ extern "C" {
 #endif
 #undef com_wolfssl_wolfcrypt_Asn_MAX_ENCODED_SIG_SIZE
 #define com_wolfssl_wolfcrypt_Asn_MAX_ENCODED_SIG_SIZE 512L
-#undef com_wolfssl_wolfcrypt_Asn_DSAk
-#define com_wolfssl_wolfcrypt_Asn_DSAk 515L
-#undef com_wolfssl_wolfcrypt_Asn_RSAk
-#define com_wolfssl_wolfcrypt_Asn_RSAk 645L
-#undef com_wolfssl_wolfcrypt_Asn_RSAPSSk
-#define com_wolfssl_wolfcrypt_Asn_RSAPSSk 654L
-#undef com_wolfssl_wolfcrypt_Asn_RSAESOAEPk
-#define com_wolfssl_wolfcrypt_Asn_RSAESOAEPk 651L
-#undef com_wolfssl_wolfcrypt_Asn_ECDSAk
-#define com_wolfssl_wolfcrypt_Asn_ECDSAk 518L
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getDSAk
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getDSAk
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getRSAk
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAk
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getRSAPSSk
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAPSSk
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getRSAESOAEPk
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAESOAEPk
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getECDSAk
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getECDSAk
+  (JNIEnv *, jclass);
+
 /*
  * Class:     com_wolfssl_wolfcrypt_Asn
  * Method:    encodeSignature

--- a/jni/jni_asn.c
+++ b/jni/jni_asn.c
@@ -35,6 +35,36 @@
 /* #define WOLFCRYPT_JNI_DEBUG_ON */
 #include <wolfcrypt_jni_debug.h>
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getDSAk
+  (JNIEnv* env, jclass class)
+{
+    return DSAk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAk
+  (JNIEnv* env, jclass class)
+{
+    return RSAk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAPSSk
+  (JNIEnv* env, jclass class)
+{
+    return RSAPSSk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getRSAESOAEPk
+  (JNIEnv* env, jclass class)
+{
+    return RSAESOAEPk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getECDSAk
+  (JNIEnv* env, jclass class)
+{
+    return ECDSAk;
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Asn_encodeSignature__Ljava_nio_ByteBuffer_2Ljava_nio_ByteBuffer_2JI(
     JNIEnv* env, jclass class, jobject encoded_object, jobject hash_object,
     jlong hashSize, jint hashOID)

--- a/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
@@ -661,16 +661,14 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
                         "unprotected key");
                 }
 
-                switch (algoId) {
-                    case Asn.RSAk:
-                        keyFact = KeyFactory.getInstance("RSA");
-                        break;
-                    case Asn.ECDSAk:
-                        keyFact = KeyFactory.getInstance("EC");
-                        break;
-                    default:
-                        throw new NoSuchAlgorithmException(
-                            "Only RSA and EC private key encoding supported");
+                if (algoId == Asn.RSAk) {
+                    keyFact = KeyFactory.getInstance("RSA");
+                } else if (algoId == Asn.ECDSAk) {
+                    keyFact = KeyFactory.getInstance("EC");
+                } else {
+                    throw new NoSuchAlgorithmException(
+                        "Only RSA and EC private key encoding " +
+                        "supported: " + algoId);
                 }
 
                 try {

--- a/src/main/java/com/wolfssl/wolfcrypt/Asn.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Asn.java
@@ -36,18 +36,38 @@ public class Asn extends WolfObject {
     /* Key Sum values, from asn.h Key_Sum enum */
 
     /** DSA key value, from asn.h Key_Sum enum */
-    public static final int DSAk = 515;
+    public static final int DSAk;
     /** RSA key value, from asn.h Key_Sum enum */
-    public static final int RSAk = 645;
+    public static final int RSAk;
     /** RSA-PSS key value, from asn.h Key_Sum enum */
-    public static final int RSAPSSk = 654;
+    public static final int RSAPSSk;
     /** RSA-OAEP key value, from asn.h Key_Sum enum */
-    public static final int RSAESOAEPk = 651;
+    public static final int RSAESOAEPk;
     /** ECDSA key value, from asn.h Key_Sum enum */
-    public static final int ECDSAk = 518;
+    public static final int ECDSAk;
 
-    /** Default Asn constructor */
-    public Asn() { }
+    static {
+        DSAk = getDSAk();
+        RSAk = getRSAk();
+        RSAPSSk = getRSAPSSk();
+        RSAESOAEPk = getRSAESOAEPk();
+        ECDSAk = getECDSAk();
+    }
+
+    /** Return value of native DSAk enum */
+    private static native int getDSAk();
+
+    /** Return value of native RSAk enum */
+    private static native int getRSAk();
+
+    /** Return value of native RSAPSSk enum */
+    private static native int getRSAPSSk();
+
+    /** Return value of native RSAESOAEPk enum */
+    private static native int getRSAESOAEPk();
+
+    /** Return value of native ECDSAk enum */
+    private static native int getECDSAk();
 
     /** ASN.1 encode message digest, before it is signed
      *


### PR DESCRIPTION
This PR adjusts the `com.wolfssl.wolfcrypt.Asn` class to dynamically get the algorithm ASN enum values (ex: `RSAk`, `ECDSAk`, etc) instead of using hard-coded values. This is much more flexible in case these values change at the native level.

These hard coded values broke some unit tests after https://github.com/wolfSSL/wolfssl/commit/1e3718ea7b92b04d9d81dbf8e7d6032ca0a904cb was merged into native wolfSSL.