### PR TITLE
Suppress JDK 24 deprecation/removal warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -323,6 +323,7 @@
             includeantruntime="false">
             <exclude name="com/wolfssl/provider/jce/test/**" unless="jar.includes.jce"/>
             <compilerarg value="-Xlint:-options" />
+            <compilerarg value="-Xlint:-path" />
         </javac>
 
     </target>

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -297,6 +297,7 @@ public class WolfCryptCipher extends CipherSpi {
      * @param spec OAEPParameterSpec containing OAEP parameters
      * @throws InvalidAlgorithmParameterException if parameters are invalid
      */
+    @SuppressWarnings("deprecation")
     private void setOaepParams(OAEPParameterSpec spec)
         throws InvalidAlgorithmParameterException {
 
@@ -1983,7 +1984,7 @@ public class WolfCryptCipher extends CipherSpi {
             () -> "[" + algString + "-" + algMode + "] " + msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
@@ -114,6 +114,7 @@ class WolfCryptDebug {
             Level level = record.getLevel();
             String levelStr = level != null ? level.getName() : "UNKNOWN";
 
+            @SuppressWarnings("deprecation")
             long threadId = record.getThreadID();
             String message = record.getMessage();
             if (message == null) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -662,7 +662,7 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
             () -> "[" + algString + "] " + msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -685,7 +685,7 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
             () -> "[" + algString + "] " + msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
@@ -320,7 +320,7 @@ public class WolfCryptMac extends MacSpi {
             () -> "[" + algString + "] " + msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestMd5.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestMd5
         return new WolfCryptMessageDigestMd5(md5Copy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestSha
         return new WolfCryptMessageDigestSha(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha224.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha224.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestSha224
         return new WolfCryptMessageDigestSha224(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha256.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestSha256
         return new WolfCryptMessageDigestSha256(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
@@ -126,7 +126,7 @@ public class WolfCryptMessageDigestSha3
         return new WolfCryptMessageDigestSha3(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha384.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestSha384
         return new WolfCryptMessageDigestSha384(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha512.java
@@ -115,7 +115,7 @@ public final class WolfCryptMessageDigestSha512
         return new WolfCryptMessageDigestSha512(shaCopy);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -84,6 +84,7 @@ public final class WolfCryptProvider extends Provider {
     /**
      * Create new WolfCryptProvider object
      */
+    @SuppressWarnings("deprecation")
     public WolfCryptProvider() {
         super("wolfJCE", 1.10, "wolfCrypt JCE Provider");
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptRandom.java
@@ -111,7 +111,7 @@ public final class WolfCryptRandom extends SecureRandomSpi {
         WolfCryptDebug.log(getClass(), WolfCryptDebug.INFO, () -> msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -1379,7 +1379,7 @@ public class WolfCryptSignature extends SignatureSpi {
             () -> "[" + keyString + "-" + digestString + "] " + msg);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
@@ -418,7 +418,7 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
     /**
      * Cleanup method to wipe KEK cache when KeyStore is garbage collected.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/NativeStruct.java
@@ -111,7 +111,7 @@ public abstract class NativeStruct extends WolfObject {
 
     private native void xfree(long pointer);
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         releaseNativeStruct();

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
@@ -811,7 +811,7 @@ public class WolfSSLCertManager {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLX509StoreCtx.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLX509StoreCtx.java
@@ -323,7 +323,7 @@ public class WolfSSLX509StoreCtx implements AutoCloseable {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     protected void finalize() throws Throwable {
         try {
             free();


### PR DESCRIPTION
Compiling with JDK 24 produced 37 `[deprecation]` and `[removal]` warnings on `ant build-jce-debug`, plus 1 path warning on the test build. All flagged APIs are intentional uses (`finalize()` for native struct cleanup, `OAEPParameterSpec.DEFAULT`, `LogRecord.getThreadID()`, `Provider(String,double,String)`).

This PR cleans those up:

  - Adds `@SuppressWarnings({"deprecation", "removal"})` on the affected `finalize()` methods across `WolfCryptCipher`, `NativeStruct`, `WolfCryptKeyAgreement`, `WolfCryptKeyPairGenerator`, `WolfCryptMac`, `WolfCryptMessageDigest*` (Md5/Sha/Sha224/256/384/512/Sha3), `WolfCryptRandom`, `WolfCryptSignature`, `WolfSSLKeyStore`, `WolfSSLCertManager`, `WolfSSLX509StoreCtx`.
  - Adds method/local-level `@SuppressWarnings("deprecation")` on `WolfCryptCipher.setOaepParams` (OAEPParameterSpec.DEFAULT), `WolfCryptDebug` (LogRecord.getThreadID), and the `WolfCryptProvider` constructor.
  - Adds `-Xlint:-path` to the `build-test` javac target in `build.xml` to silence the exploded-module classpath warning.

  `@SuppressWarnings("removal")` is unknown to Java 8 javac and silently ignored per JLS, so the Java 8 min version is preserved.