### PR TITLE
JCE: change debug log timestamp to use Java Instant.ofEpochMilli()

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
@@ -21,7 +21,9 @@
 
 package com.wolfssl.provider.jce;
 
-import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.*;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -39,6 +41,11 @@ class WolfCryptDebug {
 
     /** Info level debug message */
     public static final String INFO = "INFO";
+
+    /** Time formatter for log messages */
+    private static final DateTimeFormatter TimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+            .withZone(ZoneId.systemDefault());
 
     static {
         configureLoggers();
@@ -114,7 +121,8 @@ class WolfCryptDebug {
             }
 
             return String.format("%s [%s %s: TID %d: %s] %s\n",
-                    new Timestamp(record.getMillis()),
+                    TimeFormatter.format(
+                        Instant.ofEpochMilli(record.getMillis())),
                     "wolfJCE",
                     levelStr,
                     threadId,


### PR DESCRIPTION
This PR changes the time source for debug logs from using `java.sql.Timestamp` to using just the base Java `Instant.ofEpochMilli()`. The advantage of this is that Java 9+ users won't have to import the `java.sql` module, and this can also more easily be used when wolfcrypt-jni JCE provider is used on the bootstrap classpath (`-Xbootclasspath/a`).