### PR TITLE
Prep for 1.10 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,78 @@
+### wolfCrypt JNI Release 1.10.0 (04/15/2026)
+
+Release 1.10.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
+
+**New JCE Functionality:**
+- Add Cipher `RSA/ECB/OAEPWithSHA-256AndMGF1Padding` support (PR 188)
+- Add Cipher `RSA/ECB/OAEPWithSHA-1AndMGF1Padding` support (PR 191)
+- Add Cipher `WRAP_MODE` and `UNWRAP_MODE` support for RSA-based key wrapping (PR 197)
+- Add PKIX CertPathBuilder implementation using native wolfSSL `X509_STORE` (PR 190, 192, 198, 200)
+- Add `jdk.certpath.disabledAlgorithms` enforcement to CertPathBuilder and CertPathValidator (PR 200)
+- Register default FIPS error callback in `WolfCryptProvider` for FIPS error debugging (PR 207)
+- Enrich `WolfCryptException` with FIPS module status for `FIPS_NOT_ALLOWED_E` errors (PR 207)
+
+**New JNI Functionality:**
+- Add hex string conversion via `WolfCrypt.toHexString()` and `WolfCrypt.hexStringToByteArray()` (PR 187)
+- Add PEM to DER conversion support for keys and certificates (PR 186)
+- Add `setFlags()` and `setVerificationTime()` methods to `WolfSSLX509StoreCtx` (PR 192)
+
+**New Property Support:**
+- Add `wolfssl.skipLibraryLoad` system property for custom native library loading (PR 189)
+- Add `wolfjce.ioTimeout` system property for OCSP/CRL IO timeouts (PR 199)
+
+**JNI and JCE Changes:**
+- Fix FIPS error callback lifecycle, deregister native callback in `JNI_OnUnload` (PR 203)
+- Fix Ed25519 signature verification passing message length instead of signature length (PR 205)
+- Fix `jlong` to `word32` pointer cast in `RsaFlattenPublicKey` and `RsaExportCrtKey` (PR 205)
+- Fix unsigned return value handling for `wc_RsaEncryptSize()` across RSA functions (PR 205, 206)
+- Add HMAC offset/length bounds validation for byte array and ByteBuffer variants (PR 205)
+- Improve NULL check handling in HMAC, Ed25519, Curve25519, and Pwdbased JNI wrappers (PR 205)
+- Add missing `releaseByteArray()` calls across ECC, RSA, ChaCha, and AES-GCM JNI functions (PR 205, 206)
+- Fix incorrect error code in `HmacFinal` hash size check (PR 205)
+- Return defensive copy of IV array from `engineGetIV()` (PR 205)
+- Fix `wc_ecc_import_private_raw()` not passing validated `curveId` to underlying import function (PR 206)
+- Zeroize encoded key byte array in `WolfCryptPBEKey.destroy()` (PR 206)
+- Use constant-time comparison for GMAC tag verification (PR 206)
+- Add missing AES-CTR and AES-OFB cleanup in `WolfCryptCipher.finalize()` (PR 206)
+- Fix signed integer overflow in JNI offset/length bounds checks (PR 206)
+- Add ByteBuffer bounds validation in SHA, MD5, and RNG native functions (PR 206)
+- Fix missing return after throw in SHA and MD5 copy NULL checks (PR 206)
+- Remove unused `wc_RsaPSS_VerifyInline` JNI wrapper that skipped padding check (PR 206)
+- Reduce `WC_RNG` struct allocations in `WolfCryptCipher` and `WolfCryptDhParameterGenerator` (PR 208)
+- Expand FIPS-compliant SecureRandom sanitization in `WolfCryptKeyGenerator` (PR 209)
+- Zero intermediate output buffers before free across JNI wrappers (PR 210)
+- Fix DH key export return value reset in success paths (PR 210)
+- Free internal AES struct in GMAC after use (PR 210)
+
+**Example Changes:**
+- Add `CertPathBuilder` and `CertPathValidator` example (PR 190)
+- Update Android example project CMakeLists.txt file exclusion list (PR 198, 206)
+- Add JKS to BKS KeyStore conversion script for Android testing (PR 209)
+- Migrate Android example project from `jcenter()` to `mavenCentral()` and AndroidX (PR 209)
+- Add Gradle wrapper `distributionSha256Sum` to Android example project (PR 210)
+
+**Testing Changes:**
+- Add Java 24 and 25 tests to GitHub Actions workflows (PR 193)
+- Add GitHub Actions workflow for Linux 32-bit testing with Java 17 (PR 194)
+- Add GitHub Actions workflow for UBSan undefined behavior testing (PR 195)
+- Add `ant spotbugs` target and GitHub Actions SpotBugs static analysis workflow (PR 204)
+- Add GitHub Actions workflow for Android FIPS Ready testing (PR 209)
+- Add GitHub Actions workflow for Java 9+ module (JPMS) testing (PR 196)
+- Fix threaded MessageDigest tests hanging on FIPS error (PR 207)
+- Improve JUnit test reliability for FIPS mode and CI environments (PR 209)
+- Pin Bouncy Castle dependency version with SHA-256 hash verification (PR 209)
+- Update Apache Ant CI dependency to 1.10.16 (PR 209)
+
+**Misc Changes:**
+- Add Java 9+ module support (JPMS) for `jlink` compatibility (PR 196)
+- Fix Javadoc warnings about default constructors in `WolfCryptUtil` and `Asn` (PR 201)
+- Fix code issues and warnings found by SpotBugs static analysis (PR 204)
+- Update copyright dates to 2026 (PR 185)
+
+The wolfCrypt JNI/JCE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
+instructions and more details, please check the manual.
+
 ### wolfCrypt JNI Release 1.9.0 (12/31/2025)
 
 Release 1.9.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
