### PR TITLE
JNI/JCE: get hash OID sums dynamically and add to `Asn`

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Asn.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Asn.h
@@ -51,6 +51,86 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getECDSAk
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getMD5h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getMD5h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHAh
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHAh
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA224h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA224h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA256h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA256h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA384h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA384h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA512h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA512h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA3_224h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1224h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA3_256h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1256h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA3_384h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1384h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
+ * Method:    getSHA3_512h
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1512h
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Asn
  * Method:    encodeSignature
  * Signature: (Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;JI)V
  */

--- a/jni/jni_asn.c
+++ b/jni/jni_asn.c
@@ -27,6 +27,7 @@
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/oid_sum.h>
 
 #include <com_wolfssl_wolfcrypt_Asn.h>
 #include <wolfcrypt_jni_NativeStruct.h>
@@ -167,5 +168,85 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getPkcs8AlgoID
     (void)pkcs8Der;
     return (jint)NOT_COMPILED_IN;
 #endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getMD5h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return MD5h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHAh
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHAh;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA224h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA224h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA256h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA256h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA384h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA384h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA512h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA512h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1224h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA3_224h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1256h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA3_256h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1384h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA3_384h;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Asn_getSHA3_1512h
+  (JNIEnv* env, jclass class)
+{
+    (void)env;
+    (void)class;
+    return SHA3_512h;
 }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -72,17 +72,17 @@ public class WolfCryptSignature extends SignatureSpi {
         WC_SHA3_512
     }
 
-    /* internal hash type sums (asn.h) */
-    private int MD5h = 649;
-    private int SHAh = 88;
-    private int SHA224h = 417;
-    private int SHA256h = 414;
-    private int SHA384h = 415;
-    private int SHA512h = 416;
-    private int SHA3_224h = 420;
-    private int SHA3_256h = 421;
-    private int SHA3_384h = 422;
-    private int SHA3_512h = 423;
+    /* internal hash type sums (from oid_sum.h) - retrieved dynamically */
+    private int MD5h = Asn.MD5h;
+    private int SHAh = Asn.SHAh;
+    private int SHA224h = Asn.SHA224h;
+    private int SHA256h = Asn.SHA256h;
+    private int SHA384h = Asn.SHA384h;
+    private int SHA512h = Asn.SHA512h;
+    private int SHA3_224h = Asn.SHA3_224h;
+    private int SHA3_256h = Asn.SHA3_256h;
+    private int SHA3_384h = Asn.SHA3_384h;
+    private int SHA3_512h = Asn.SHA3_512h;
 
     /* internal key objects */
     private Rsa rsa = null;
@@ -623,9 +623,14 @@ public class WolfCryptSignature extends SignatureSpi {
                 }
 
                 /* compare expected digest to one unwrapped from verify */
