### PR TITLE
Throw correct InvalidParameterException from Cipher.init() on unsupported mode

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -42,6 +42,7 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
 import java.security.InvalidKeyException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -522,8 +523,8 @@ public class WolfCryptCipher extends CipherSpi {
                 break;
 
             default:
-                throw new InvalidKeyException(
-                    "Cipher opmode must be ENCRYPT_MODE or DECRPYT_MODE");
+                throw new InvalidParameterException(
+                    "Cipher opmode must be ENCRYPT_MODE or DECRYPT_MODE");
         }
     }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -61,6 +61,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.AlgorithmParameters;
+import java.security.InvalidParameterException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.AlgorithmParameters;
 
@@ -191,6 +192,35 @@ public class WolfCryptCipherTest {
                 fail("Expected Cipher block size did not match, " +
                         "algo = " + enabledJCEAlgos.get(i));
             }
+        }
+    }
+
+    @Test
+    public void testAesInvalidModeThrowsInvalidParameterException()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               NoSuchPaddingException, InvalidKeyException,
+               InvalidAlgorithmParameterException {
+
+        Cipher cipher;
+
+        try {
+            cipher = Cipher.getInstance("AES/CBC/NoPadding", jceProvider);
+        } catch (NoSuchAlgorithmException e) {
+            /* skip if AES-CBC is not enabled */
+            return;
+        }
+
+        SecretKeySpec keySpec = new SecretKeySpec(new byte[16], "AES");
+        IvParameterSpec ivSpec = new IvParameterSpec(new byte[16]);
+
+        int invalidMode = 100;
+
+        try {
+            cipher.init(invalidMode, keySpec, ivSpec);
+            fail("Cipher.init() with invalid mode should throw " +
+                 "InvalidParameterException");
+        } catch (InvalidParameterException e) {
+            /* expected */
         }
     }
 


### PR DESCRIPTION
This PR adjusts the exception type thrown by `Cipher.init()` if an unsupported or incorrect mode is passed in. It was previously `InvalidKeyException`, but should be `InvalidParameterException` to match what consumers will expect.

This fixes the OpenJDK SunJCE test: `crypto/Cipher/TestCipherMode.java`