### PR TITLE
JCE: refresh debug flags when WolfCryptProvider is loaded

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -38,6 +38,11 @@ public final class WolfCryptProvider extends Provider {
      */
     public WolfCryptProvider() {
         super("wolfJCE", 1.8, "wolfCrypt JCE Provider");
+
+        /* Refresh debug flags in case system properties were set after
+         * WolfCryptDebug class was first loaded (e.g., via JAVA_OPTS) */
+        WolfCryptDebug.refreshDebugFlags();
+
         registerServices();
     }
 


### PR DESCRIPTION
The WolfCryptDebug class caches the debug flag during static initialization, sometimes before system properties like `-Dwolfjce.debug=true` are set (ex: via JAVA_OPTS). This can cause debug logging to remain disabled even when the property is correctly set at runtime.

This PR adds a call to `WolfCryptDebug.refreshDebugFlags()` in the `WolfCryptProvider` constructor to refresh the debug state when the provider is loaded, to make sure logging shows up correctly when enabled via system properties.