-                for (int i = 0; i < verify.length; i++) {
-                    if (verify[i] != encDigest[i]) {
-                        verified = false;
+                if (verify.length != encodedSz) {
+                    verified = false;
+                } else {
+                    for (int i = 0; i < encodedSz; i++) {
+                        if (verify[i] != encDigest[i]) {
+                            verified = false;
+                            break;
+                        }
                     }
                 }
 

--- a/src/main/java/com/wolfssl/wolfcrypt/Asn.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Asn.java
@@ -46,12 +46,46 @@ public class Asn extends WolfObject {
     /** ECDSA key value, from asn.h Key_Sum enum */
     public static final int ECDSAk;
 
+    /* Hash Sum values, from oid_sum.h Hash_Sum enum */
+
+    /** MD5 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int MD5h;
+    /** SHA-1 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHAh;
+    /** SHA-224 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA224h;
+    /** SHA-256 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA256h;
+    /** SHA-384 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA384h;
+    /** SHA-512 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA512h;
+    /** SHA3-224 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA3_224h;
+    /** SHA3-256 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA3_256h;
+    /** SHA3-384 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA3_384h;
+    /** SHA3-512 hash OID value, from oid_sum.h Hash_Sum enum */
+    public static final int SHA3_512h;
+
     static {
         DSAk = getDSAk();
         RSAk = getRSAk();
         RSAPSSk = getRSAPSSk();
         RSAESOAEPk = getRSAESOAEPk();
         ECDSAk = getECDSAk();
+
+        MD5h = getMD5h();
+        SHAh = getSHAh();
+        SHA224h = getSHA224h();
+        SHA256h = getSHA256h();
+        SHA384h = getSHA384h();
+        SHA512h = getSHA512h();
+        SHA3_224h = getSHA3_224h();
+        SHA3_256h = getSHA3_256h();
+        SHA3_384h = getSHA3_384h();
+        SHA3_512h = getSHA3_512h();
     }
 
     /** Return value of native DSAk enum */
@@ -68,6 +102,36 @@ public class Asn extends WolfObject {
 
     /** Return value of native ECDSAk enum */
     private static native int getECDSAk();
+
+    /** Return value of native MD5h enum */
+    private static native int getMD5h();
+
+    /** Return value of native SHAh enum */
+    private static native int getSHAh();
+
+    /** Return value of native SHA224h enum */
+    private static native int getSHA224h();
+
+    /** Return value of native SHA256h enum */
+    private static native int getSHA256h();
+
+    /** Return value of native SHA384h enum */
+    private static native int getSHA384h();
+
+    /** Return value of native SHA512h enum */
+    private static native int getSHA512h();
+
+    /** Return value of native SHA3_224h enum */
+    private static native int getSHA3_224h();
+
+    /** Return value of native SHA3_256h enum */
+    private static native int getSHA3_256h();
+
+    /** Return value of native SHA3_384h enum */
+    private static native int getSHA3_384h();
+
+    /** Return value of native SHA3_512h enum */
+    private static native int getSHA3_512h();
 
     /** ASN.1 encode message digest, before it is signed
      *

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AsnTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AsnTest.java
@@ -1,0 +1,128 @@
+/* AsnTest.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335,
+ * USA
+ */
+
+package com.wolfssl.wolfcrypt.test;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+
+import com.wolfssl.wolfcrypt.Asn;
+
+/**
+ * Unit tests for Asn class, particularly dynamic OID retrieval
+ */
+public class AsnTest {
+
+    @BeforeClass
+    public static void checkAvailability() {
+        try {
+            /* Force initialization of Asn class static variables */
+            int md5 = Asn.MD5h;
+        } catch (UnsatisfiedLinkError ule) {
+            /* wolfCrypt JNI library not found, skip tests */
+            System.out.println("wolfCrypt JNI library not found, " +
+                               "skipping tests");
+            org.junit.Assume.assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void testDynamicOIDRetrieval() {
+
+        /* Test that all OID constants are initialized to non-zero values.
+         * The new dynamic system should return proper hash-based OID values
+         * from native wolfSSL, not the old hard-coded values. */
+
+        assertNotEquals("MD5h should not be zero", 0, Asn.MD5h);
+        assertNotEquals("SHAh should not be zero", 0, Asn.SHAh);
+        assertNotEquals("SHA224h should not be zero", 0, Asn.SHA224h);
+        assertNotEquals("SHA256h should not be zero", 0, Asn.SHA256h);
+        assertNotEquals("SHA384h should not be zero", 0, Asn.SHA384h);
+        assertNotEquals("SHA512h should not be zero", 0, Asn.SHA512h);
+        assertNotEquals("SHA3_224h should not be zero", 0, Asn.SHA3_224h);
+        assertNotEquals("SHA3_256h should not be zero", 0, Asn.SHA3_256h);
+        assertNotEquals("SHA3_384h should not be zero", 0, Asn.SHA3_384h);
+        assertNotEquals("SHA3_512h should not be zero", 0, Asn.SHA3_512h);
+    }
+
+    @Test
+    public void testOIDEncodingWithNewValues() {
+
+        /* Test that the new OID values produce valid DER encodings.
+         * Valid encodings should have length > 40 and proper structure. */
+
+        byte[] digest = new byte[32];
+        byte[] encoded = new byte[512];
+
+        /* Test SHA-256 encoding */
+        long encodedLength = Asn.encodeSignature(encoded, digest,
+                                                 digest.length, Asn.SHA256h);
+        assertTrue("SHA-256 encoding should be successful", encodedLength > 40);
+        assertTrue("SHA-256 encoding should be reasonable length",
+                   encodedLength < 100);
+
+        /* Check basic DER structure */
+        assertEquals("First byte should be SEQUENCE tag", 0x30,
+                     encoded[0] & 0xFF);
+        assertTrue("SEQUENCE length should be reasonable",
+                   (encoded[1] & 0xFF) > 30);
+        assertEquals("Algorithm ID should be SEQUENCE", 0x30,
+                     encoded[2] & 0xFF);
+
+        /* Test SHA-1 encoding */
+        encodedLength = Asn.encodeSignature(encoded, digest, digest.length,
+                                            Asn.SHAh);
+        assertTrue("SHA-1 encoding should be successful", encodedLength > 40);
+        assertTrue("SHA-1 encoding should be reasonable length",
+                   encodedLength < 100);
+
+        /* Test MD5 encoding */
+        encodedLength = Asn.encodeSignature(encoded, digest, digest.length,
+                                            Asn.MD5h);
+        assertTrue("MD5 encoding should be successful", encodedLength > 40);
+        assertTrue("MD5 encoding should be reasonable length",
+                   encodedLength < 100);
+    }
+
+    @Test
+    public void testOIDUniqueness() {
+
+        /* Test that all OID values are unique.
+         * Each algorithm should have a distinct OID value. */
+
+        int[] oids = {
+            Asn.MD5h, Asn.SHAh, Asn.SHA224h, Asn.SHA256h, Asn.SHA384h,
+            Asn.SHA512h, Asn.SHA3_224h, Asn.SHA3_256h, Asn.SHA3_384h,
+            Asn.SHA3_512h
+        };
+
+        /* Check that all values are unique */
+        for (int i = 0; i < oids.length; i++) {
+            for (int j = i + 1; j < oids.length; j++) {
+                assertNotEquals("OID values should be unique", oids[i],
+                                oids[j]);
+            }
+        }
+    }
+}

--- a/src/test/java/com/wolfssl/wolfcrypt/test/WolfCryptTestSuite.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/WolfCryptTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
     AesTest.class,
     AesGcmTest.class,
+    AsnTest.class,
     Des3Test.class,
     ChachaTest.class,
     Md5Test.class,


### PR DESCRIPTION
This PR fixes some hard-coded ASN.1 OID enum values that were previously correct but after native wolfSSL commit [112351667ada10501771194baeb56b494ffa9435.](https://github.com/wolfSSL/wolfssl/commit/112351667ada10501771194baeb56b494ffa9435) have diverged.

We are changing to retrieving them dynamically from JNI here, so we will always get the accurate/current version of the enum independent of how native wolfSSL has been compiled.