### PR TITLE
Fix RSA-PSS signature verification and key generation issues

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -389,8 +389,9 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.RsaKeyGenEnabled()) {
             put("KeyPairGenerator.RSA",
                 "com.wolfssl.provider.jce.WolfCryptKeyPairGenerator$wcKeyPairGenRSA");
-            /* RSASSA-PSS uses same key generation as RSA */
-            put("Alg.Alias.KeyPairGenerator.RSASSA-PSS", "RSA");
+            put("KeyPairGenerator.RSASSA-PSS",
+                "com.wolfssl.provider.jce.WolfCryptKeyPairGenerator$wcKeyPairGenRSAPSS");
+            put("Alg.Alias.KeyPairGenerator.1.2.840.113549.1.1.10", "RSASSA-PSS");
         }
         if (FeatureDetect.EccKeyGenEnabled()) {
             put("KeyPairGenerator.EC",
@@ -401,6 +402,7 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfCryptKeyPairGenerator$wcKeyPairGenDH");
             put("Alg.Alias.KeyPairGenerator.DiffieHellman", "DH");
         }
+
 
         /* CertPathValidator */
         put("CertPathValidator.PKIX",

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPssParameters.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPssParameters.java
@@ -29,6 +29,7 @@ import java.security.spec.PSSParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
 
 import com.wolfssl.wolfcrypt.Rsa;
+import com.wolfssl.wolfcrypt.Sha256;
 
 /**
  * wolfCrypt JCE AlgorithmParametersSpi implementation for RSA-PSS parameters
@@ -46,7 +47,7 @@ public class WolfCryptPssParameters extends AlgorithmParametersSpi {
             "SHA-256",                       /* message digest */
             "MGF1",                          /* mask generation function */
             MGF1ParameterSpec.SHA256,        /* MGF parameters */
-            Rsa.RSA_PSS_SALT_LEN_DEFAULT,    /* salt length (hash length) */
+            Sha256.DIGEST_SIZE,              /* salt length */
             1                                /* trailer field (always 1) */
         );
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -25,6 +25,7 @@ import java.security.SignatureSpi;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -355,6 +356,14 @@ public class WolfCryptSignature extends SignatureSpi {
         if (this.keyType == KeyType.WC_RSA &&
                 !(privateKey instanceof RSAPrivateKey)) {
             throw new InvalidKeyException("Key is not of type RSAPrivateKey");
+
+        } else if (this.keyType == KeyType.WC_RSA &&
+                   privateKey instanceof RSAPrivateKey &&
+                   !(privateKey instanceof RSAPrivateCrtKey)) {
+            throw new InvalidKeyException(
+                "RSA private key must include CRT parameters " +
+                "(p, q, dP, dQ, qInv). Keys created from only " +
+                "modulus and exponent are not supported by wolfSSL.");
 
         } else if (this.keyType == KeyType.WC_ECDSA &&
                 !(privateKey instanceof ECPrivateKey)) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -856,9 +856,13 @@ public class WolfCryptSignature extends SignatureSpi {
                     }
 
                     try {
-                        verified = this.rsa.rsaPssVerify(sigBytes, digest,
-                            digestTypeToHashType(this.digestType),
-                            mgfType, saltLen);
+                        /* Use rsaPssVerifyWithDigest for pre-computed digest
+                         * verification. Pass digest as both data and digest
+                         * since we only have the final digest here */
+                        verified = this.rsa.rsaPssVerifyWithDigest(
+                            sigBytes, digest, digest,
+                            digestTypeToHashType(this.digestType), mgfType,
+                            saltLen);
 
                     } catch (WolfCryptException e) {
                         verified = false;


### PR DESCRIPTION
This PR includes several fixes for RSA-PSS signature verification and key generation issues:

- Fix `WolfCryptSignature.engineVerify()` to correctly pass digest to `rsaPssVerifyWithDigest()` instead of incorrect digest as "full data"
- Add restriction for `RSAPrivateCrtKey` keys in `WolfCryptSignature`, similar to `WolfCryptCipher`, since native wolfCrypt requires CRT parameters for RSA ops.
- Improve `RSASSA-PSS` `KeyPairGenerator` compatibility with system `KeyFactory`
- Fix default SHA-256 salt length in `WolfCryptPSSParameters`

This PR includes JUnit tests to help prevent regression.

These fixes fix several of the OpenJDK SunJCE tests that were failing with wolfJCE running underneath.