### PR TITLE
JNI resource-leak and key-material cleanup fixes                                      

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Aes.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Aes.h
@@ -53,6 +53,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__
 JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jint, jobject, jint, jint, jobject, jint);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_Aes
+ * Method:    wc_AesFree
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Aes_wc_1AesFree
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_AesCtr.h
+++ b/jni/include/com_wolfssl_wolfcrypt_AesCtr.h
@@ -49,6 +49,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesCtr_native_1update_1interna
 JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesCtr_native_1update_1internal__Ljava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint, jint, jobject, jint);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_AesCtr
+ * Method:    wc_AesFree
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCtr_wc_1AesFree
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_AesCts.h
+++ b/jni/include/com_wolfssl_wolfcrypt_AesCts.h
@@ -31,6 +31,14 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_AesCts_mallocNativeStruct_1in
 
 /*
  * Class:     com_wolfssl_wolfcrypt_AesCts
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1free
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_AesCts
  * Method:    native_set_key_internal
  * Signature: ([B[BI)V
  */

--- a/jni/include/com_wolfssl_wolfcrypt_AesEcb.h
+++ b/jni/include/com_wolfssl_wolfcrypt_AesEcb.h
@@ -53,6 +53,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesEcb_native_1update_1interna
 JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesEcb_native_1update_1internal__ILjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jint, jobject, jint, jint, jobject, jint);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_AesEcb
+ * Method:    wc_AesFree
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesEcb_wc_1AesFree
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_AesOfb.h
+++ b/jni/include/com_wolfssl_wolfcrypt_AesOfb.h
@@ -85,6 +85,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesOfb_native_1decrypt_1intern
 JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesOfb_native_1decrypt_1internal__Ljava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2I
   (JNIEnv *, jobject, jobject, jint, jint, jobject, jint);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_AesOfb
+ * Method:    wc_AesFree
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesOfb_wc_1AesFree
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_Chacha.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Chacha.h
@@ -41,6 +41,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setKey
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
   (JNIEnv *, jobject, jbyteArray);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_Chacha
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_native_1free
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_Des3.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Des3.h
@@ -43,6 +43,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal_
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Des3
+ * Method:    wc_Des3Free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Des3_wc_1Des3Free
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Des3
  * Method:    mallocNativeStruct
  * Signature: ()J
  */

--- a/jni/include/com_wolfssl_wolfcrypt_Hmac.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Hmac.h
@@ -59,6 +59,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSizeByType
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_native_1free
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
  * Method:    getCodeMd5
  * Signature: ()I
  */

--- a/jni/jni_aes.c
+++ b/jni/jni_aes.c
@@ -235,3 +235,26 @@ Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__ILjava_nio_ByteBuffer_2
     return ret;
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Aes_wc_1AesFree
+  (JNIEnv* env, jobject this)
+{
+#ifndef NO_AES
+    Aes* aes = NULL;
+
+    aes = (Aes*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, if so stop and return */
+        return;
+    }
+
+    if (aes != NULL) {
+        wc_AesFree(aes);
+    }
+
+    LogStr("wc_AesFree(aes=%p)\n", aes);
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_aesccm.c
+++ b/jni/jni_aesccm.c
@@ -232,11 +232,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesCcm_wc_1AesCcmEncrypt
         }
     }
 
