### PR TITLE
Pin JCE KeyFactory lookups to wolfJCE and accept opaque CRT-encoded RSA keys

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyPairGenerator.java
@@ -39,6 +39,8 @@ import java.security.spec.ECGenParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.interfaces.ECPrivateKey;
@@ -473,12 +475,20 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                         }
                         pubSpec = new X509EncodedKeySpec(pubDer);
 
-                        KeyFactory kf = KeyFactory.getInstance("RSA");
+                        /* Prefer wolfJCE KeyFactory by name to avoid a
+                         * higher priority Provider that may strip RSA CRT
+                         * params (incompatible with WolfCryptSignature). Fall
+                         * back to default lookup in builds where wolfJCE does
+                         * not register KeyFactory.RSA (!WOLFSSL_PUBLIC_MP). */
+                        KeyFactory kf =
+                            WolfCryptUtil.getKeyFactoryPreferWolfJCE("RSA");
                         rsaPriv = (RSAPrivateKey)kf.generatePrivate(privSpec);
                         rsaPub  = (RSAPublicKey)kf.generatePublic(pubSpec);
 
                         if (this.type == KeyType.WC_RSA_PSS) {
                             /* Try to use RSASSA-PSS KeyFactory if available.
+                             * wolfJCE does not currently register one, so
+                             * this resolves through Provider priority order.
                              * Not all platforms support it (e.g. Android). */
                             try {
                                 /* Get key specs to generate PSS keys */
@@ -492,11 +502,20 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                                 /* Use RSASSA-PSS KeyFactory */
                                 KeyFactory pssKf =
                                     KeyFactory.getInstance("RSASSA-PSS");
-                                rsaPriv = (RSAPrivateKey)pssKf
+                                RSAPrivateKey altPriv = (RSAPrivateKey)pssKf
                                     .generatePrivate(privCrtSpec);
-                                rsaPub  = (RSAPublicKey)pssKf
+                                RSAPublicKey altPub = (RSAPublicKey)pssKf
                                     .generatePublic(pubKeySpec);
-                            } catch (NoSuchAlgorithmException e) {
+
+                                /* Only adopt PSS KeyFactory output if it
+                                 * preserves CRT params. */
+                                if (altPriv instanceof RSAPrivateCrtKey) {
+                                    rsaPriv = altPriv;
+                                    rsaPub  = altPub;
+                                }
+                            } catch (NoSuchAlgorithmException |
+                                     InvalidKeySpecException |
+                                     ClassCastException e) {
                                 /* RSASSA-PSS KeyFactory not available on this
                                  * platform, use regular RSA keys which are
                                  * still valid for PSS operations */
@@ -594,7 +613,8 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                     ecc.releaseNativeStruct();
 
                     try {
-                        KeyFactory kf = KeyFactory.getInstance("EC");
+                        KeyFactory kf =
+                            WolfCryptUtil.getKeyFactoryPreferWolfJCE("EC");
 
                         eccPriv  = (ECPrivateKey)kf.generatePrivate(privSpec);
                         eccPub   = (ECPublicKey)kf.generatePublic(pubSpec);
@@ -642,7 +662,8 @@ public class WolfCryptKeyPairGenerator extends KeyPairGeneratorSpi {
                 dh.releaseNativeStruct();
 
                 try {
-                    KeyFactory kf = KeyFactory.getInstance("DH");
+                    KeyFactory kf =
+                        WolfCryptUtil.getKeyFactoryPreferWolfJCE("DH");
 
                     dhPriv  = (DHPrivateKey)kf.generatePrivate(privSpec);
                     dhPub   = (DHPublicKey)kf.generatePublic(pubSpec);

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -412,14 +412,6 @@ public class WolfCryptSignature extends SignatureSpi {
                 !(privateKey instanceof RSAPrivateKey)) {
             throw new InvalidKeyException("Key is not of type RSAPrivateKey");
 
-        } else if (this.keyType == KeyType.WC_RSA &&
-                   privateKey instanceof RSAPrivateKey &&
-                   !(privateKey instanceof RSAPrivateCrtKey)) {
-            throw new InvalidKeyException(
-                "RSA private key must include CRT parameters " +
-                "(p, q, dP, dQ, qInv). Keys created from only " +
-                "modulus and exponent are not supported by wolfSSL.");
-
         } else if (this.keyType == KeyType.WC_ECDSA &&
                 !(privateKey instanceof ECPrivateKey)) {
             throw new InvalidKeyException("Key is not of type ECPrivateKey");
@@ -470,7 +462,28 @@ public class WolfCryptSignature extends SignatureSpi {
                     break;
             }
 
-            wolfCryptInitPrivateKey(privateKey, encodedKey);
+            try {
+                wolfCryptInitPrivateKey(privateKey, encodedKey);
+            } catch (WolfCryptException e) {
+                /* Native PKCS#8 decode or import failed. wolfSSL's
+                 * wc_RsaPrivateKeyDecode() requires all 8 RSA components
+                 * (n, e, d, p, q, dP, dQ, qInv) to be present in the
+                 * encoding, even though native signing math can handle
+                 * non-CRT keys. */
+                if (this.keyType == KeyType.WC_RSA &&
+                        !(privateKey instanceof RSAPrivateCrtKey)) {
+                    InvalidKeyException ike = new InvalidKeyException(
+                        "RSA private key import failed. wolfSSL requires " +
+                        "the PKCS#8 encoding to include CRT parameters " +
+                        "(p, q, dP, dQ, qInv).");
+                    ike.initCause(e);
+                    throw ike;
+                }
+                InvalidKeyException ike = new InvalidKeyException(
+                    "Failed to import private key: " + e.getMessage());
+                ike.initCause(e);
+                throw ike;
+            }
 
             /* init hash object if digest type is set */
             if (this.digestType == null) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.Key;
+import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -797,6 +798,28 @@ public class WolfCryptUtil {
         /* Remove spaces after commas, split into List */
         disabledAlgos = disabledAlgos.replaceAll(", ", ",");
         return Arrays.asList(disabledAlgos.split(","));
+    }
+
+    /**
+     * Get a KeyFactory for the given algorithm, preferring wolfJCE if it
+     * registers one and falling back to default Provider lookup otherwise.
+     *
+     * @param algorithm KeyFactory algorithm name (e.g. "RSA", "EC", "DH")
+     *
+     * @return KeyFactory instance, never null
+     *
+     * @throws NoSuchAlgorithmException if no Provider supports the algorithm
+     */
+    public static KeyFactory getKeyFactoryPreferWolfJCE(String algorithm)
+        throws NoSuchAlgorithmException {
+
+        try {
+            return KeyFactory.getInstance(algorithm, "wolfJCE");
+        } catch (NoSuchAlgorithmException e) {
+            return KeyFactory.getInstance(algorithm);
+        } catch (NoSuchProviderException e) {
+            return KeyFactory.getInstance(algorithm);
+        }
     }
 }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfSSLKeyStore.java
@@ -33,19 +33,19 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.security.Key;
+import java.security.KeyFactory;
 import java.security.KeyStoreSpi;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
-import java.security.KeyFactory;
 import java.security.Security;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.InvalidKeySpecException;
 import java.security.KeyStoreException;
 import java.security.NoSuchProviderException;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.InvalidKeySpecException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateFactory;
@@ -1154,12 +1154,17 @@ public class WolfSSLKeyStore extends KeyStoreSpi {
                         "unprotected key");
                 }
 
+                /* Prefer wolfJCE KeyFactory by name for RSA/EC, fall back to
+                 * default Provider lookup in builds where wolfJCE does not
+                 * register that KeyFactory (e.g. KeyFactory.RSA when
+                 * !WOLFSSL_PUBLIC_MP). No KeyFactory.RSASSA-PSS in wolfJCE
+                 * yet, so PSS keeps default lookup. */
                 if (algoId == Asn.RSAk) {
-                    keyFact = KeyFactory.getInstance("RSA");
+                    keyFact = WolfCryptUtil.getKeyFactoryPreferWolfJCE("RSA");
                 } else if (algoId == Asn.RSAPSSk) {
                     keyFact = KeyFactory.getInstance("RSASSA-PSS");
                 } else if (algoId == Asn.ECDSAk) {
-                    keyFact = KeyFactory.getInstance("EC");
+                    keyFact = WolfCryptUtil.getKeyFactoryPreferWolfJCE("EC");
                 } else {
                     throw new NoSuchAlgorithmException(
                         "Only RSA, RSASSA-PSS, and EC private key " +

--- a/src/test/java/com/wolfssl/provider/jce/test/MockNonCrtProvider.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/MockNonCrtProvider.java
@@ -1,0 +1,318 @@
+/* MockNonCrtProvider.java
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jce.test;
+
+import java.io.Closeable;
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyFactorySpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+import javax.crypto.interfaces.DHPrivateKey;
+import javax.crypto.interfaces.DHPublicKey;
+import javax.crypto.spec.DHParameterSpec;
+
+import com.wolfssl.provider.jce.WolfCryptProvider;
+
+/**
+ * Test-only JCE Provider that registers degraded KeyFactory implementations
+ * for RSA, RSASSA-PSS, EC, and DH.
+ *
+ * When installed at higher priority than wolfJCE, any code path that calls
+ * {@code KeyFactory.getInstance("RSA"|"EC"|"DH")} without naming a provider
+ * resolves to this Provider instead of wolfJCE. The returned keys are
+ * intentionally degraded so subsequent wolfJCE operations on them fail in
+ * an observable way:
+ *
+ *   - RSA: returns an RSAPrivateKey that does not implement RSAPrivateCrtKey,
+ *          with null getEncoded().
+ *   - EC:  returns ECPrivateKey/ECPublicKey with null getParams() and null
+ *          getEncoded().
+ *   - DH:  returns DHPrivateKey/DHPublicKey with zero values, null
+ *          getParams(), and null getEncoded().
+ *
+ * Usage:
+ * <pre>
+ *   try (Closeable scope = MockNonCrtProvider.install()) {
+ *       // ... assertions
+ *   }
+ * </pre>
+ *
+ * Decoding inside the mock uses an explicit
+ * {@code KeyFactory.getInstance(alg, "wolfJCE")} lookup, which bypasses
+ * Provider priority order and avoids any dependency on JDK-bundled
+ * providers (e.g. SunRsaSign) that may not exist on Android.
+ */
+public final class MockNonCrtProvider extends Provider {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String NAME = "MockNonCrtProvider";
+    static final String WOLFJCE_NAME = "wolfJCE";
+
+    public MockNonCrtProvider() {
+        super(NAME, 1.0,
+            "Test-only Provider returning degraded KeyFactory output for " +
+            "RSA, EC, and DH");
+        put("KeyFactory.RSA", MockRsaKeyFactorySpi.class.getName());
+        put("KeyFactory.RSASSA-PSS",
+            MockRsaKeyFactorySpi.class.getName());
+        put("KeyFactory.EC", MockEcKeyFactorySpi.class.getName());
+        put("KeyFactory.DH", MockDhKeyFactorySpi.class.getName());
+    }
+
+    /**
+     * Install the mock provider at priority 1 with wolfJCE re-added at the
+     * bottom of the provider list. Returns a Closeable that restores the
+     * provider list on close: removes the mock and reinstates wolfJCE at
+     * priority 1.
+     */
+    public static Closeable install() {
+        Security.removeProvider(WOLFJCE_NAME);
+        Security.removeProvider(NAME);
+
+        Security.insertProviderAt(new MockNonCrtProvider(), 1);
+        Security.addProvider(new WolfCryptProvider());
+
+        return new Closeable() {
+            @Override
+            public void close() {
+                Security.removeProvider(NAME);
+                Security.removeProvider(WOLFJCE_NAME);
+                Security.insertProviderAt(new WolfCryptProvider(), 1);
+            }
+        };
+    }
+
+    /**
+     * RSA KeyFactory that returns an RSAPrivateKey which does NOT implement
+     * RSAPrivateCrtKey, with null getEncoded(). The PKCS#8 input is decoded
+     * via an explicit by-name "wolfJCE" lookup, then unwrapped to drop the
+     * CRT parameters and encoding.
+     */
+    public static final class MockRsaKeyFactorySpi extends KeyFactorySpi {
+
+        @Override
+        protected PrivateKey engineGeneratePrivate(KeySpec keySpec)
+            throws InvalidKeySpecException {
+
+            if (!(keySpec instanceof PKCS8EncodedKeySpec)) {
+                throw new InvalidKeySpecException(
+                    "Mock RSA SPI only supports PKCS8EncodedKeySpec");
+            }
+
+            try {
+                /* Explicit-by-name lookup bypasses provider priority order
+                 * and avoids re-entry into this mock. */
+                KeyFactory delegate =
+                    KeyFactory.getInstance("RSA", WOLFJCE_NAME);
+                PrivateKey real = delegate.generatePrivate(keySpec);
+                if (!(real instanceof RSAPrivateKey)) {
+                    throw new InvalidKeySpecException(
+                        "Delegate did not return RSAPrivateKey");
+                }
+                RSAPrivateKey rsa = (RSAPrivateKey) real;
+                final BigInteger n = rsa.getModulus();
+                final BigInteger d = rsa.getPrivateExponent();
+
+                return new RSAPrivateKey() {
+                    private static final long serialVersionUID = 1L;
+                    @Override public BigInteger getModulus() { return n; }
+                    @Override public BigInteger getPrivateExponent() {
+                        return d;
+                    }
+                    @Override public String getAlgorithm() { return "RSA"; }
+                    @Override public String getFormat() { return null; }
+                    @Override public byte[] getEncoded() { return null; }
+                };
+
+            } catch (NoSuchAlgorithmException e) {
+                throw new InvalidKeySpecException(e);
+            } catch (NoSuchProviderException e) {
+                throw new InvalidKeySpecException(e);
+            }
+        }
+
+        @Override
+        protected PublicKey engineGeneratePublic(KeySpec keySpec)
+            throws InvalidKeySpecException {
+
+            if (!(keySpec instanceof X509EncodedKeySpec)) {
+                throw new InvalidKeySpecException(
+                    "Mock RSA SPI only supports X509EncodedKeySpec");
+            }
+
+            try {
+                KeyFactory delegate =
+                    KeyFactory.getInstance("RSA", WOLFJCE_NAME);
+                PublicKey real = delegate.generatePublic(keySpec);
+                if (!(real instanceof RSAPublicKey)) {
+                    throw new InvalidKeySpecException(
+                        "Delegate did not return RSAPublicKey");
+                }
+                RSAPublicKey rsa = (RSAPublicKey) real;
+                final BigInteger n = rsa.getModulus();
+                final BigInteger e = rsa.getPublicExponent();
+
+                return new RSAPublicKey() {
+                    private static final long serialVersionUID = 1L;
+                    @Override public BigInteger getModulus() { return n; }
+                    @Override public BigInteger getPublicExponent() {
+                        return e;
+                    }
+                    @Override public String getAlgorithm() { return "RSA"; }
+                    @Override public String getFormat() { return null; }
+                    @Override public byte[] getEncoded() { return null; }
+                };
+
+            } catch (NoSuchAlgorithmException nse) {
+                throw new InvalidKeySpecException(nse);
+            } catch (NoSuchProviderException nspe) {
+                throw new InvalidKeySpecException(nspe);
+            }
+        }
+
+        @Override
+        protected <T extends KeySpec> T engineGetKeySpec(Key k,
+            Class<T> spec) throws InvalidKeySpecException {
+
+            throw new InvalidKeySpecException("not used");
+        }
+
+        @Override
+        protected Key engineTranslateKey(Key k) {
+            return k;
+        }
+    }
+
+    /**
+     * Returns degraded EC keys with no encoding and no parameters. wolfJCE
+     * should never reach this SPI.
+     */
+    public static final class MockEcKeyFactorySpi extends KeyFactorySpi {
+
+        @Override
+        protected PrivateKey engineGeneratePrivate(KeySpec keySpec)
+            throws InvalidKeySpecException {
+
+            return new ECPrivateKey() {
+                private static final long serialVersionUID = 1L;
+                @Override public BigInteger getS() { return BigInteger.ONE; }
+                @Override public ECParameterSpec getParams() { return null; }
+                @Override public String getAlgorithm() { return "EC"; }
+                @Override public String getFormat() { return null; }
+                @Override public byte[] getEncoded() { return null; }
+            };
+        }
+
+        @Override
+        protected PublicKey engineGeneratePublic(KeySpec keySpec)
+            throws InvalidKeySpecException {
+
+            return new ECPublicKey() {
+                private static final long serialVersionUID = 1L;
+                @Override public ECPoint getW() {
+                    return ECPoint.POINT_INFINITY;
+                }
+                @Override public ECParameterSpec getParams() { return null; }
+                @Override public String getAlgorithm() { return "EC"; }
+                @Override public String getFormat() { return null; }
+                @Override public byte[] getEncoded() { return null; }
+            };
+        }
+
+        @Override
+        protected <T extends KeySpec> T engineGetKeySpec(Key k,
+            Class<T> spec) throws InvalidKeySpecException {
+
+            throw new InvalidKeySpecException("not used");
+        }
+
+        @Override
+        protected Key engineTranslateKey(Key k) {
+            return k;
+        }
+    }
+
+    /**
+     * Returns degraded DH keys with no parameters. wolfJCE should never
+     * reach this SPI.
+     */
+    public static final class MockDhKeyFactorySpi extends KeyFactorySpi {
+
+        @Override
+        protected PrivateKey engineGeneratePrivate(KeySpec keySpec)
+                throws InvalidKeySpecException {
+
+            return new DHPrivateKey() {
+                private static final long serialVersionUID = 1L;
+                @Override public BigInteger getX() { return BigInteger.ZERO; }
+                @Override public DHParameterSpec getParams() { return null; }
+                @Override public String getAlgorithm() { return "DH"; }
+                @Override public String getFormat() { return null; }
+                @Override public byte[] getEncoded() { return null; }
+            };
+        }
+
+        @Override
+        protected PublicKey engineGeneratePublic(KeySpec keySpec)
+            throws InvalidKeySpecException {
+
+            return new DHPublicKey() {
+                private static final long serialVersionUID = 1L;
+                @Override public BigInteger getY() { return BigInteger.ZERO; }
+                @Override public DHParameterSpec getParams() { return null; }
+                @Override public String getAlgorithm() { return "DH"; }
+                @Override public String getFormat() { return null; }
+                @Override public byte[] getEncoded() { return null; }
+            };
+        }
+
+        @Override
+        protected <T extends KeySpec> T engineGetKeySpec(Key k,
+            Class<T> spec) throws InvalidKeySpecException {
+
+            throw new InvalidKeySpecException("not used");
+        }
+
+        @Override
+        protected Key engineTranslateKey(Key k) {
+            return k;
+        }
+    }
+}

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -37,6 +37,7 @@ import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.interfaces.DHPrivateKey;
 import javax.crypto.spec.DHParameterSpec;
 
+import java.io.Closeable;
 import java.security.Security;
 import java.security.Provider;
 import java.security.NoSuchProviderException;
@@ -45,6 +46,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.security.PrivateKey;
+import java.security.Signature;
 import java.security.KeyFactory;
 import java.security.InvalidParameterException;
 import java.security.InvalidAlgorithmParameterException;
@@ -57,6 +59,7 @@ import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.PSSParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.interfaces.ECPublicKey;
@@ -1309,6 +1312,224 @@ public class WolfCryptKeyPairGeneratorTest {
                 ECPublicKey ecPub1 = (ECPublicKey) kp1.getPublic();
                 ECPublicKey ecPub2 = (ECPublicKey) kp2.getPublic();
             }
+        }
+    }
+
+    /*
+     * Tests for the case where a foreign Provider sits above wolfJCE in the
+     * Provider list and returns degraded keys for "RSA"/"EC"/"DH" lookups.
+     * wolfJCE KeyPairGenerator must not fall through to that Provider.
+     * See MockNonCrtProvider for details.
+     */
+
+    /* RSA KeyPairGenerator should produce an RSAPrivateCrtKey, and a
+     * SHA256withRSA sign/verify roundtrip on that key should succeed, even with
+     * a degraded RSA KeyFactory installed at higher priority than wolfJCE */
+    @Test
+    public void testKeyPairGeneratorRsaWhenMockRsaProviderIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("RSA", "wolfJCE");
+            kpg.initialize(new RSAKeyGenParameterSpec(2048,
+                BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+
+            KeyPair kp = kpg.generateKeyPair();
+            assertNotNull(kp);
+
+            assertTrue("Generated RSA priv key must be RSAPrivateCrtKey got: " +
+                kp.getPrivate().getClass().getName(),
+                kp.getPrivate() instanceof RSAPrivateCrtKey);
+
+            /* WolfCryptSignature.engineInitSign rejects non-CRT inputs, so
+             * a key fabricated by the mock would fail here. */
+            Signature signer =
+                Signature.getInstance("SHA256withRSA", "wolfJCE");
+            signer.initSign(kp.getPrivate());
+            signer.update("hello".getBytes());
+            byte[] sig = signer.sign();
+            assertNotNull(sig);
+
+            Signature verifier =
+                Signature.getInstance("SHA256withRSA", "wolfJCE");
+            verifier.initVerify(kp.getPublic());
+            verifier.update("hello".getBytes());
+            assertTrue("Signature verify should succeed",
+                verifier.verify(sig));
+        } finally {
+            scope.close();
+        }
+    }
+
+    /* RSASSA-PSS KeyPairGenerator should produce an RSAPrivateCrtKey, and an
+     * RSASSA-PSS sign/verify roundtrip on that key should succeed, even with a
+     * degraded RSA KeyFactory installed at higher priority than wolfJCE. */
+    @Test
+    public void testKeyPairGeneratorRsaPssWhenMockRsaProviderIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+        Assume.assumeTrue("RSA-PSS not available",
+            Security.getProvider("wolfJCE")
+                .getService("Signature", "RSASSA-PSS") != null);
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("RSASSA-PSS", "wolfJCE");
+            kpg.initialize(new RSAKeyGenParameterSpec(2048,
+                BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+
+            KeyPair kp = kpg.generateKeyPair();
+            assertNotNull(kp);
+
+            assertTrue("Generated RSASSA-PSS private key must be " +
+                "RSAPrivateCrtKey",
+                kp.getPrivate() instanceof RSAPrivateCrtKey);
+
+            PSSParameterSpec pssSpec = new PSSParameterSpec(
+                "SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+
+            Signature signer =
+                Signature.getInstance("RSASSA-PSS", "wolfJCE");
+            signer.setParameter(pssSpec);
+            signer.initSign(kp.getPrivate());
+            signer.update("pss-hello".getBytes());
+            byte[] sig = signer.sign();
+            assertNotNull(sig);
+
+            Signature verifier =
+                Signature.getInstance("RSASSA-PSS", "wolfJCE");
+            verifier.setParameter(pssSpec);
+            verifier.initVerify(kp.getPublic());
+            verifier.update("pss-hello".getBytes());
+            assertTrue(verifier.verify(sig));
+        } finally {
+            scope.close();
+        }
+    }
+
+    /* Generated RSA public key should expose a non-null X.509
+     * SubjectPublicKeyInfo encoding via getEncoded(), even with a degraded
+     * RSA KeyFactory installed at higher priority than wolfJCE. */
+    @Test
+    public void testKeyPairGeneratorRsaPublicEncodingWhenMockRsaIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("RSA", "wolfJCE");
+            kpg.initialize(new RSAKeyGenParameterSpec(2048,
+                BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+
+            KeyPair kp = kpg.generateKeyPair();
+            assertTrue("Generated RSA public key must be RSAPublicKey",
+                kp.getPublic() instanceof RSAPublicKey);
+
+            /* getEncoded() must produce X.509 SubjectPublicKeyInfo bytes.
+             * The mock returns null encoding, so a fall-through fails. */
+            byte[] enc = kp.getPublic().getEncoded();
+            assertNotNull("Public key encoding must be non-null", enc);
+            assertTrue("Public key encoding too small: " + enc.length,
+                enc.length > 64);
+        } finally {
+            scope.close();
+        }
+    }
+
+    /* EC KeyPairGenerator should produce an ECPrivateKey with valid params,
+     * and a SHA256withECDSA sign/verify roundtrip on that key should succeed,
+     * even with degraded EC KeyFactory at higher priority than wolfJCE. */
+    @Test
+    public void testKeyPairGeneratorEcWhenMockEcProviderIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("ECC not enabled", FeatureDetect.EccEnabled());
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("EC", "wolfJCE");
+            kpg.initialize(new ECGenParameterSpec("secp256r1"));
+
+            KeyPair kp = kpg.generateKeyPair();
+            assertNotNull(kp);
+
+            assertTrue("EC private key must be ECPrivateKey",
+                kp.getPrivate() instanceof ECPrivateKey);
+            assertTrue("EC public key must be ECPublicKey",
+                kp.getPublic() instanceof ECPublicKey);
+
+            ECPrivateKey ecPriv = (ECPrivateKey) kp.getPrivate();
+            assertNotNull("EC private key params must be present",
+                ecPriv.getParams());
+            assertTrue("EC private key value must be positive",
+                ecPriv.getS().signum() > 0);
+
+            Signature signer =
+                Signature.getInstance("SHA256withECDSA", "wolfJCE");
+            signer.initSign(kp.getPrivate());
+            signer.update("ec-hello".getBytes());
+            byte[] sig = signer.sign();
+            assertNotNull(sig);
+
+            Signature verifier =
+                Signature.getInstance("SHA256withECDSA", "wolfJCE");
+            verifier.initVerify(kp.getPublic());
+            verifier.update("ec-hello".getBytes());
+            assertTrue(verifier.verify(sig));
+        } finally {
+            scope.close();
+        }
+    }
+
+    /* DH KeyPairGenerator should produce DHPrivateKey/DHPublicKey objects
+     * with positive private/public values and parameters matching the input
+     * DHParameterSpec, even with a degraded DH KeyFactory installed at
+     * higher priority than wolfJCE. */
+    @Test
+    public void testKeyPairGeneratorDhWhenMockDhProviderIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("DH not enabled", FeatureDetect.DhEnabled());
+
+        BigInteger pVal = new BigInteger(1, prime);
+        BigInteger gVal = new BigInteger(1, base);
+        DHParameterSpec dhSpec = new DHParameterSpec(pVal, gVal);
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("DH", "wolfJCE");
+            kpg.initialize(dhSpec);
+
+            KeyPair kp = kpg.generateKeyPair();
+            assertNotNull(kp);
+
+            assertTrue("DH private key must be DHPrivateKey",
+                kp.getPrivate() instanceof DHPrivateKey);
+            assertTrue("DH public key must be DHPublicKey",
+                kp.getPublic() instanceof DHPublicKey);
+
+            DHPrivateKey dhPriv = (DHPrivateKey) kp.getPrivate();
+            DHPublicKey dhPub = (DHPublicKey) kp.getPublic();
+            assertTrue("DH private value must be positive",
+                dhPriv.getX().signum() > 0);
+            assertTrue("DH public value must be positive",
+                dhPub.getY().signum() > 0);
+            assertEquals("DH private p must match input", pVal,
+                dhPriv.getParams().getP());
+            assertEquals("DH private g must match input", gVal,
+                dhPriv.getParams().getG());
+        } finally {
+            scope.close();
         }
     }
 }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSignatureTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Assume;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
