### PR TITLE
Build fixes for older wolfSSL or FIPS variants

### DIFF
--- a/jni/jni_asn.c
+++ b/jni/jni_asn.c
@@ -27,7 +27,6 @@
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/oid_sum.h>
 
 #include <com_wolfssl_wolfcrypt_Asn.h>
 #include <wolfcrypt_jni_NativeStruct.h>

--- a/jni/jni_dh.c
+++ b/jni/jni_dh.c
@@ -39,6 +39,25 @@
     #define RNG WC_RNG
 #endif
 
+/* Some FIPS versions don't have DH_MAX_SIZE defined */
+#ifndef DH_MAX_SIZE
+    #ifdef USE_FAST_MATH
+        /* FP implementation support numbers up to FP_MAX_BITS / 2 bits. */
+        #define DH_MAX_SIZE    (FP_MAX_BITS / 2)
+    #elif defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_SP_MATH)
+        /* SP implementation supports numbers of SP_INT_BITS bits. */
+        #define DH_MAX_SIZE    (((SP_INT_BITS + 7) / 8) * 8)
+    #else
+        #ifdef WOLFSSL_MYSQL_COMPATIBLE
+            /* Integer maths is dynamic but we only go up to 8192 bits. */
+            #define DH_MAX_SIZE 8192
+        #else
+            /* Integer maths is dynamic but we only go up to 4096 bits. */
+            #define DH_MAX_SIZE 4096
+        #endif
+    #endif
+#endif
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Dh_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {


### PR DESCRIPTION
This PR includes two small fixes for older wolfSSL build or FIPS build compatibility:

- Remove explicit inclusion of `wolfssl/wolfcrypt/oid_sum.h`. It is not available in older builds, and gets pulled in automatically by other headers in newer builds anyways.
- Define `DH_MAX_SIZE` if not defined in native wolfSSL. Some older versions and FIPS variants don't have this defined.