-    /* Commit authTag changes back to original Java array on success */
+    /* Commit authTag changes back to original Java array on success.
+     * Use mode 0 to both commit changes and free the elems buffer. */
     if (authTagArr != NULL) {
         if (ret == 0) {
             (*env)->ReleaseByteArrayElements(env, authTagArr,
-                (jbyte*)authTag, JNI_COMMIT);
+                (jbyte*)authTag, 0);
         }
         else {
             (*env)->ReleaseByteArrayElements(env, authTagArr,

--- a/jni/jni_aesctr.c
+++ b/jni/jni_aesctr.c
@@ -229,3 +229,26 @@ Java_com_wolfssl_wolfcrypt_AesCtr_native_1update_1internal__Ljava_nio_ByteBuffer
     return ret;
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCtr_wc_1AesFree
+  (JNIEnv* env, jobject this)
+{
+#if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER)
+    Aes* aes = NULL;
+
+    aes = (Aes*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, if so stop and return */
+        return;
+    }
+
+    if (aes != NULL) {
+        wc_AesFree(aes);
+    }
+
+    LogStr("wc_AesFree(aes=%p)\n", aes);
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_aescts.c
+++ b/jni/jni_aescts.c
@@ -338,3 +338,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1update_1interna
     return ret;
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1free(
+    JNIEnv* env, jobject this)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_AES) && defined(HAVE_CTS) && \
+    !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API)
+    AesCtsCtx* ctx = (AesCtsCtx*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free AesCts %p\n", ctx);
+
+    if (ctx != NULL) {
+        #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+            !defined(WOLFSSL_NO_FORCE_ZERO)
+            wc_ForceZero(ctx, sizeof(AesCtsCtx));
+        #else
+            XMEMSET(ctx, 0, sizeof(AesCtsCtx));
+        #endif
+    }
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_aesecb.c
+++ b/jni/jni_aesecb.c
@@ -244,3 +244,26 @@ Java_com_wolfssl_wolfcrypt_AesEcb_native_1update_1internal__ILjava_nio_ByteBuffe
     return ret;
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesEcb_wc_1AesFree
+  (JNIEnv* env, jobject this)
+{
+#if !defined(NO_AES) && defined(HAVE_AES_ECB)
+    Aes* aes = NULL;
+
+    aes = (Aes*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, if so stop and return */
+        return;
+    }
+
+    if (aes != NULL) {
+        wc_AesFree(aes);
+    }
+
+    LogStr("wc_AesFree(aes=%p)\n", aes);
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_aesgcm.c
+++ b/jni/jni_aesgcm.c
@@ -233,11 +233,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesGcmEncrypt
         }
     }
 
-    /* Commit authTag changes back to original Java array on success */
+    /* Commit authTag changes back to original Java array on success.
+     * Use mode 0 to both commit changes and free the elems buffer. */
     if (authTagArr != NULL) {
         if (ret == 0) {
             (*env)->ReleaseByteArrayElements(env, authTagArr,
-                (jbyte*)authTag, JNI_COMMIT);
+                (jbyte*)authTag, 0);
         }
         else {
             (*env)->ReleaseByteArrayElements(env, authTagArr,

--- a/jni/jni_aesofb.c
+++ b/jni/jni_aesofb.c
@@ -300,3 +300,26 @@ Java_com_wolfssl_wolfcrypt_AesOfb_native_1decrypt_1internal__Ljava_nio_ByteBuffe
         output_object, outputOffset);
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesOfb_wc_1AesFree
+  (JNIEnv* env, jobject this)
+{
+#if !defined(NO_AES) && defined(WOLFSSL_AES_OFB)
+    Aes* aes = NULL;
+
+    aes = (Aes*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, if so stop and return */
+        return;
+    }
+
+    if (aes != NULL) {
+        wc_AesFree(aes);
+    }
+
+    LogStr("wc_AesFree(aes=%p)\n", aes);
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_chacha.c
+++ b/jni/jni_chacha.c
@@ -206,3 +206,31 @@ Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1process(
 #endif
     return result;
 }
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_native_1free(
+    JNIEnv* env, jobject this)
+{
+#ifdef HAVE_CHACHA
+    ChaCha* chacha = (ChaCha*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free ChaCha %p\n", chacha);
+
+    if (chacha != NULL) {
+        /* Zero ChaCha state (key material) before NativeStruct.xfree
+         * releases the memory. */
+        #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+            !defined(WOLFSSL_NO_FORCE_ZERO)
+            wc_ForceZero(chacha, sizeof(ChaCha));
+        #else
+            XMEMSET(chacha, 0, sizeof(ChaCha));
+        #endif
+    }
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}

--- a/jni/jni_des3.c
+++ b/jni/jni_des3.c
@@ -227,3 +227,26 @@ Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__ILjava_nio_ByteBuffer_
 
     return ret;
 }
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Des3_wc_1Des3Free
+  (JNIEnv* env, jobject this)
+{
+#ifndef NO_DES3
+    Des3* des = NULL;
+
+    des = (Des3*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, if so stop and return */
+        return;
+    }
+
+    if (des != NULL) {
+        wc_Des3Free(des);
+    }
+
+    LogStr("wc_Des3Free(des=%p)\n", des);
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -491,3 +491,32 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha3_1512
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_native_1free(
+    JNIEnv* env, jobject this)
+{
+#ifndef NO_HMAC
+    Hmac* hmac = (Hmac*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free Hmac %p\n", hmac);
+
+    if (hmac != NULL) {
+        /* Zero ipad/opad and any key-derived state. Memory itself is
+         * freed by NativeStruct.xfree. */
+        wc_HmacFree(hmac);
+        #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+            !defined(WOLFSSL_NO_FORCE_ZERO)
+            wc_ForceZero(hmac, sizeof(Hmac));
+        #else
+            XMEMSET(hmac, 0, sizeof(Hmac));
+        #endif
+    }
+#else
+    (void)this;
+    throwNotCompiledInException(env);
+#endif
+}
+

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -190,8 +190,8 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal___3BII(
     data   = getByteArray(env, data_buffer);
     dataSz = getByteArrayLength(env, data_buffer);
 
-    if (md5 == NULL || data == NULL ||
-        ((word32)(offset + len) > dataSz)) {
+    if (md5 == NULL || data == NULL || offset < 0 || len < 0 ||
+        ((jlong)offset + (jlong)len) > (jlong)dataSz) {
         ret = BAD_FUNC_ARG;
     } else {
         ret = wc_Md5Update(md5, data + offset, len);

--- a/jni/jni_wolfssl_cert_manager.c
+++ b/jni/jni_wolfssl_cert_manager.c
@@ -40,10 +40,12 @@
 
 /* Struct holding Java callback information for verify callback to use for
  * reaching back to Java. Stored in CallbackNode struct, which is is mapped to
- * WOLFSSL_CERT_MANAGER pointer in CallbackNode. */
+ * WOLFSSL_CERT_MANAGER pointer in CallbackNode. refcount is protected by
+ * g_callbackMutex; ctx is freed when it reaches 0. */
 typedef struct {
     JavaVM* jvm;       /* Java VM pointer for thread attachment */
     jobject callback;  /* Global reference to Java callback object */
+    int refcount;
 } VerifyCallbackCtx;
 
 /* Linked list node struct for callback context storage */
@@ -170,6 +172,70 @@ static void removeCallbackCtx(WOLFSSL_CERT_MANAGER* cm)
     }
 }
 
+/* Decrement ctx refcount; free if it reaches 0. Acquires the mutex
+ * internally; caller must not hold it. Tolerates ctx == NULL. */
+static void releaseCtx(VerifyCallbackCtx* ctx)
+{
+    int shouldFree = 0;
+    jobject callback = NULL;
+    JavaVM* jvm = NULL;
+    JNIEnv* env = NULL;
+    int needsDetach = 0;
+
+    if (ctx == NULL) {
+        return;
+    }
+
+    if (wc_LockMutex(&g_callbackMutex) != 0) {
+        /* Mutex error: leak rather than risk corrupting refcount */
+        return;
+    }
+
+    if (--ctx->refcount == 0) {
+        callback = ctx->callback;
+        jvm = ctx->jvm;
+        shouldFree = 1;
+    }
+
+    wc_UnLockMutex(&g_callbackMutex);
+
+    if (!shouldFree) {
+        return;
+    }
+
+    /* Delete GlobalRef using a JNIEnv on the current thread */
+    if (callback != NULL && jvm != NULL) {
+        if ((*jvm)->GetEnv(jvm, (void**)&env, JNI_VERSION_1_6)
+            == JNI_EDETACHED) {
+#ifdef __ANDROID__
+            if ((*jvm)->AttachCurrentThread(jvm, &env, NULL) == 0) {
+                needsDetach = 1;
+            }
+            else {
+                env = NULL;
+            }
+#else
+            if ((*jvm)->AttachCurrentThread(jvm, (void**)&env, NULL) == 0) {
+                needsDetach = 1;
+            }
+            else {
+                env = NULL;
+            }
+#endif
+        }
+        if (env != NULL) {
+            (*env)->DeleteGlobalRef(env, callback);
+            if (needsDetach) {
+                (*jvm)->DetachCurrentThread(jvm);
+            }
+        }
+        /* If env attach fails (rare), GlobalRef is leaked rather than
+         * corrupting the JVM. */
+    }
+
+    XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+}
+
 /* Extract cert DER bytes at given depth from WOLFSSL_X509_STORE_CTX into
  * a new jbyteArray. Returns NULL if cert not available at depth. */
 static jbyteArray getCertDerAtDepth(JNIEnv* jenv,
@@ -234,10 +300,19 @@ static int nativeVerifyCallback(int preverify, WOLFSSL_X509_STORE_CTX* store)
         ctx = g_callbackList->ctx;
     }
 
+    /* Retain ctx so a concurrent SetVerify/ClearVerify can't free it
+     * while we're using it. */
+    if (ctx != NULL) {
+        ctx->refcount++;
+    }
+
     wc_UnLockMutex(&g_callbackMutex);
 
     /* No callback registered, use preverify result */
     if (ctx == NULL || ctx->callback == NULL) {
+        if (ctx != NULL) {
+            releaseCtx(ctx);
+        }
         return preverify;
     }
 
@@ -253,7 +328,8 @@ static int nativeVerifyCallback(int preverify, WOLFSSL_X509_STORE_CTX* store)
             ctx->jvm, (void**)&jenv, NULL);
 #endif
         if (result != 0) {
-            /* Failed to attach, reject */
+            /* Failed to attach, drop our retained reference and reject */
+            releaseCtx(ctx);
             return 0;
         }
         needsDetach = 1;
@@ -275,6 +351,7 @@ static int nativeVerifyCallback(int preverify, WOLFSSL_X509_STORE_CTX* store)
         if (needsDetach) {
             (*ctx->jvm)->DetachCurrentThread(ctx->jvm);
         }
+        releaseCtx(ctx);
         return 0;
     }
 
@@ -288,6 +365,7 @@ static int nativeVerifyCallback(int preverify, WOLFSSL_X509_STORE_CTX* store)
         if (needsDetach) {
             (*ctx->jvm)->DetachCurrentThread(ctx->jvm);
         }
+        releaseCtx(ctx);
         return 0;
     }
 
@@ -317,6 +395,7 @@ static int nativeVerifyCallback(int preverify, WOLFSSL_X509_STORE_CTX* store)
         (*ctx->jvm)->DetachCurrentThread(ctx->jvm);
     }
 
+    releaseCtx(ctx);
     return (int)result;
 }
 
@@ -856,8 +935,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_WolfSSLCertManager_CertManager
 {
 #ifndef NO_WOLFSSL_CM_VERIFY
     int ret = 0;
+    int clearNativeVerify = 0;
     WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)(uintptr_t)cmPtr;
     VerifyCallbackCtx* ctx = NULL;
+    VerifyCallbackCtx* oldCtx = NULL;
     JavaVM* jvm = NULL;
     (void)jcl;
 
@@ -876,30 +957,58 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_WolfSSLCertManager_CertManager
     if (ctx == NULL) {
         return MEMORY_E;
     }
+    XMEMSET(ctx, 0, sizeof(VerifyCallbackCtx));
+    ctx->refcount = 1;
+    ctx->jvm = jvm;
 
     /* Create global reference to callback object so it persists across
      * JNI calls and thread boundaries */
     ctx->callback = (*env)->NewGlobalRef(env, callback);
     if (ctx->callback == NULL) {
-        XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        releaseCtx(ctx);
         return MEMORY_E;
     }
-    ctx->jvm = jvm;
 
     /* Add context to global list */
     if (wc_LockMutex(&g_callbackMutex) != 0) {
-        (*env)->DeleteGlobalRef(env, ctx->callback);
-        XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        releaseCtx(ctx);
         return BAD_MUTEX_E;
+    }
+
+    /* If a callback ctx is already registered for this cm, remove it.
+     * The list's reference is dropped via releaseCtx; an in-flight
+     * verify thread keeps oldCtx alive via its own refcount. */
+    oldCtx = findCallbackCtx(cm);
+    if (oldCtx != NULL) {
+        removeCallbackCtx(cm);
     }
 
     ret = addCallbackCtx(cm, ctx);
 
+    /* If add failed and we displaced oldCtx, try to put it back. If
+     * rollback also fails, defer clearing the wolfSSL native callback
+     * until after the mutex is dropped, so we don't hold our lock across
+     * an external wolfSSL call. */
+    if (ret != 0 && oldCtx != NULL) {
+        if (addCallbackCtx(cm, oldCtx) == 0) {
+            oldCtx = NULL;
+        }
+        else {
+            clearNativeVerify = 1;
+        }
+    }
+
     wc_UnLockMutex(&g_callbackMutex);
 
+    if (clearNativeVerify) {
+        wolfSSL_CertManagerSetVerify(cm, NULL);
+    }
+
+    /* Drop list's reference on displaced ctx (NULL if restored above) */
+    releaseCtx(oldCtx);
+
     if (ret != 0) {
-        (*env)->DeleteGlobalRef(env, ctx->callback);
-        XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        releaseCtx(ctx);
         return ret;
     }
 
@@ -945,15 +1054,10 @@ Java_com_wolfssl_wolfcrypt_WolfSSLCertManager_CertManagerClearVerify
 
     wc_UnLockMutex(&g_callbackMutex);
 
-    /* Free context if it existed */
+    /* Drop list's reference; in-flight verify will keep ctx alive
+     * via its own refcount. */
     if (ctx != NULL) {
-        /* Delete global reference to callback object */
-        if (ctx->callback != NULL) {
-            (*env)->DeleteGlobalRef(env, ctx->callback);
-        }
-
-        /* Free context structure */
-        XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        releaseCtx(ctx);
     }
 
     return WOLFSSL_SUCCESS;

--- a/src/main/java/com/wolfssl/wolfcrypt/Aes.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Aes.java
@@ -57,6 +57,7 @@ public class Aes extends BlockCipher {
         int offset, int length, byte[] output, int outputOffset);
     private native int native_update_internal(int opmode, ByteBuffer input,
         int offset, int length, ByteBuffer output, int outputOffset);
+    private native void wc_AesFree();
 
     /**
      * Malloc native JNI AES structure
@@ -130,6 +131,15 @@ public class Aes extends BlockCipher {
             return native_update_internal(opmode, input, offset, length,
                 output, outputOffset);
         }
+    }
+
+    /**
+     * Zero AES key schedule via wc_AesFree before native struct memory
+     * is freed. Caller (BlockCipher.releaseNativeStruct) holds pointerLock.
+     */
+    @Override
+    protected void native_free() {
+        wc_AesFree();
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/AesCtr.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesCtr.java
@@ -56,6 +56,7 @@ public class AesCtr extends NativeStruct {
         int offset, int length, byte[] output, int outputOffset);
     private native int native_update_internal(ByteBuffer input,
         int offset, int length, ByteBuffer output, int outputOffset);
+    private native void wc_AesFree();
 
     /**
      * Malloc native AesCtr structure
@@ -315,7 +316,14 @@ public class AesCtr extends NativeStruct {
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (stateLock) {
-            if (state != WolfCryptState.RELEASED) {
+            if ((state != WolfCryptState.UNINITIALIZED) &&
+                (state != WolfCryptState.RELEASED)) {
+                /* Only scrub key schedule if a key was actually set */
+                if (state == WolfCryptState.READY) {
+                    synchronized (pointerLock) {
+                        wc_AesFree();
+                    }
+                }
                 super.releaseNativeStruct();
                 state = WolfCryptState.RELEASED;
             }

--- a/src/main/java/com/wolfssl/wolfcrypt/AesCts.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesCts.java
@@ -65,6 +65,7 @@ public class AesCts extends NativeStruct {
     /* Native JNI methods, internally reach back and grab/use pointer from
      * NativeStruct.java. */
     private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_free();
     private native void native_set_key_internal(byte[] key, byte[] iv,
         int opmode);
     private native int native_update_internal(int opmode, byte[] input,
@@ -376,7 +377,14 @@ public class AesCts extends NativeStruct {
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (stateLock) {
-            if (state != WolfCryptState.RELEASED) {
+            if ((state != WolfCryptState.UNINITIALIZED) &&
+                (state != WolfCryptState.RELEASED)) {
+                /* Only scrub AES_KEY/IV if a key was actually set */
+                if (state == WolfCryptState.READY) {
+                    synchronized (pointerLock) {
+                        native_free();
+                    }
+                }
                 super.releaseNativeStruct();
                 state = WolfCryptState.RELEASED;
             }

--- a/src/main/java/com/wolfssl/wolfcrypt/AesEcb.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesEcb.java
@@ -58,6 +58,7 @@ public class AesEcb extends BlockCipher {
         int offset, int length, byte[] output, int outputOffset);
     private native int native_update_internal(int opmode, ByteBuffer input,
         int offset, int length, ByteBuffer output, int outputOffset);
+    private native void wc_AesFree();
 
     /**
      * Malloc native AesEcb structure
@@ -126,6 +127,15 @@ public class AesEcb extends BlockCipher {
             return native_update_internal(opmode, input, offset, length,
                 output, outputOffset);
         }
+    }
+
+    /**
+     * Zero AES key schedule via wc_AesFree before native struct memory
+     * is freed. Caller (BlockCipher.releaseNativeStruct) holds pointerLock.
+     */
+    @Override
+    protected void native_free() {
+        wc_AesFree();
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/AesOfb.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesOfb.java
@@ -71,6 +71,7 @@ public class AesOfb extends NativeStruct {
         int offset, int length, byte[] output, int outputOffset);
     private native int native_decrypt_internal(ByteBuffer input,
         int offset, int length, ByteBuffer output, int outputOffset);
+    private native void wc_AesFree();
 
     /**
      * Malloc native AesOfb structure
@@ -664,7 +665,14 @@ public class AesOfb extends NativeStruct {
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (stateLock) {
-            if (state != WolfCryptState.RELEASED) {
+            if ((state != WolfCryptState.UNINITIALIZED) &&
+                (state != WolfCryptState.RELEASED)) {
+                /* Only scrub key schedule if a key was actually set */
+                if (state == WolfCryptState.READY) {
+                    synchronized (pointerLock) {
+                        wc_AesFree();
+                    }
+                }
                 super.releaseNativeStruct();
                 state = WolfCryptState.RELEASED;
             }

--- a/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
@@ -262,11 +262,27 @@ public abstract class BlockCipher extends NativeStruct {
         return ret;
     }
 
+    /**
+     * Hook for subclasses to zero/free key material in the native struct
+     * (e.g. wc_AesFree, wc_Des3Free) before the underlying memory is
+     * freed by NativeStruct.xfree. Default is a no-op.
+     */
+    protected void native_free() {
+        /* no-op by default */
+    }
+
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (stateLock) {
             if ((state != WolfCryptState.UNINITIALIZED) &&
                 (state != WolfCryptState.RELEASED)) {
+                /* Only scrub key schedule if a key was actually set;
+                 * INITIALIZED means alloc'd but never keyed. */
+                if (state == WolfCryptState.READY) {
+                    synchronized (pointerLock) {
+                        native_free();
+                    }
+                }
                 super.releaseNativeStruct();
                 state = WolfCryptState.RELEASED;
             }

--- a/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
@@ -57,13 +57,19 @@ public class Chacha extends NativeStruct {
     private native byte[] wc_Chacha_process(byte in[]);
     private native void wc_Chacha_setKey(byte[] Key);
     private native void wc_Chacha_setIV(byte[] IV);
+    private native void native_free();
 
     @Override
     public synchronized void releaseNativeStruct() {
-        /* No native ChaCha free API, so just release NativeStruct */
         synchronized (stateLock) {
             if ((state != WolfCryptState.UNINITIALIZED) &&
                 (state != WolfCryptState.RELEASED)) {
+                /* Only scrub ChaCha state if a key was actually set */
+                if (state == WolfCryptState.READY) {
+                    synchronized (pointerLock) {
+                        native_free();
+                    }
+                }
                 super.releaseNativeStruct();
                 state = WolfCryptState.RELEASED;
             }

--- a/src/main/java/com/wolfssl/wolfcrypt/Des3.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Des3.java
@@ -49,6 +49,7 @@ public class Des3 extends BlockCipher {
         int offset, int length, byte[] output, int outputOffset);
     private native int native_update_internal(int opmode, ByteBuffer input,
         int offset, int length, ByteBuffer output, int outputOffset);
+    private native void wc_Des3Free();
 
     /**
      * Malloc native JNI Des3 structure
@@ -116,6 +117,15 @@ public class Des3 extends BlockCipher {
             return native_update_internal(opmode, input, offset, length,
                 output, outputOffset);
         }
+    }
+
+    /**
+     * Zero 3DES key schedule via wc_Des3Free before native struct memory
+     * is freed. Caller (BlockCipher.releaseNativeStruct) holds pointerLock.
+     */
+    @Override
+    protected void native_free() {
+        wc_Des3Free();
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -105,6 +105,7 @@ public class Hmac extends NativeStruct {
     private native void wc_HmacUpdate(ByteBuffer data, int offset, int length);
     private native byte[] wc_HmacFinal();
     private native int wc_HmacSizeByType(int type);
+    private native void native_free();
     private native static int getCodeMd5();
     private native static int getCodeSha();
     private native static int getCodeSha224();
@@ -125,6 +126,26 @@ public class Hmac extends NativeStruct {
      * @throws OutOfMemoryError when malloc fails with memory error
      */
     protected native long mallocNativeStruct() throws OutOfMemoryError;
+
+    /**
+     * Zero ipad/opad (key-derived state) in the native Hmac struct via
+     * wc_HmacFree before the underlying memory is freed.
+     */
+    @Override
+    public synchronized void releaseNativeStruct() {
+        synchronized (stateLock) {
+            synchronized (pointerLock) {
+                /* Gate on pointer, not state: clearKey and partial-init
+                 * failure can both leave pointer != 0 with non-READY state. */
+                if (getNativeStruct() == NULL) {
+                    return;
+                }
+                native_free();
+                super.releaseNativeStruct();
+            }
+            state = WolfCryptState.RELEASED;
+        }
+    }
 
     /**
      * Check if type is -1, if so that type is not compiled in at native
@@ -202,13 +223,30 @@ public class Hmac extends NativeStruct {
 
         throwIfKeyNotLoaded();
 
-        synchronized (pointerLock) {
-            /* Reset the HMAC state */
-            releaseNativeStruct();
-            initNativeStruct();
-
-            /* Re-set the key and type */
-            wc_HmacSetKey(type, key);
+        synchronized (stateLock) {
+            boolean success = false;
+            try {
+                synchronized (pointerLock) {
+                    releaseNativeStruct();
+                    initNativeStruct();
+                    wc_HmacSetKey(type, key);
+                }
+                /* Only reached on success; if any step threw, state stays
+                 * RELEASED so a follow-up update/doFinal fails fast rather
+                 * than running on a half-initialized native struct. */
+                state = WolfCryptState.READY;
+                success = true;
+            } finally {
+                if (!success) {
+                    /* Scrub stored key material on partial-init failure so
+                     * the secret doesn't linger in the Java heap. */
+                    if (this.key != null) {
+                        Arrays.fill(this.key, (byte) 0);
+                        this.key = null;
+                    }
+                    this.type = -1;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes F-3569, F-3570, F-3571, F-3572, F-3561, F-3563

- F-3569/F-3570: free authTag elems buffer on AES-GCM/CCM encrypt
- F-3571: free prior ctx on CertManagerSetVerify reuse
- F-3572: guard Md5 update against negative offset/len
- F-3561: zero AES/DES3 key schedule on release
- F-3563: zero Hmac/ChaCha key state on release
