### PR TITLE
Fix ECC KeyPairGenerator bits to bytes conversion

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -111,7 +111,12 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                 "please call initialize() with DHParameterSpec");
         }
 
-        this.keysize = keysize;
+        if (type == KeyType.WC_ECC) {
+            /* ECC keysize from Java is bits, but wolfSSL expects bytes */
+            this.keysize = (keysize + 7) / 8;
+        } else {
+            this.keysize = keysize;
+        }
 
         if (type == KeyType.WC_RSA) {
             /* Set default RSA exponent for wolfSSL */
@@ -313,6 +318,10 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                  * multiple threads from mixing up keys during generation */
                 synchronized (rngLock) {
                     ecc = new Ecc(this.rng);
+
+                    log("generating ECC key on curve: " +
+                        (this.curve == null ? "default" : this.curve) +
+                        ", keysize: " + this.keysize);
 
                     if (this.curve == null) {
                         ecc.makeKey(this.rng, this.keysize);


### PR DESCRIPTION
This PR fixes ECC KeyPairGenerator bits to bytes conversion. Java applications pass in key size in bits, but native wolfSSL expects key size in bytes.

JUnit test added for regression prevention.

This fixes OpenJDK SunJCE test: `security/Signature/SignatureLength.java`