@@ -49,8 +50,12 @@ import java.security.spec.ECGenParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.interfaces.RSAKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.io.Closeable;
+import java.math.BigInteger;
 
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
@@ -2365,6 +2370,189 @@ public class WolfCryptSignatureTest {
             boolean verified = verifier.verify(signature);
             assertTrue("Signature verification should succeed for " + algo +
                 " after setParameter(ECParameterSpec)", verified);
+        }
+    }
+
+    /* WolfCryptSignature rejects RSAPrivateKey instances that do not also
+     * implement RSAPrivateCrtKey. These tests:
+     *   (a) document that restriction by asserting the error type and that
+     *       the message identifies CRT parameters as the cause,
+     *   (b) verify that a key produced by wolfJCE KeyPairGenerator is accepted
+     *       by wolfJCE Signature, even when a foreign Provider sits above
+     *       wolfJCE in the Provider list.
+     */
+
+    /* SHA256withRSA Signature.initSign() should accept a non-CRT-typed
+     * RSAPrivateKey when its getEncoded() returns a valid PKCS#8 that still
+     * contains all CRT components (mimics opaque keys returned by some
+     * Providers where the Java type does not advertise CRT support but the
+     * encoding does carry CRT. */
+    @Test
+    public void testEngineInitSignAcceptsNonCrtTypedKeyWithCrtEncoding()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        /* Generate a real wolfJCE RSA CRT key, then wrap it as a plain
+         * RSAPrivateKey that hides the CRT interface but exposes the full
+         * PKCS#8 encoding from getEncoded(). */
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "wolfJCE");
+        kpg.initialize(new RSAKeyGenParameterSpec(2048,
+            BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+        KeyPair kp = kpg.generateKeyPair();
+        final RSAPrivateKey realPriv = (RSAPrivateKey) kp.getPrivate();
+        final byte[] realEncoded = realPriv.getEncoded();
+
+        RSAPrivateKey nonCrtTypedWithCrtEncoding = new RSAPrivateKey() {
+            private static final long serialVersionUID = 1L;
+            @Override public BigInteger getModulus() {
+                return realPriv.getModulus();
+            }
+            @Override public BigInteger getPrivateExponent() {
+                return realPriv.getPrivateExponent();
+            }
+            @Override public String getAlgorithm() { return "RSA"; }
+            @Override public String getFormat() { return "PKCS#8"; }
+            @Override public byte[] getEncoded() {
+                return realEncoded.clone();
+            }
+        };
+
+        Signature signer = Signature.getInstance("SHA256withRSA", "wolfJCE");
+        signer.initSign(nonCrtTypedWithCrtEncoding);
+        signer.update("non-crt-type-crt-encoding".getBytes());
+        byte[] sig = signer.sign();
+        assertNotNull(sig);
+
+        Signature verifier =
+            Signature.getInstance("SHA256withRSA", "wolfJCE");
+        verifier.initVerify(kp.getPublic());
+        verifier.update("non-crt-type-crt-encoding".getBytes());
+        assertTrue(verifier.verify(sig));
+    }
+
+    /* SHA256withRSA Signature.initSign() should throw InvalidKeyException with
+     * a CRT-specific message when the encoded form fails native decode and
+     * the Java type is not RSAPrivateCrtKey. */
+    @Test
+    public void testEngineInitSignRejectsNonCrtKeyWithBadEncoding()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "wolfJCE");
+        kpg.initialize(new RSAKeyGenParameterSpec(2048,
+            BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+        KeyPair kp = kpg.generateKeyPair();
+        final RSAPrivateKey realPriv = (RSAPrivateKey) kp.getPrivate();
+
+        /* Encoding is undecodable garbage, native wc_RsaPrivateKeyDecode()
+         * will fail. Java type is non-CRT, so the catch path should
+         * produce the CRT-specific error message. */
+        final byte[] badEncoded = new byte[] {
+            0x30, 0x10, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        RSAPrivateKey nonCrtPriv = new RSAPrivateKey() {
+            private static final long serialVersionUID = 1L;
+            @Override public BigInteger getModulus() {
+                return realPriv.getModulus();
+            }
+            @Override public BigInteger getPrivateExponent() {
+                return realPriv.getPrivateExponent();
+            }
+            @Override public String getAlgorithm() { return "RSA"; }
+            @Override public String getFormat() { return "PKCS#8"; }
+            @Override public byte[] getEncoded() {
+                return badEncoded.clone();
+            }
+        };
+
+        Signature signer = Signature.getInstance("SHA256withRSA", "wolfJCE");
+        try {
+            signer.initSign(nonCrtPriv);
+            fail("Expected InvalidKeyException for undecodable encoding");
+
+        } catch (InvalidKeyException e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage();
+            assertTrue("Error must mention CRT parameters, got: " + msg,
+                msg.contains("CRT"));
+        }
+    }
+
+    /* SHA256withRSA Signature.initSign() should throw InvalidKeyException
+     * referencing the encoding for a key that returns null from getEncoded() */
+    @Test
+    public void testEngineInitSignRejectsKeyWithNullEncoding()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "wolfJCE");
+        kpg.initialize(new RSAKeyGenParameterSpec(2048,
+            BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+        KeyPair kp = kpg.generateKeyPair();
+        final RSAPrivateKey realPriv = (RSAPrivateKey) kp.getPrivate();
+        RSAPrivateKey opaquePriv = new RSAPrivateKey() {
+            private static final long serialVersionUID = 1L;
+            @Override public BigInteger getModulus() {
+                return realPriv.getModulus();
+            }
+            @Override public BigInteger getPrivateExponent() {
+                return realPriv.getPrivateExponent();
+            }
+            @Override public String getAlgorithm() { return "RSA"; }
+            @Override public String getFormat() { return null; }
+            @Override public byte[] getEncoded() { return null; }
+        };
+
+        Signature signer = Signature.getInstance("SHA256withRSA", "wolfJCE");
+        try {
+            signer.initSign(opaquePriv);
+            fail("Expected InvalidKeyException for null encoding");
+
+        } catch (InvalidKeyException e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage();
+            assertTrue("Error should reference encoding, got: " + msg,
+                msg.contains("encoding"));
+        }
+    }
+
+    /* SHA256withRSA Signature.initSign() should accept the PrivateKey
+     * returned by wolfJCE RSA KeyPairGenerator and produce a verifiable
+     * signature, even with a degraded RSA KeyFactory installed at higher
+     * priority than wolfJCE. */
+    @Test
+    public void testEngineInitSignAcceptsKpgKeyWhenMockRsaIsHighest()
+        throws Exception {
+
+        Assume.assumeTrue("RSA min size > 2048", Rsa.RSA_MIN_SIZE <= 2048);
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("RSA", "wolfJCE");
+            kpg.initialize(new RSAKeyGenParameterSpec(2048,
+                BigInteger.valueOf(Rsa.getDefaultRsaExponent())));
+            KeyPair kp = kpg.generateKeyPair();
+
+            /* Signature.initSign() must not throw "RSA private key must
+             * include CRT parameters" for a key produced by wolfJCE
+             * KeyPairGenerator, regardless of what other Providers are
+             * registered above wolfJCE. */
+            Signature signer =
+                Signature.getInstance("SHA256withRSA", "wolfJCE");
+            signer.initSign(kp.getPrivate());
+            signer.update("kpg-to-signature".getBytes());
+            byte[] sig = signer.sign();
+            assertNotNull(sig);
+
+            Signature verifier =
+                Signature.getInstance("SHA256withRSA", "wolfJCE");
+            verifier.initVerify(kp.getPublic());
+            verifier.update("kpg-to-signature".getBytes());
+            assertTrue(verifier.verify(sig));
+        } finally {
+            scope.close();
         }
     }
 }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.ByteArrayInputStream;
