### PR TITLE
Add `Cipher.getInstance("AES")` support

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -107,7 +107,7 @@ The JCE provider currently supports the following algorithms:
         AES/CCM/NoPadding
         AES/CTR/NoPadding
         AES/ECB/NoPadding
-        AES/ECB/PKCS5Padding
+        AES/ECB/PKCS5Padding (aliased also as: AES)
         AES/GCM/NoPadding
         AES/OFB/NoPadding
         DESede/CBC/NoPadding

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -281,6 +281,13 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcAESECBNoPadding");
             put("Cipher.AES/ECB/PKCS5Padding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcAESECBPKCS5Padding");
+
+            /* SunJCE and Bouncy Castle alias AES to AES/ECB/PKCS5Padding,
+             * we do the same here for compatibility. */
+            put("Cipher.AES",
+                "com.wolfssl.provider.jce.WolfCryptCipher$wcAESECBPKCS5Padding");
+            put("Cipher.AES SupportedModes", "ECB");
+            put("Cipher.AES SupportedPaddings", "NoPadding, PKCS5Padding");
         }
         if (FeatureDetect.AesCtrEnabled()) {
             put("Cipher.AES/CTR/NoPadding",


### PR DESCRIPTION
This PR adds support for the generic "AES" Cipher type (ex: `Cipher.getInstance("AES");`). Both SunJCE and Bouncy Castle map this to "AES/ECB/PKCS5Padding" internally, so we do the same here for compatibility.

This fixes one OpenJDK SunJCE test: `crypto/Cipher/GCMAPI.java`