### PR TITLE
AES and GCM AlgorithmParameters Support

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -191,6 +191,7 @@ The JCE provider currently supports the following algorithms:
         WKS
 
     AlgorithmParameters
+        GCM
         RSASSA-PSS
 
 ### SecureRandom.getInstanceStrong()

--- a/README_JCE.md
+++ b/README_JCE.md
@@ -191,6 +191,7 @@ The JCE provider currently supports the following algorithms:
         WKS
 
     AlgorithmParameters
+        AES
         GCM
         RSASSA-PSS
 

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -70,6 +70,7 @@ infer --fail-on-issue run -- javac \
     src/main/java/com/wolfssl/wolfcrypt/WolfCryptState.java \
     src/main/java/com/wolfssl/wolfcrypt/WolfObject.java \
     src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptAesParameters.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptGcmParameters.java \

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -72,6 +72,7 @@ infer --fail-on-issue run -- javac \
     src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java \
+    src/main/java/com/wolfssl/provider/jce/WolfCryptGcmParameters.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java \
     src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java \

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptAesParameters.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptAesParameters.java
@@ -1,0 +1,138 @@
+/* WolfCryptAesParameters.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jce;
+
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import javax.crypto.spec.IvParameterSpec;
+
+/**
+ * wolfCrypt JCE AlgorithmParametersSpi implementation for AES parameters
+ */
+public class WolfCryptAesParameters extends AlgorithmParametersSpi {
+
+    private IvParameterSpec ivSpec;
+
+    /**
+     * Create new WolfCryptAesParameters object
+     */
+    public WolfCryptAesParameters() {
+        /* Set when initialized */
+        this.ivSpec = null;
+    }
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+            throws InvalidParameterSpecException {
+
+        if (!(paramSpec instanceof IvParameterSpec)) {
+            throw new InvalidParameterSpecException(
+                "Only IvParameterSpec supported");
+        }
+
+        IvParameterSpec spec = (IvParameterSpec) paramSpec;
+
+        /* Validate AES IV parameters */
+        if (spec.getIV() == null || spec.getIV().length == 0) {
+            throw new InvalidParameterSpecException(
+                "AES IV cannot be null or empty");
+        }
+
+        /* AES block size is 16 bytes, IV should match */
+        if (spec.getIV().length != 16) {
+            throw new InvalidParameterSpecException(
+                "AES IV must be 16 bytes, got: " + spec.getIV().length);
+        }
+
+        /* Clone the IV to prevent external modification */
+        this.ivSpec = new IvParameterSpec(spec.getIV().clone());
+    }
+
+    @Override
+    protected void engineInit(byte[] params)
+        throws IOException {
+
+        throw new IOException("Encoded AES parameters not supported");
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format)
+        throws IOException {
+
+        throw new IOException("Encoded AES parameters not supported");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(
+            Class<T> paramSpec) throws InvalidParameterSpecException {
+
+        if (this.ivSpec == null) {
+            throw new InvalidParameterSpecException(
+                "AES parameters not initialized");
+        }
+
+        if (paramSpec == null) {
+            throw new InvalidParameterSpecException(
+                "Parameter spec class cannot be null");
+        }
+
+        if (paramSpec == IvParameterSpec.class ||
+            paramSpec == AlgorithmParameterSpec.class) {
+            /* Return a copy to prevent external modification */
+            return (T) new IvParameterSpec(this.ivSpec.getIV().clone());
+        }
+
+        throw new InvalidParameterSpecException(
+            "Unsupported parameter spec: " + paramSpec.getName());
+    }
+
+    @Override
+    protected byte[] engineGetEncoded() throws IOException {
+        throw new IOException("Encoded AES parameters not supported");
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format) throws IOException {
+        throw new IOException("Encoded AES parameters not supported");
+    }
+
+    @Override
+    protected String engineToString() {
+        if (this.ivSpec == null) {
+            return "WolfCryptAesParameters[uninitialized]";
+        }
+
+        return "WolfCryptAesParameters[" +
+               "ivLen=" + (this.ivSpec.getIV() != null ?
+                           this.ivSpec.getIV().length : 0) +
+               "]";
+    }
+
+    @Override
+    public String toString() {
+        return engineToString();
+    }
+}
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -122,8 +122,8 @@ public class WolfCryptCipher extends CipherSpi {
     private AlgorithmParameterSpec storedSpec = null;
     private byte[] iv = null;
 
-    /* AES-GCM tag length (bytes) */
-    private int gcmTagLen = 0;
+    /* AES-GCM/CCM tag length (bytes), default to 128 bits */
+    private int gcmTagLen = 16;
 
     /* AAD data for AES-GCM, populated via engineUpdateAAD() */
     private byte[] aadData = null;
@@ -551,6 +551,7 @@ public class WolfCryptCipher extends CipherSpi {
                 rand.nextBytes(this.iv);
             }
 
+
         } else {
             if (cipherMode == CipherMode.WC_GCM) {
                 if (!(spec instanceof GCMParameterSpec)) {
@@ -790,7 +791,8 @@ public class WolfCryptCipher extends CipherSpi {
         try {
 
             if (params != null) {
-                if (this.cipherMode == CipherMode.WC_GCM) {
+                if (this.cipherMode == CipherMode.WC_GCM ||
+                    this.cipherMode == CipherMode.WC_CCM) {
                     spec = params.getParameterSpec(GCMParameterSpec.class);
                 }
                 else {
@@ -1141,10 +1143,18 @@ public class WolfCryptCipher extends CipherSpi {
              * (no IV was provided initially), wolfCryptSetIV would generate
              * a new random IV, overwriting the original one. */
             if (storedSpec == null && this.iv != null) {
-                /* Create an IvParameterSpec with the current IV to avoid
+                /* Create appropriate ParameterSpec with the current IV to avoid
                  * generating a new random IV during reset */
-                AlgorithmParameterSpec currentIvSpec =
-                    new IvParameterSpec(this.iv.clone());
+                AlgorithmParameterSpec currentIvSpec;
+                if (cipherMode == CipherMode.WC_GCM) {
+                    /* For GCM mode, create GCMParameterSpec with current
+                     * IV and tag length */
+                    currentIvSpec = new GCMParameterSpec(
+                        this.gcmTagLen * 8, this.iv.clone());
+                } else {
+                    /* For other modes, use IvParameterSpec */
+                    currentIvSpec = new IvParameterSpec(this.iv.clone());
+                }
                 wolfCryptSetIV(currentIvSpec, null);
             } else {
                 wolfCryptSetIV(storedSpec, null);

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -466,9 +466,9 @@ public class WolfCryptCipher extends CipherSpi {
             switch (this.cipherMode) {
                 case WC_GCM:
                 case WC_CCM:
-                    /* For AES-GCM/CCM, return GCM parameters */
-                    params = AlgorithmParameters.getInstance("GCM");
+                    /* Return parameters only if initialized */
                     if (this.iv != null && this.gcmTagLen > 0) {
+                        params = AlgorithmParameters.getInstance("GCM");
                         GCMParameterSpec gcmSpec = new GCMParameterSpec(
                             this.gcmTagLen * 8, this.iv);
                         params.init(gcmSpec);

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptGcmParameters.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptGcmParameters.java
@@ -1,0 +1,135 @@
+/* WolfCryptGcmParameters.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jce;
+
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * wolfCrypt JCE AlgorithmParametersSpi implementation for AES-GCM parameters
+ */
+public class WolfCryptGcmParameters extends AlgorithmParametersSpi {
+
+    private GCMParameterSpec gcmSpec;
+
+    /**
+     * Create new WolfCryptGcmParameters object
+     */
+    public WolfCryptGcmParameters() {
+        /* Set when initialized */
+        this.gcmSpec = null;
+    }
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+            throws InvalidParameterSpecException {
+
+        if (!(paramSpec instanceof GCMParameterSpec)) {
+            throw new InvalidParameterSpecException(
+                "Only GCMParameterSpec supported");
+        }
+
+        GCMParameterSpec spec = (GCMParameterSpec) paramSpec;
+
+        /* Validate parameters */
+        if (spec.getIV() == null || spec.getIV().length == 0) {
+            throw new InvalidParameterSpecException(
+                "GCM IV cannot be null or empty");
+        }
+
+        if (spec.getTLen() <= 0) {
+            throw new InvalidParameterSpecException(
+                "GCM tag length must be positive");
+        }
+
+        /* Clone the IV to prevent external modification */
+        this.gcmSpec = new GCMParameterSpec(
+            spec.getTLen(), spec.getIV().clone());
+    }
+
+    @Override
+    protected void engineInit(byte[] params)
+        throws IOException {
+
+        throw new IOException("Encoded GCM parameters not supported");
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format)
+        throws IOException {
+
+        throw new IOException("Encoded GCM parameters not supported");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(
+            Class<T> paramSpec) throws InvalidParameterSpecException {
+
+        if (this.gcmSpec == null) {
+            throw new InvalidParameterSpecException(
+                "GCM parameters not initialized");
+        }
+
+        if (paramSpec == null) {
+            throw new InvalidParameterSpecException(
+                "Parameter spec class cannot be null");
+        }
+
+        if (paramSpec == GCMParameterSpec.class ||
+            paramSpec == AlgorithmParameterSpec.class) {
+            /* Return a copy to prevent external modification */
+            return (T) new GCMParameterSpec(
+                this.gcmSpec.getTLen(), this.gcmSpec.getIV().clone());
+        }
+
+        throw new InvalidParameterSpecException(
+            "Unsupported parameter spec: " + paramSpec.getName());
+    }
+
+    @Override
+    protected byte[] engineGetEncoded() throws IOException {
+        throw new IOException("Encoded GCM parameters not supported");
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format) throws IOException {
+        throw new IOException("Encoded GCM parameters not supported");
+    }
+
+    @Override
+    protected String engineToString() {
+        if (this.gcmSpec == null) {
+            return "WolfCryptGcmParameters[uninitialized]";
+        }
+
+        return "WolfCryptGcmParameters[" +
+               "tagLen=" + this.gcmSpec.getTLen() +
+               ", ivLen=" + (this.gcmSpec.getIV() != null ?
+                             this.gcmSpec.getIV().length : 0) +
+               "]";
+    }
+}
+

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -339,6 +339,10 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.AesEnabled()) {
             put("KeyGenerator.AES",
                 "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcAESKeyGenerator");
+
+            /* AES Algorithm Parameters */
+            put("AlgorithmParameters.AES",
+                "com.wolfssl.provider.jce.WolfCryptAesParameters");
         }
         if (FeatureDetect.HmacShaEnabled()) {
             put("KeyGenerator.HmacSHA1",

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -300,6 +300,12 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.AesGcmEnabled()) {
             put("Cipher.AES/GCM/NoPadding",
                 "com.wolfssl.provider.jce.WolfCryptCipher$wcAESGCMNoPadding");
+
+            /* GCM Algorithm Parameters */
+            put("AlgorithmParameters.GCM",
+                "com.wolfssl.provider.jce.WolfCryptGcmParameters");
+            /* Alias for AES-GCM */
+            put("Alg.Alias.AlgorithmParameters.AES-GCM", "GCM");
         }
         if (FeatureDetect.AesCcmEnabled()) {
             put("Cipher.AES/CCM/NoPadding",

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -5639,5 +5639,403 @@ public class WolfCryptCipherTest {
                 plaintext, ptext);
         }
     }
+
+    /**
+     * Test AlgorithmParameters.getInstance("GCM") basic functionality
+     */
+    @Test
+    public void testGCMAlgorithmParametersGetInstance()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        /* Test getting instance with "GCM" algorithm */
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+        assertNotNull("GCM AlgorithmParameters should not be null", params);
+        assertEquals("Provider should be wolfJCE", jceProvider,
+            params.getProvider().getName());
+
+        /* Test alias "AES-GCM" */
+        AlgorithmParameters paramsAlias =
+            AlgorithmParameters.getInstance("AES-GCM", jceProvider);
+        assertNotNull("AES-GCM AlgorithmParameters should not be null",
+            paramsAlias);
+        assertEquals("Provider should be wolfJCE", jceProvider,
+            paramsAlias.getProvider().getName());
+    }
+
+    /**
+     * Test GCM AlgorithmParameters initialization with GCMParameterSpec
+     */
+    @Test
+    public void testGCMAlgorithmParametersInit()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        /* Test with valid GCMParameterSpec */
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+
+        params.init(gcmSpec);
+
+        /* Get the spec back and verify */
+        GCMParameterSpec retrievedSpec =
+            params.getParameterSpec(GCMParameterSpec.class);
+        assertNotNull("Retrieved GCMParameterSpec should not be null",
+            retrievedSpec);
+        assertEquals("Tag length should match", 128, retrievedSpec.getTLen());
+        assertArrayEquals("IV should match", iv, retrievedSpec.getIV());
+
+        /* Test with different tag lengths */
+        int[] tagLengths = {96, 104, 112, 120, 128};
+        for (int tagLen : tagLengths) {
+            params = AlgorithmParameters.getInstance("GCM", jceProvider);
+            gcmSpec = new GCMParameterSpec(tagLen, iv);
+            params.init(gcmSpec);
+
+            retrievedSpec = params.getParameterSpec(GCMParameterSpec.class);
+            assertEquals("Tag length should match for " + tagLen,
+                tagLen, retrievedSpec.getTLen());
+        }
+    }
+
+    /**
+     * Test GCM AlgorithmParameters parameter validation
+     */
+    @Test
+    public void testGCMAlgorithmParametersValidation()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        /* Test with null IV - GCMParameterSpec constructor throws
+         * IllegalArgumentException for null IV */
+        try {
+            GCMParameterSpec invalidSpec = new GCMParameterSpec(128, null);
+            params.init(invalidSpec);
+            fail("Should throw IllegalArgumentException for null IV");
+        } catch (Exception e) {
+            assertTrue("Should be IllegalArgumentException",
+                e instanceof IllegalArgumentException);
+        }
+
+        /* Test with empty IV */
+        try {
+            params = AlgorithmParameters.getInstance("GCM", jceProvider);
+            GCMParameterSpec invalidSpec = new GCMParameterSpec(128,
+                new byte[0]);
+            params.init(invalidSpec);
+            fail("Should throw InvalidParameterSpecException for empty IV");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+
+        /* Test with invalid tag length */
+        try {
+            params = AlgorithmParameters.getInstance("GCM", jceProvider);
+            byte[] iv = new byte[12];
+            GCMParameterSpec invalidSpec = new GCMParameterSpec(0, iv);
+            params.init(invalidSpec);
+            fail("Should throw InvalidParameterSpecException for " +
+                "zero tag length");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+
+        /* Test with negative tag length */
+        try {
+            params = AlgorithmParameters.getInstance("GCM", jceProvider);
+            byte[] iv = new byte[12];
+            GCMParameterSpec invalidSpec = new GCMParameterSpec(-1, iv);
+            params.init(invalidSpec);
+            fail("Should throw InvalidParameterSpecException for " +
+                "negative tag length");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+
+        /* Test with non-GCMParameterSpec */
+        try {
+            params = AlgorithmParameters.getInstance("GCM", jceProvider);
+            IvParameterSpec invalidSpec = new IvParameterSpec(new byte[12]);
+            params.init(invalidSpec);
+            fail("Should throw InvalidParameterSpecException for " +
+                "non-GCMParameterSpec");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+    }
+
+    /**
+     * Test GCM AlgorithmParameters getParameterSpec with different classes
+     */
+    @Test
+    public void testGCMAlgorithmParametersGetParameterSpec()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        params.init(gcmSpec);
+
+        /* Test getting GCMParameterSpec */
+        GCMParameterSpec retrievedSpec =
+            params.getParameterSpec(GCMParameterSpec.class);
+        assertNotNull("Should return GCMParameterSpec", retrievedSpec);
+        assertEquals("Tag length should match", 128, retrievedSpec.getTLen());
+        assertArrayEquals("IV should match", iv, retrievedSpec.getIV());
+
+        /* Test getting AlgorithmParameterSpec (superclass) */
+        AlgorithmParameterSpec genericSpec =
+            params.getParameterSpec(AlgorithmParameterSpec.class);
+        assertNotNull("Should return AlgorithmParameterSpec", genericSpec);
+        assertTrue("Should be instance of GCMParameterSpec",
+            genericSpec instanceof GCMParameterSpec);
+
+        /* Test with unsupported class */
+        try {
+            params.getParameterSpec(IvParameterSpec.class);
+            fail("Should throw InvalidParameterSpecException for " +
+                "unsupported class");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+
+        /* Test with null class */
+        try {
+            params.getParameterSpec(null);
+            fail("Should throw InvalidParameterSpecException for null class");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+
+        /* Test getting spec from uninitialized parameters */
+        try {
+            AlgorithmParameters uninitParams =
+                AlgorithmParameters.getInstance("GCM", jceProvider);
+            uninitParams.getParameterSpec(GCMParameterSpec.class);
+            fail("Should throw InvalidParameterSpecException for " +
+                "uninitialized parameters");
+        } catch (Exception e) {
+            assertTrue("Should be InvalidParameterSpecException",
+                e instanceof java.security.spec.InvalidParameterSpecException);
+        }
+    }
+
+    /**
+     * Test GCM AlgorithmParameters unsupported operations
+     */
+    @Test
+    public void testGCMAlgorithmParametersUnsupportedOperations()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        /* Test encoded parameter operations (should be unsupported) */
+        try {
+            params.init(new byte[16]);
+            fail("Should throw IOException for encoded init");
+        } catch (Exception e) {
+            assertTrue("Should be IOException",
+                e instanceof java.io.IOException);
+        }
+
+        try {
+            params.init(new byte[16], "DER");
+            fail("Should throw IOException for encoded init with format");
+        } catch (Exception e) {
+            assertTrue("Should be IOException",
+                e instanceof java.io.IOException);
+        }
+
+        /* Initialize with valid spec for encoding tests */
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        params.init(gcmSpec);
+
+        try {
+            params.getEncoded();
+            fail("Should throw IOException for getEncoded");
+        } catch (Exception e) {
+            assertTrue("Should be IOException",
+                e instanceof java.io.IOException);
+        }
+
+        try {
+            params.getEncoded("DER");
+            fail("Should throw IOException for getEncoded with format");
+        } catch (Exception e) {
+            assertTrue("Should be IOException",
+                e instanceof java.io.IOException);
+        }
+    }
+
+    /**
+     * Test GCM AlgorithmParameters toString method
+     */
+    @Test
+    public void testGCMAlgorithmParametersToString()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        /* Test toString for uninitialized parameters - Java
+         * AlgorithmParameters.toString() returns null when uninitialized */
+        String uninitString = params.toString();
+        /* Standard Java behavior is to return null for uninitialized params */
+        assertNull("Uninitialized toString should return null", uninitString);
+
+        /* Test toString for initialized parameters */
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        params.init(gcmSpec);
+
+        String initString = params.toString();
+        assertNotNull("toString should not return null", initString);
+        assertTrue("Should contain tag length",
+            initString.contains("tagLen=128"));
+        assertTrue("Should contain IV length",
+            initString.contains("ivLen=12"));
+    }
+
+    /**
+     * Test GCM AlgorithmParameters IV isolation (no external modification)
+     */
+    @Test
+    public void testGCMAlgorithmParametersIVIsolation()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        /* Create IV and modify original after init */
+        byte[] originalIV = new byte[12];
+        new SecureRandom().nextBytes(originalIV);
+        byte[] originalIVCopy = originalIV.clone();
+
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, originalIV);
+        params.init(gcmSpec);
+
+        /* Modify the original IV array */
+        Arrays.fill(originalIV, (byte) 0xFF);
+
+        /* Get the spec back and verify IV wasn't modified */
+        GCMParameterSpec retrievedSpec =
+            params.getParameterSpec(GCMParameterSpec.class);
+        assertArrayEquals("IV should not be affected by external modification",
+            originalIVCopy, retrievedSpec.getIV());
+
+        /* Modify the retrieved IV and get spec again */
+        byte[] retrievedIV = retrievedSpec.getIV();
+        Arrays.fill(retrievedIV, (byte) 0x00);
+
+        GCMParameterSpec retrievedSpec2 =
+            params.getParameterSpec(GCMParameterSpec.class);
+        assertArrayEquals("Internal IV should not be affected by " +
+            "modification of returned array", originalIVCopy,
+            retrievedSpec2.getIV());
+    }
+
+    /**
+     * Test GCM AlgorithmParameters integration with Cipher operations
+     */
+    @Test
+    public void testGCMAlgorithmParametersWithCipher()
+            throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            /* GCM not compiled in */
+            return;
+        }
+
+        /* Create AlgorithmParameters with GCM spec */
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("GCM", jceProvider);
+
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        params.init(gcmSpec);
+
+        /* Use with cipher for encryption */
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+        SecretKeySpec keySpec = new SecretKeySpec(new byte[16], "AES");
+
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, params);
+
+        byte[] plaintext = "Test message for GCM cipher integration".getBytes();
+        byte[] ciphertext = cipher.doFinal(plaintext);
+
+        /* Decrypt using the same parameters */
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, params);
+        byte[] decrypted = cipher.doFinal(ciphertext);
+
+        assertArrayEquals("Decrypted text should match original",
+            plaintext, decrypted);
+
+        /* Verify cipher returns compatible parameters */
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        AlgorithmParameters cipherParams = cipher.getParameters();
+        assertNotNull("Cipher should return parameters", cipherParams);
+
+        /* Should be able to use cipher-returned params for decryption */
+        byte[] ciphertext2 = cipher.doFinal(plaintext);
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, cipherParams);
+        byte[] decrypted2 = cipher.doFinal(ciphertext2);
+
+        assertArrayEquals("Should decrypt correctly with cipher parameters",
+            plaintext, decrypted2);
+    }
 }
 


### PR DESCRIPTION
This PR adds `AlgorithmParameters.getInstance("AES")` and `AlgorithmParameters.getInstance("GCM")` support to wolfJCE. These normally come from SunJCE, but if that provider has been removed from the system these can now be used directly from wolfJCE's implementations.

This PR also fixes a AES-GCM/CCM tag length issue by setting the default tag length to 128 bits (16 bytes).

These changes allow several additional OpenJDK SunJCE tests to pass.