@@ -57,7 +58,10 @@ import java.security.KeyFactory;
 import java.security.KeyStoreException;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
 import java.security.UnrecoverableKeyException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateException;
@@ -2938,6 +2942,98 @@ public class WolfSSLKeyStoreTest {
         /* Verify the certificate can also be retrieved */
         Certificate certOut = store.getCertificate("pssKey");
         assertNotNull("Retrieved PSS cert should not be null", certOut);
+    }
+
+    /* Tests for the case where a foreign Provider sits above wolfJCE in the
+     * Provider list and returns degraded keys for "RSA"/"EC" lookups.
+     * WolfSSLKeyStore.engineGetKey() must not fall through to that Provider
+     * when reconstructing PrivateKey objects from PKCS#8.
+     * See MockNonCrtProvider for details.
+     *
+     * WKS store + load + getKey on an RSA private key entry should return
+     * an RSAPrivateCrtKey usable as a SHA256withRSA Signature input, even
+     * with a degraded RSA KeyFactory installed at higher priority than
+     * wolfJCE. */
+    @Test
+    public void testGetKeyRsaWhenMockRsaProviderIsHighest() throws Exception {
+
+        Assume.assumeNotNull(serverKeyRsa, serverCertRsa);
+
+        char[] pw = storePass.toCharArray();
+
+        KeyStore ks = KeyStore.getInstance(storeType, storeProvider);
+        ks.load(null, pw);
+        ks.setKeyEntry("rsa-key", serverKeyRsa, pw,
+            new Certificate[] { serverCertRsa });
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ks.store(bos, pw);
+        bos.close();
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyStore loaded = KeyStore.getInstance(storeType, storeProvider);
+            loaded.load(new ByteArrayInputStream(bos.toByteArray()), pw);
+
+            PrivateKey priv = (PrivateKey) loaded.getKey("rsa-key", pw);
+            assertNotNull(priv);
+            assertTrue("Loaded RSA key must be RSAPrivateCrtKey: " +
+                priv.getClass().getName(),
+                priv instanceof RSAPrivateCrtKey);
+
+            /* Sanity check, usable as a wolfJCE Signature input. */
+            Signature signer =
+                Signature.getInstance("SHA256withRSA", "wolfJCE");
+            signer.initSign(priv);
+            signer.update("ks-rsa".getBytes());
+            assertNotNull(signer.sign());
+        } finally {
+            scope.close();
+        }
+    }
+
+    /* WKS store + load + getKey on an EC private key entry should return an
+     * ECPrivateKey with non-null params usable as a SHA256withECDSA Signature
+     * input, even with a degraded EC KeyFactory installed at higher priority
+     * than wolfJCE. */
+    @Test
+    public void testGetKeyEcWhenMockEcProviderIsHighest() throws Exception {
+
+        Assume.assumeNotNull(serverKeyEcc, serverCertEcc);
+
+        char[] pw = storePass.toCharArray();
+
+        KeyStore ks = KeyStore.getInstance(storeType, storeProvider);
+        ks.load(null, pw);
+        ks.setKeyEntry("ec-key", serverKeyEcc, pw,
+            new Certificate[] { serverCertEcc });
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ks.store(bos, pw);
+        bos.close();
+
+        Closeable scope = MockNonCrtProvider.install();
+        try {
+            KeyStore loaded = KeyStore.getInstance(storeType, storeProvider);
+            loaded.load(new ByteArrayInputStream(bos.toByteArray()), pw);
+
+            PrivateKey priv = (PrivateKey) loaded.getKey("ec-key", pw);
+            assertNotNull(priv);
+            assertTrue("Loaded EC key must be ECPrivateKey: " +
+                priv.getClass().getName(),
+                priv instanceof ECPrivateKey);
+            ECPrivateKey ecPriv = (ECPrivateKey) priv;
+            assertNotNull("Loaded EC key params must be non-null",
+                ecPriv.getParams());
+
+            Signature signer =
+                Signature.getInstance("SHA256withECDSA", "wolfJCE");
+            signer.initSign(priv);
+            signer.update("ks-ec".getBytes());
+            assertNotNull(signer.sign());
+        } finally {
+            scope.close();
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes two issues that show up when a non-wolfSSL JCE Provider is registered above wolfJCE in the Provider list and returns RSA/EC/DH keys that wolfCrypt cannot consume directly.

  - Route internal `KeyFactory.getInstance("RSA"|"EC"|"DH")` lookups in `WolfCryptKeyPairGenerator` and `WolfSSLKeyStore` through a new `WolfCryptUtil.getKeyFactoryPreferWolfJCE()` helper that prefers wolfJCE by name (so generated/loaded keys retain CRT parameters and full encodings regardless of Provider priority order), and falls back to default Provider lookup in builds where wolfJCE does not register that KeyFactory (e.g. `KeyFactory.RSA` when `!WOLFSSL_PUBLIC_MP`).
  - In the RSASSA-PSS branch of `WolfCryptKeyPairGenerator`, only use the PSS `KeyFactory` output when it preserves `RSAPrivateCrtKey`, and broaden the fallback to also catch `InvalidKeySpecException` and `ClassCastException` so a non-wolfSSL PSS factory cannot fail key generation.
  - Relax `WolfCryptSignature.engineInitSign()` to accept an `RSAPrivateKey` that does not implement `RSAPrivateCrtKey` as long as its PKCS#8 encoding still contains the CRT components.

Additional unit tests are added here to cover these changes, including:
  - Add `MockNonCrtProvider` test helper and JUnit tests in `WolfCryptKeyPairGeneratorTest`, `WolfSSLKeyStoreTest`, and `WolfCryptSignatureTest` covering RSA, RSASSA-PSS, EC, and DH paths under a degraded higher-priority Provider.

  ZD 21784