### PR TITLE
Add JCE support for HmacSHA3 KeyGenerator

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -166,6 +166,10 @@ The JCE provider currently supports the following algorithms:
         HmacSHA256
         HmacSHA384
         HmacSHA512
+        HmacSHA3-224
+        HmacSHA3-256
+        HmacSHA3-384
+        HmacSHA3-512
 
     KeyPairGenerator Class
         RSA

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
@@ -27,6 +27,7 @@ import com.wolfssl.wolfcrypt.Sha224;
 import com.wolfssl.wolfcrypt.Sha256;
 import com.wolfssl.wolfcrypt.Sha384;
 import com.wolfssl.wolfcrypt.Sha512;
+import com.wolfssl.wolfcrypt.Sha3;
 import javax.crypto.KeyGeneratorSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -49,7 +50,11 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
         WC_HMAC_SHA224,
         WC_HMAC_SHA256,
         WC_HMAC_SHA384,
-        WC_HMAC_SHA512
+        WC_HMAC_SHA512,
+        WC_HMAC_SHA3_224,
+        WC_HMAC_SHA3_256,
+        WC_HMAC_SHA3_384,
+        WC_HMAC_SHA3_512
     }
 
     private AlgoType algoType = AlgoType.WC_INVALID;
@@ -91,6 +96,22 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
             case WC_HMAC_SHA512:
                 this.algString = "HmacSHA512";
                 this.keySizeBits = (Sha512.DIGEST_SIZE * 8);
+                break;
+            case WC_HMAC_SHA3_224:
+                this.algString = "HmacSHA3-224";
+                this.keySizeBits = (Sha3.DIGEST_SIZE_224 * 8);
+                break;
+            case WC_HMAC_SHA3_256:
+                this.algString = "HmacSHA3-256";
+                this.keySizeBits = (Sha3.DIGEST_SIZE_256 * 8);
+                break;
+            case WC_HMAC_SHA3_384:
+                this.algString = "HmacSHA3-384";
+                this.keySizeBits = (Sha3.DIGEST_SIZE_384 * 8);
+                break;
+            case WC_HMAC_SHA3_512:
+                this.algString = "HmacSHA3-512";
+                this.keySizeBits = (Sha3.DIGEST_SIZE_512 * 8);
                 break;
         }
 
@@ -232,6 +253,10 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
             case WC_HMAC_SHA256:
             case WC_HMAC_SHA384:
             case WC_HMAC_SHA512:
+            case WC_HMAC_SHA3_224:
+            case WC_HMAC_SHA3_256:
+            case WC_HMAC_SHA3_384:
+            case WC_HMAC_SHA3_512:
                 return new SecretKeySpec(keyArr, this.algString);
             default:
                 return null;
@@ -319,6 +344,62 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
          */
         public wcHMACSha512KeyGenerator() {
             super(AlgoType.WC_HMAC_SHA512);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA3-224) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha3_224KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha3_224KeyGenerator.
+         */
+        public wcHMACSha3_224KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA3_224);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA3-256) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha3_256KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha3_256KeyGenerator.
+         */
+        public wcHMACSha3_256KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA3_256);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA3-384) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha3_384KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha3_384KeyGenerator.
+         */
+        public wcHMACSha3_384KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA3_384);
+        }
+    }
+
+    /**
+     * KeyGenerator(HmacSHA3-512) class, called by WolfCryptProvider.
+     */
+    public static final class wcHMACSha3_512KeyGenerator
+        extends WolfCryptKeyGenerator {
+
+        /**
+         * Constructor for wcHMACSha3_512KeyGenerator.
+         */
+        public wcHMACSha3_512KeyGenerator() {
+            super(AlgoType.WC_HMAC_SHA3_512);
         }
     }
 }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -364,6 +364,22 @@ public final class WolfCryptProvider extends Provider {
             put("KeyGenerator.HmacSHA512",
                 "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha512KeyGenerator");
         }