@@ -107,7 +182,7 @@ Release 1.9.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
 
 The wolfCrypt JNI/JCE Manual is available at:
 https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
-instructions and more details comments, please check the manual.
+instructions and more details, please check the manual.
 
 ### wolfCrypt JNI Release 1.8.0 (01/23/2025)
 
@@ -128,7 +203,7 @@ Release 1.8.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
 
 The wolfCrypt JNI/JCE Manual is available at:
 https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
-instructions and more details comments, please check the manual.
+instructions and more details, please check the manual.
 
 ### wolfCrypt JNI Release 1.7.0 (11/11/2024)
 
@@ -152,7 +227,7 @@ Release 1.7.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
 
 The wolfCrypt JNI/JCE Manual is available at:
 https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
-instructions and more details comments, please check the manual.
+instructions and more details, please check the manual.
 
 ### wolfCrypt JNI Release 1.6.0 (4/17/2024)
 
@@ -208,7 +283,7 @@ Release 1.6.0 of wolfCrypt JNI and JCE has bug fixes and new features including:
 
 The wolfCrypt JNI/JCE Manual is available at:
 https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
-instructions and more details comments, please check the manual.
+instructions and more details, please check the manual.
 
 ### wolfCrypt JNI Release 1.5.0 (11/14/2022)
 

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -138,6 +138,12 @@ section titled `/* Configuration */`:
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
 #define OPENSSL_ALL
