### PR TITLE
Check for RSAPrivateCrtKey in WolfCryptCipher for RSA

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -45,6 +45,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.InvalidKeyException;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 
 import com.wolfssl.wolfcrypt.Aes;
@@ -666,6 +667,17 @@ public class WolfCryptCipher extends CipherSpi {
 
             if (key instanceof RSAPrivateKey) {
                 this.rsaKeyType = RsaKeyType.WC_RSA_PRIVATE;
+
+                /* wolfSSL requires CRT parameters for RSA private key
+                 * operations. Non-CRT keys (created with only n and d) will
+                 * fail with "mp_exptmod error state" or similar in the
+                 * native layer. */
+                if (!(key instanceof RSAPrivateCrtKey)) {
+                    throw new InvalidKeyException(
+                        "RSA private key must include CRT parameters " +
+                        "(p, q, dP, dQ, qInv). Keys created from only " +
+                        "modulus and exponent are not supported by wolfSSL.");
+                }
 
             } else if (key instanceof RSAPublicKey) {
                 this.rsaKeyType = RsaKeyType.WC_RSA_PUBLIC;


### PR DESCRIPTION
WolfCryptCipher RSA currently only supports `PrivateKey` objects of type `RSAPrivateCrtKey`. This PR adjusts to throw an exception if the key does not include CRT parameters, as required by native wolfSSL. This gives users a more meaningful error/exception up front rather than a `mp_exptmod error` later on.

JUnit tests included for regression prevention.

This helps fix OpenJDK SunJCE test: `crypto/provider/Cipher/RSA/TestRSA.java`