### PR TITLE
Testing: add GitHub action to enforce multi-line style comments

### DIFF
--- a/.github/workflows/comment-style-check.yml
+++ b/.github/workflows/comment-style-check.yml
@@ -1,0 +1,99 @@
+name: Comment Style Check
+
+on:
+  pull_request:
+    branches: [ '*' ]
+    paths:
+      - '**/*.java'
+      - '**/*.c'
+      - '**/*.h'
+
+jobs:
+  check-comment-style:
+    runs-on: ubuntu-latest
+    name: Check Multi-line Comment Style
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          # Get list of changed .java and .c/.h files in this PR
+          git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD | \
+            grep -E '\.(java|c|h)$' > changed_files.txt || echo "No matching files found"
+
+          if [ -s changed_files.txt ]; then
+            echo "Found changed files:"
+            cat changed_files.txt
+            echo "has_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "No .java, .c, or .h files changed in this PR"
+            echo "has_files=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for single-line comments in changed files
+        if: steps.changed-files.outputs.has_files == 'true'
+        run: |
+          violations_found=false
+
+          while IFS= read -r file; do
+            if [ -f "$file" ]; then
+              echo "Checking $file for comment style violations..."
+
+              # Find potential single-line comments (//)
+              # This is a simple check that may have some false positives
+              # but catches the most common violations
+              violations=$(grep -n '//' "$file" | \
+                grep -v 'http://' | \
+                grep -v 'https://' | \
+                grep -v -E '/\*.*//.*\*/' | \
+                grep -v -E '"[^"]*//[^"]*"' | \
+                grep -E ':[[:space:]]*//' || true)
+
+              if [ -n "$violations" ]; then
+                echo "❌ Single-line comments found in $file:"
+                echo "$violations"
+                echo ""
+                violations_found=true
+              else
+                echo "✅ $file: No single-line comment violations found"
+              fi
+            fi
+          done < changed_files.txt
+
+          if [ "$violations_found" = true ]; then
+            echo ""
+            echo "=================================="
+            echo "❌ COMMENT STYLE CHECK FAILED"
+            echo "=================================="
+            echo ""
+            echo "Single-line comments (//) were found in the changed files."
+            echo "According to the coding standard in CLAUDE.md:"
+            echo "- MUST only use multi-line comments, no \"//\" style ones"
+            echo ""
+            echo "Please replace all single-line comments (//) with multi-line comments (/* */)."
+            echo ""
+            echo "Examples:"
+            echo "  ❌ Bad:  // This is a comment"
+            echo "  ✅ Good: /* This is a comment */"
+            echo ""
+            echo "  ❌ Bad:  // TODO: implement this"
+            echo "  ✅ Good: /* TODO: implement this */"
+            echo ""
+            exit 1
+          else
+            echo ""
+            echo "=================================="
+            echo "✅ COMMENT STYLE CHECK PASSED"
+            echo "=================================="
+            echo "All changed files follow the multi-line comment style standard."
+          fi
+
+      - name: Comment style check skipped
+        if: steps.changed-files.outputs.has_files == 'false'
+        run: |
+          echo "✅ Comment style check skipped - no .java, .c, or .h files were changed in this PR"


### PR DESCRIPTION
This PR adds a GitHub action that checks to make sure new code uses multi-line comment style (ie: `/* */`) not single line style (ie: `//`), to match internal coding standards.

Only checks `.java`, `.c`, and `.h` source files changed in a PR.

Example of a failure run: https://github.com/wolfSSL/wolfcrypt-jni/actions/runs/16276508001/job/45956586842?pr=127