+#define WOLFSSL_SHA224
+#define HAVE_FFDHE_2048
+#define HAVE_FFDHE_3072
+#define HAVE_FFDHE_4096
+#define HAVE_FFDHE_Q
+#define WOLFSSL_VALIDATE_FFC_IMPORT
 #define WOLFSSL_PUBLIC_MP
 ```
 
@@ -210,6 +216,7 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
 #define OPENSSL_ALL
+#define HAVE_FFDHE_2048
 ```
 
 If also building wolfSSL JNI/JSSE, additional defines may be needed. Please

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ on the current release):
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfcrypt-jni</artifactId>
-            <version>1.9.0-SNAPSHOT</version>
+            <version>1.10.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.9" />
+    <property name="implementation.version" value="1.10" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.9.0-SNAPSHOT</version>
+	<version>1.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
     <url>https://www.wolfssl.com</url>

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -198,9 +198,16 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.ShaEnabled()) {
             put("Signature.SHA1withRSA",
                     "com.wolfssl.provider.jce.WolfCryptSignature$wcSHA1wRSA");
-            put("Signature.SHA1withECDSA",
+
+            /* FIPS 186-5 (wolfCrypt FIPS v7+) no longer allows SHA-1 for
+             * ECDSA signatures. Only register SHA1withECDSA when not using
+             * FIPS, or when using FIPS versions prior to v7 which follow
+             * FIPS 186-4. */
+            if (!Fips.enabled || Fips.fipsVersion < 7) {
+                put("Signature.SHA1withECDSA",
                     "com.wolfssl.provider.jce.WolfCryptSignature$wcSHA1wECDSA");
-            put("Alg.Alias.Signature.1.2.840.10045.4.1", "SHA1withECDSA");
+                put("Alg.Alias.Signature.1.2.840.10045.4.1", "SHA1withECDSA");
+            }
         }
         if (FeatureDetect.Sha224Enabled()) {
             put("Signature.SHA224withRSA",

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -85,7 +85,7 @@ public final class WolfCryptProvider extends Provider {
      * Create new WolfCryptProvider object
      */
     public WolfCryptProvider() {
-        super("wolfJCE", 1.9, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.10, "wolfCrypt JCE Provider");
 
         /* Refresh debug flags in case system properties were set after
          * WolfCryptDebug class was first loaded (e.g., via JAVA_OPTS) */

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfCryptError.java
@@ -33,8 +33,18 @@ public enum WolfCryptError {
 
     /* error codes match <wolfssl>/wolfssl/wolfcrypt/error-crypt.h */
 
-    /** errors -101 - -299 */
-    MAX_CODE_E          (-100),
+    /** errors -97 - -1008 */
+    MAX_CODE_E          (-96),
+
+    /** MP dynamic memory allocation failed */
+    MP_MEM              (-97),
+    /** MP value passed is not able to be used */
+    MP_VAL              (-98),
+    /** MP non-blocking returning after partial completion */
+    MP_WOULDBLOCK       (-99),
+    /** MP point not at infinity */
+    MP_NOT_INF          (-100),
+
     /** opening random device error */
     OPEN_RAN_E          (-101),
     /** reading random device error */
@@ -79,10 +89,21 @@ public enum WolfCryptError {
     /** got a mp zero result, not expected */
     MP_ZERO_E           (-121),
 
+    /** AES-EAX Authentication check failure */
+    AES_EAX_AUTH_E      (-122),
+    /** No longer usable for operation */
+    KEY_EXHAUSTED_E     (-123),
+
     /** out of memory error */
     MEMORY_E            (-125),
     /** var state modified by different thread */
     VAR_STATE_CHANGE_E  (-126),
+    /** FIPS Module in degraded mode */
+    FIPS_DEGRADED_E     (-127),
+    /** Module CODE too big */
+    FIPS_CODE_SZ_E      (-128),
+    /** Module DATA too big */
+    FIPS_DATA_SZ_E      (-129),
 
     /** RSA wrong block type for RSA function */
     RSA_WRONG_TYPE_E    (-130),
@@ -143,14 +164,22 @@ public enum WolfCryptError {
     ASN_SIG_KEY_E       (-157),
     /** ASN key init error, invalid input */
     ASN_DH_KEY_E        (-158),
-    /** ASN ntru key decode error, invalid input */
-    ASN_NTRU_KEY_E      (-159),
+    /** SRTP-KDF Known Answer Test Failure */
+    KDF_SRTP_KAT_FIPS_E (-159),
     /** ASN unsupported critical extension */
     ASN_CRIT_EXT_E      (-160),
     /** ASN alternate name error */
     ASN_ALT_NAME_E      (-161),
     /** ASN no PEM header found */
     ASN_NO_PEM_HEADER   (-162),
+    /** Ed25519 Known answer test failure */
+    ED25519_KAT_FIPS_E  (-163),
+    /** Ed448 Known answer test failure */
+    ED448_KAT_FIPS_E    (-164),
+    /** PBKDF2 Known answer test failure */
+    PBKDF2_KAT_FIPS_E   (-165),
+    /** Error for private/public key mismatch */
+    WC_KEY_MISMATCH_E   (-166),
 
     /** ECC input argument of wrong type */
     ECC_BAD_ARG_E       (-170),
@@ -170,6 +199,8 @@ public enum WolfCryptError {
     ALT_NAME_E          (-177),
     /** missing key usage extension */
     BAD_OCSP_RESPONDER  (-178),
+    /** CRL date error */
+    CRL_CERT_DATE_ERR   (-179),
 
     /** AES-GCM Authentication check failure */
     AES_GCM_AUTH_E      (-180),
@@ -290,6 +321,9 @@ public enum WolfCryptError {
     /** Hash Type not enabled/available */
     HASH_TYPE_E          (-232),
 
+    /** Invalid FIPS Version defined */
+    FIPS_INVALID_VER_E   (-233),
+
     /** Key size error, either too small or large */
     WC_KEY_SIZE_E        (-234),
     /** ASN Cert Gen, invalid country code size */
@@ -340,15 +374,117 @@ public enum WolfCryptError {
     ECDSA_PAT_FIPS_E     (-255),
     /** DH KAT failure */
     DH_KAT_FIPS_E        (-256),
-
+    /** AESCCM KAT failure */
+    AESCCM_KAT_FIPS_E   (-257),
+    /** SHA-3 KAT failure */
+    SHA3_KAT_FIPS_E      (-258),
+    /** ECDHE KAT failure */
+    ECDHE_KAT_FIPS_E     (-259),
+    /** AES-GCM invocation counter overflow */
+    AES_GCM_OVERFLOW_E   (-260),
+    /** AES-CCM invocation counter overflow */
+    AES_CCM_OVERFLOW_E   (-261),
+    /** RSA Key Pair-Wise Consistency check fail */
+    RSA_KEY_PAIR_E       (-262),
+    /** DH Check Priv Key error */
+    DH_CHECK_PRIV_E      (-263),
+    /** AF_ALG socket error */
+    WC_AFALG_SOCK_E      (-264),
+    /** /dev/crypto error */
+    WC_DEVCRYPTO_E       (-265),
+    /** zlib init error */
+    ZLIB_INIT_ERROR      (-266),
+    /** zlib compression error */
+    ZLIB_COMPRESS_ERROR  (-267),
+    /** zlib decompression error */
+    ZLIB_DECOMPRESS_ERROR (-268),
+    /** No signer in PKCS#7 signed data msg */
+    PKCS7_NO_SIGNER_E   (-269),
+    /** PKCS7 operations wants more input */
+    WC_PKCS7_WANT_READ_E (-270),
+    /** Crypto callback unavailable */
+    CRYPTOCB_UNAVAILABLE (-271),
+    /** Signature needs verified by caller */
+    PKCS7_SIGNEEDS_CHECK (-272),
+    /** PSS salt length not recoverable */
+    PSS_SALTLEN_RECOVER_E (-273),
+    /** ChaCha20Poly1305 limit overflow */
+    CHACHA_POLY_OVERFLOW (-274),
+    /** ASN self-signed certificate error */
+    ASN_SELF_SIGNED_E    (-275),
+    /** SAKKE derivation verification error */
+    SAKKE_VERIFY_FAIL_E  (-276),
+    /** IV was not set */
+    MISSING_IV           (-277),
+    /** Key was not set */
+    MISSING_KEY          (-278),
+    /** Value of length parameter is invalid */
+    BAD_LENGTH_E         (-279),
+    /** ECDSA KAT failure */
+    ECDSA_KAT_FIPS_E    (-280),
+    /** RSA Pairwise failure */
+    RSA_PAT_FIPS_E       (-281),
+    /** TLS12 KDF KAT failure */
+    KDF_TLS12_KAT_FIPS_E (-282),
+    /** TLS13 KDF KAT failure */
+    KDF_TLS13_KAT_FIPS_E (-283),
+    /** SSH KDF KAT failure */
+    KDF_SSH_KAT_FIPS_E   (-284),
+    /** DHE Pairwise Consistency Test failure */
+    DHE_PCT_E            (-285),
+    /** ECDHE Pairwise Consistency Test failure */
+    ECC_PCT_E            (-286),
     /** Cannot export private key */
     FIPS_PRIVATE_KEY_LOCKED_E (-287),
+    /** Protocol callback unavailable */
+    PROTOCOLCB_UNAVAILABLE (-288),
+    /** AES-SIV authentication failed */
+    AES_SIV_AUTH_E       (-289),
+    /** No valid device ID */
+    NO_VALID_DEVID       (-290),
+    /** Input/output failure */
+    IO_FAILED_E          (-291),
+    /** System/library call failed */
+    SYSLIB_FAILED_E      (-292),
+    /** Callback return to indicate HW has PSK */
+    USE_HW_PSK           (-293),
+    /** Entropy Repetition Test failed */
+    ENTROPY_RT_E         (-294),
+    /** Entropy Adaptive Proportion Test failed */
+    ENTROPY_APT_E        (-295),
+    /** Invalid ASN.1 - depth check */
+    ASN_DEPTH_E          (-296),
+    /** ASN.1 length invalid */
+    ASN_LEN_E            (-297),
+    /** SM4-GCM Authentication check failure */
+    SM4_GCM_AUTH_E       (-298),
+    /** SM4-CCM Authentication check failure */
+    SM4_CCM_AUTH_E       (-299),
+
+    /** Deadlock averted -- retry the call */
+    DEADLOCK_AVERTED_E   (-1000),
+    /** ASCON Authentication check failure */
+    ASCON_AUTH_E         (-1001),
+    /** Crypto acceleration is currently inhibited */
+    WC_ACCEL_INHIBIT_E   (-1002),
+    /** Bad index */
+    BAD_INDEX_E          (-1003),
+    /** Process interrupted */
+    INTERRUPTED_E        (-1004),
+    /** Encoded public key does not match stored hash */
+    MLKEM_PUB_HASH_E     (-1005),
+    /** Object is busy */
+    BUSY_E               (-1006),
+    /** Operation was redundant or preempted */
+    ALREADY_E            (-1007),
+    /** Sequence counter would overflow */
+    SEQ_OVERFLOW_E       (-1008),
 
     /** Update this to indicate last error */
-    WC_LAST_E            (-299),
+    WC_LAST_E            (-1008),
 
-    /** errors -101 - -299 */
-    MIN_CODE_E           (-300),
+    /** Last usable code */
+    MIN_CODE_E           (-1999),
 
     /** OCSP Certificate revoked */
     OCSP_CERT_REVOKED    (-360),

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptDHKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptDHKeyFactoryTest.java
@@ -46,6 +46,7 @@ import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -103,9 +104,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testDHKeyFactoryInstantiation() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         /* Test that we can get a DH KeyFactory instance */
         KeyFactory kf = KeyFactory.getInstance("DH", "wolfJCE");
@@ -123,9 +122,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testPKCS8PrivateKeyConversion() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a test key pair using wolfJCE */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -158,9 +156,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testX509PublicKeyConversion() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a test key pair using wolfJCE */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -193,9 +190,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testDHPrivateKeySpecConversion() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         /* Generate a test key pair using system provider for reference */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH");
@@ -230,9 +225,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testDHPublicKeySpecConversion() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         /* Generate a test key pair using system provider for reference */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH");
@@ -267,9 +260,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testKeySpecExtraction() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a test key pair using wolfJCE */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -306,9 +298,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testKeyTranslation() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         /* Generate a test key pair using system provider */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH");
@@ -342,9 +332,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testRoundTripConversion() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a test key pair using wolfJCE */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -374,9 +363,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testMultipleKeySizes() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         KeyFactory kf = KeyFactory.getInstance("DH", "wolfJCE");
 
@@ -416,9 +403,7 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testInvalidKeySpecs() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
 
         KeyFactory kf = KeyFactory.getInstance("DH", "wolfJCE");
 
@@ -467,9 +452,8 @@ public class WolfCryptDHKeyFactoryTest {
     public void testDHPrivateKeySpecConversionWithoutSunJCE()
         throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Remove SunJCE provider temporarily if present */
         Provider sunJCE = Security.getProvider("SunJCE");
@@ -512,9 +496,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testBigIntegerEdgeCases() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a reference key to get the DHParameterSpec */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -594,9 +577,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testParameterValidation() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         KeyFactory wolfKF = KeyFactory.getInstance("DH", "wolfJCE");
 
@@ -655,9 +637,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testPrivateKeyBoundaryValues() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a reference key to get the DHParameterSpec */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -706,9 +687,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testMemoryCleanup() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         KeyFactory wolfKF = KeyFactory.getInstance("DH", "wolfJCE");
 
@@ -740,9 +720,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testBackwardCompatibility() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate key using standard approach */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -774,9 +753,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testErrorHandling() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         KeyFactory wolfKF = KeyFactory.getInstance("DH", "wolfJCE");
 
@@ -830,9 +808,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testInteroperabilityWithSunJCE() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate key pair using SunJCE */
         KeyPairGenerator sunKpg = KeyPairGenerator.getInstance("DH");
@@ -890,9 +867,8 @@ public class WolfCryptDHKeyFactoryTest {
     @Test
     public void testRoundTripWithDHKeySpec() throws Exception {
 
-        if (!FeatureDetect.DhEnabled()) {
-            return;
-        }
+        Assume.assumeTrue(FeatureDetect.DhEnabled());
+        Assume.assumeTrue(enabledKeySizes.contains(2048));
 
         /* Generate a test key pair using wolfJCE */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");


### PR DESCRIPTION
This PR preps for the 1.10 release of wolfCrypt JNI/JCE:

- Updates ChangeLog.md
- Bump version to 1.10 in `build.xml`, `pom.xml`, `WolfCryptProvider.java`, `README.md`
- Update Windows Visual Studio `IDE/WIN/README.md` list of defines
- Update DH 2048 detection in tests
- Update wolfCrypt error code enum in `WolfCryptEnum.java` to match native `error-crypt.h`
- Skip registration of `SHA1withECDSA` when using wolfCrypt FIPS v7+ (FIPS 186-5 no longer allows SHA-1 for ECDSA signatures