### PR TITLE
Fix Cipher.engineInit() with null parameters

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -739,15 +739,17 @@ public class WolfCryptCipher extends CipherSpi {
             AlgorithmParameters params, SecureRandom random)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
 
-        AlgorithmParameterSpec spec;
+        AlgorithmParameterSpec spec = null;
 
         try {
 
-            if (this.cipherMode == CipherMode.WC_GCM) {
-                spec = params.getParameterSpec(GCMParameterSpec.class);
-            }
-            else {
-                spec = params.getParameterSpec(IvParameterSpec.class);
+            if (params != null) {
+                if (this.cipherMode == CipherMode.WC_GCM) {
+                    spec = params.getParameterSpec(GCMParameterSpec.class);
+                }
+                else {
+                    spec = params.getParameterSpec(IvParameterSpec.class);
+                }
             }
 
             log("initialized with key and AlgorithmParameters");
@@ -1024,12 +1026,14 @@ public class WolfCryptCipher extends CipherSpi {
 
                 /* strip PKCS#5/PKCS#7 padding if required,
                  * CCM, CTR and OFB modes do not use padding */
-                if (this.direction == OpMode.WC_DECRYPT &&
-                    this.paddingType == PaddingType.WC_PKCS5 &&
-                    cipherMode != CipherMode.WC_CCM &&
-                    cipherMode != CipherMode.WC_CTR &&
-                    cipherMode != CipherMode.WC_OFB) {
-                    tmpOut = Aes.unPadPKCS7(tmpOut, Aes.BLOCK_SIZE);
+                if (tmpOut != null && tmpOut.length > 0) {
+                    if (this.direction == OpMode.WC_DECRYPT &&
+                        this.paddingType == PaddingType.WC_PKCS5 &&
+                        cipherMode != CipherMode.WC_CCM &&
+                        cipherMode != CipherMode.WC_CTR &&
+                        cipherMode != CipherMode.WC_OFB) {
+                        tmpOut = Aes.unPadPKCS7(tmpOut, Aes.BLOCK_SIZE);
+                    }
                 }
 
                 break;
@@ -1041,9 +1045,11 @@ public class WolfCryptCipher extends CipherSpi {
                 tmpOut = Arrays.copyOfRange(tmpOut, 0, tmpIn.length);
 
                 /* strip PKCS#5/PKCS#7 padding if required */
-                if (this.direction == OpMode.WC_DECRYPT &&
-                    this.paddingType == PaddingType.WC_PKCS5) {
-                    tmpOut = Des3.unPadPKCS7(tmpOut, Des3.BLOCK_SIZE);
+                if (tmpOut != null && tmpOut.length > 0) {
+                    if (this.direction == OpMode.WC_DECRYPT &&
+                        this.paddingType == PaddingType.WC_PKCS5) {
+                        tmpOut = Des3.unPadPKCS7(tmpOut, Des3.BLOCK_SIZE);
+                    }
                 }
 
                 break;

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -60,6 +60,7 @@ import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.AlgorithmParameters;
 import java.security.spec.AlgorithmParameterSpec;
 
 import com.wolfssl.wolfcrypt.FeatureDetect;
@@ -4874,6 +4875,52 @@ public class WolfCryptCipherTest {
 
         public byte[] getAAD() {
             return this.aad;
+        }
+    }
+
+    /**
+     * Test for regression of NPE when AlgorithmParameters is null.
+     */
+    @Test
+    public void testNullAlgorithmParametersNPERegression()
+        throws NoSuchAlgorithmException, NoSuchProviderException,
+               NoSuchPaddingException, InvalidKeyException,
+               InvalidAlgorithmParameterException, IllegalBlockSizeException,
+               BadPaddingException {
+
+        Cipher c;
+        SecretKeySpec key = new SecretKeySpec(new byte[16], "AES");
+
+        /* Test AES/ECB/PKCS5Padding - mode that doesn't require IV */
+        if (enabledJCEAlgos.contains("AES/ECB/PKCS5Padding")) {
+            c = Cipher.getInstance("AES/ECB/PKCS5Padding", jceProvider);
+            c.init(Cipher.ENCRYPT_MODE, key);
+
+            /* Get parameters (may be null for ECB mode) */
+            AlgorithmParameters params = c.getParameters();
+
+            /* This should not throw NPE even if params is null */
+            c.init(Cipher.DECRYPT_MODE, key, params);
+
+            /* Should be able to call doFinal with empty buffer */
+            byte[] result = c.doFinal(new byte[0]);
+            assertNotNull("doFinal should not return null", result);
+        }
+
+        /* Test AES/CBC/PKCS5Padding - mode that has parameters */
+        if (enabledJCEAlgos.contains("AES/CBC/PKCS5Padding")) {
+            c = Cipher.getInstance("AES/CBC/PKCS5Padding", jceProvider);
+            c.init(Cipher.ENCRYPT_MODE, key);
+
+            /* Get parameters (should contain IV for CBC mode) */
+            AlgorithmParameters params = c.getParameters();
+
+            /* This should not throw NPE */
+            c.init(Cipher.DECRYPT_MODE, key, params);
+
+            /* Should be able to call doFinal with empty buffer */
+            byte[] result = c.doFinal(new byte[0]);
+            assertNotNull("doFinal should not return null", result);
         }
     }
 }


### PR DESCRIPTION
This PR fixes an edge case in `Cipher.engineInit()` to prevent a NullPointerException when null AlgorithmParameters are provided.

This also adds a regression test, which without this fix would fail like so:

```
395 Testcase: testNullAlgorithmParametersNPERegression took 0.002 sec
396     Caused an ERROR
397 Cannot invoke "java.security.AlgorithmParameters.getParameterSpec(java.lang.Class)" because "params" is null
398 java.lang.NullPointerException: Cannot invoke "java.security.AlgorithmParameters.getParameterSpec(java.lang.Class)" because "params" is null
399     at com.wolfssl.provider.jce.WolfCryptCipher.engineInit(WolfCryptCipher.java:750)
400     at java.base/javax.crypto.Cipher.init(Cipher.java:1611)
401     at java.base/javax.crypto.Cipher.init(Cipher.java:1541)
402     at com.wolfssl.provider.jce.test.WolfCryptCipherTest.testNullAlgorithmParametersNPERegression(WolfCryptCipherTest.java:4906)
403     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

This fixes part of the OpenJDK SunJCE test: `crypto/Cipher/EmptyFinalBuffer.java`