+        if (FeatureDetect.HmacSha3_224Enabled()) {
+            put("KeyGenerator.HmacSHA3-224",
+                "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha3_224KeyGenerator");
+        }
+        if (FeatureDetect.HmacSha3_256Enabled()) {
+            put("KeyGenerator.HmacSHA3-256",
+                "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha3_256KeyGenerator");
+        }
+        if (FeatureDetect.HmacSha3_384Enabled()) {
+            put("KeyGenerator.HmacSHA3-384",
+                "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha3_384KeyGenerator");
+        }
+        if (FeatureDetect.HmacSha3_512Enabled()) {
+            put("KeyGenerator.HmacSHA3-512",
+                "com.wolfssl.provider.jce.WolfCryptKeyGenerator$wcHMACSha3_512KeyGenerator");
+        }
 
         /* KeyPairGenerator */
         if (FeatureDetect.RsaKeyGenEnabled()) {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyGeneratorTest.java
@@ -47,6 +47,7 @@ import com.wolfssl.wolfcrypt.Sha224;
 import com.wolfssl.wolfcrypt.Sha256;
 import com.wolfssl.wolfcrypt.Sha384;
 import com.wolfssl.wolfcrypt.Sha512;
+import com.wolfssl.wolfcrypt.Sha3;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 
 public class WolfCryptKeyGeneratorTest {
@@ -57,7 +58,11 @@ public class WolfCryptKeyGeneratorTest {
         "HmacSHA224",
         "HmacSHA256",
         "HmacSHA384",
-        "HmacSHA512"
+        "HmacSHA512",
+        "HmacSHA3-224",
+        "HmacSHA3-256",
+        "HmacSHA3-384",
+        "HmacSHA3-512"
     };
 
     private static int[] aesKeySizes = { 128, 192, 256 };
@@ -96,6 +101,23 @@ public class WolfCryptKeyGeneratorTest {
             /* Skip HmacSHA224 if not supported by native wolfSSL */
             if (alg.equals("HmacSHA224") &&
                 !FeatureDetect.HmacSha224Enabled()) {
+                continue;
+            }
+            /* Skip HmacSHA3 algorithms if not supported by native wolfSSL */
+            if (alg.equals("HmacSHA3-224") &&
+                !FeatureDetect.HmacSha3_224Enabled()) {
+                continue;
+            }
+            if (alg.equals("HmacSHA3-256") &&
+                !FeatureDetect.HmacSha3_256Enabled()) {
+                continue;
+            }
+            if (alg.equals("HmacSHA3-384") &&
+                !FeatureDetect.HmacSha3_384Enabled()) {
+                continue;
+            }
+            if (alg.equals("HmacSHA3-512") &&
+                !FeatureDetect.HmacSha3_512Enabled()) {
                 continue;
             }
             kg = KeyGenerator.getInstance(alg, "wolfJCE");
@@ -164,6 +186,62 @@ public class WolfCryptKeyGeneratorTest {
 
         testKeyGeneration("HmacSHA512", new int[] { 512 });
         testKeyGenerationDefaultKeySize("HmacSHA512", Sha512.DIGEST_SIZE * 8);
+    }
+
+    @Test
+    public void testHmacSHA3_224KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* Skip test if HmacSHA3-224 is not supported by native wolfSSL */
+        if (!FeatureDetect.HmacSha3_224Enabled()) {
+            return;
+        }
+
+        testKeyGeneration("HmacSHA3-224", new int[] { 224 });
+        testKeyGenerationDefaultKeySize("HmacSHA3-224",
+            Sha3.DIGEST_SIZE_224 * 8);
+    }
+
+    @Test
+    public void testHmacSHA3_256KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* Skip test if HmacSHA3-256 is not supported by native wolfSSL */
+        if (!FeatureDetect.HmacSha3_256Enabled()) {
+            return;
+        }
+
+        testKeyGeneration("HmacSHA3-256", new int[] { 256 });
+        testKeyGenerationDefaultKeySize("HmacSHA3-256",
+            Sha3.DIGEST_SIZE_256 * 8);
+    }
+
+    @Test
+    public void testHmacSHA3_384KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* Skip test if HmacSHA3-384 is not supported by native wolfSSL */
+        if (!FeatureDetect.HmacSha3_384Enabled()) {
+            return;
+        }
+
+        testKeyGeneration("HmacSHA3-384", new int[] { 384 });
+        testKeyGenerationDefaultKeySize("HmacSHA3-384",
+            Sha3.DIGEST_SIZE_384 * 8);
+    }
+
+    @Test
+    public void testHmacSHA3_512KeyGeneration()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* Skip test if HmacSHA3-512 is not supported by native wolfSSL */
+        if (!FeatureDetect.HmacSha3_512Enabled()) {
+            return;
+        }
+
+        testKeyGeneration("HmacSHA3-512", new int[] { 512 });
+        testKeyGenerationDefaultKeySize("HmacSHA3-512",
+            Sha3.DIGEST_SIZE_512 * 8);
     }
 
     /**


### PR DESCRIPTION
This PR implements HmacSHA3 variant support in `KeyGenerator`. We already had HmacSHA3 support in the `Mac` class, but not yet in `KeyGenerator`:

```
KeyGenerator:
- HmacSHA3-224
- HmacSHA3-256
- HmacSHA3-384
- HmacSHA3-512
```

JUnit tests are included here for regression.  This fixes the OpenJDK SunJCE test: `crypto/provider/Mac/MacKAT.java`