### PR TITLE
Validate DH parameter generation sizes in AlgorithmParameterGenerator engineInit()

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDhParameterGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDhParameterGenerator.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.AlgorithmParameterGeneratorSpi;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 
@@ -32,6 +33,7 @@ import javax.crypto.spec.DHGenParameterSpec;
 import javax.crypto.spec.DHParameterSpec;
 
 import com.wolfssl.wolfcrypt.Dh;
+import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.Rng;
 import com.wolfssl.wolfcrypt.WolfCryptError;
 import com.wolfssl.wolfcrypt.WolfCryptException;
@@ -59,17 +61,66 @@ public class WolfCryptDhParameterGenerator
     }
 
     /**
+     * Validate requested DH prime size.
+     *
+     * In FIPS mode, only sizes with pre-computed FFDHE groups (RFC 7919:
+     * 2048/3072/4096/6144/8192) are supported. Other sizes would require
+     * dynamic generation via wc_DhGenerateParams(), which has edge case
+     * issues in some FIPS bundles. Simple pass through for non-FIPS builds,
+     * since native filters sizes. Enforced size checking here for FIPS
+     * builds.
+     *
+     * @param size desired prime size in bits
+     *
+     * @throws InvalidParameterException if size is not positive, or is
+     *         not supported in FIPS mode
+     */
+    private static void validateParamSize(int size)
+        throws InvalidParameterException {
+
+        if (size <= 0) {
+            throw new InvalidParameterException(
+                "DH parameter size must be positive: " + size);
+        }
+
+        if (!Fips.enabled) {
+            return;
+        }
+
+        switch (size) {
+            case 2048:
+            case 3072:
+            case 4096:
+            case 6144:
+            case 8192:
+                return;
+            default:
+                break;
+        }
+
+        throw new InvalidParameterException(
+            "Unsupported DH parameter size in FIPS mode: " + size +
+            " bits, supported sizes: 2048, 3072, 4096, 6144, 8192");
+    }
+
+    /**
      * Initialize with desired prime size.
      *
      * The SecureRandom parameter is intentionally ignored;
      * wolfCrypt uses its own internal RNG for DH parameter
      * generation to ensure FIPS-compliant randomness.
      *
-     * @param size desired prime size in bits
+     * @param size desired prime size in bits. In FIPS mode, must be one
+     *        of 2048, 3072, 4096, 6144, or 8192.
      * @param random caller-supplied randomness (ignored)
+     *
+     * @throws InvalidParameterException if size is not supported
      */
     @Override
-    protected void engineInit(int size, SecureRandom random) {
+    protected void engineInit(int size, SecureRandom random)
+        throws InvalidParameterException {
+
+        validateParamSize(size);
         this.size = size;
     }
 
@@ -82,8 +133,8 @@ public class WolfCryptDhParameterGenerator
      *
      * @param genParamSpec DH generation parameters
      * @param random caller-supplied randomness (ignored)
-     * @throws InvalidAlgorithmParameterException if
-     *         genParamSpec is null or not a DHGenParameterSpec
+     * @throws InvalidAlgorithmParameterException if genParamSpec is null, not
+     *         a DHGenParameterSpec, or contains an unsupported prime size
      */
     @Override
     protected void engineInit(AlgorithmParameterSpec genParamSpec,
@@ -101,6 +152,14 @@ public class WolfCryptDhParameterGenerator
         }
 
         DHGenParameterSpec dhGenSpec = (DHGenParameterSpec)genParamSpec;
+
+        try {
+            validateParamSize(dhGenSpec.getPrimeSize());
+
+        } catch (InvalidParameterException e) {
+            throw new InvalidAlgorithmParameterException(e.getMessage(), e);
+        }
+
         this.size = dhGenSpec.getPrimeSize();
         this.exponentSize = dhGenSpec.getExponentSize();
     }

--- a/src/main/java/com/wolfssl/wolfcrypt/Dh.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Dh.java
@@ -412,13 +412,21 @@ public class Dh extends NativeStruct {
      * 6144, 8192), consider using getNamedDhParams() which uses
      * pre-computed FFDHE parameters from RFC 7919.
      *
+     * Supported modulus sizes depend on the native wolfSSL build. Native
+     * wc_DhGenerateParams() supports the FIPS 186-4 sizes (1024, 2048,
+     * 3072 bits), plus other sizes if built with WOLFSSL_NO_DH186. In FIPS
+     * mode, only the FIPS 186-4 sizes are passed through to native code,
+     * since wc_DhGenerateParams() has edge case issues with other sizes
+     * in some FIPS bundles.
+     *
      * @param rng Initialized Rng object to use for parameter generation
-     * @param modSz Modulus size in bits (e.g., 512, 1024, 2048)
+     * @param modSz Modulus size in bits. In FIPS mode, must be 1024,
+     *        2048, or 3072
      *
      * @return byte array containing [p, g] parameters, or null on error
      *
-     * @throws WolfCryptException if native operation fails or if
-     *         parameter generation is not supported
+     * @throws WolfCryptException if native operation fails, if modSz is
+     *         not supported, or if parameter generation is not supported
      */
     public static byte[][] generateDhParams(Rng rng, int modSz)
         throws WolfCryptException {
@@ -434,6 +442,13 @@ public class Dh extends NativeStruct {
 
         if (modSz <= 0) {
             throw new WolfCryptException("Invalid modulus size: " + modSz);
+        }
+
+        if (Fips.enabled &&
+            modSz != 1024 && modSz != 2048 && modSz != 3072) {
+            throw new WolfCryptException(
+                "Unsupported DH modulus size in FIPS mode: " + modSz +
+                " bits, allowed sizes are 1024, 2048, or 3072 bits");
         }
 
         return wc_DhGenerateParams(rng, modSz);

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParameterGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParameterGeneratorTest.java
@@ -37,6 +37,7 @@ import java.security.AlgorithmParameterGenerator;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
 import java.security.NoSuchProviderException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
@@ -181,13 +182,67 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     }
 
     @Test
+    public void testDHParameterGenerationUnsupportedSizesFIPS()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               Exception {
+
+        /* In FIPS mode, sizes without a pre-computed FFDHE group must be
+         * rejected at init() time, before reaching native
+         * wc_DhGenerateParams() */
+        if (!Fips.enabled) {
+            return;
+        }
+
+        int[] unsupportedSizes = { 512, 768, 832, 1024, 1536 };
+
+        for (int size : unsupportedSizes) {
+            AlgorithmParameterGenerator paramGen =
+                AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
+            assertNotNull(paramGen);
+
+            try {
+                paramGen.init(size);
+                fail("AlgorithmParameterGenerator.init should throw " +
+                     "InvalidParameterException for " + size + "-bit " +
+                     "size in FIPS mode");
+            } catch (InvalidParameterException e) {
+                /* expected */
+            }
+        }
+    }
+
+    @Test
+    public void testDHParameterGenerationNonPositiveSizes()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               Exception {
+
+        /* Non-positive sizes must be rejected at init() time in all
+         * modes */
+        int[] invalidSizes = { 0, -1, -2048 };
+
+        for (int size : invalidSizes) {
+            AlgorithmParameterGenerator paramGen =
+                AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
+            assertNotNull(paramGen);
+
+            try {
+                paramGen.init(size);
+                fail("AlgorithmParameterGenerator.init should throw " +
+                     "InvalidParameterException for " + size + "-bit size");
+            } catch (InvalidParameterException e) {
+                /* expected */
+            }
+        }
+    }
+
+    @Test
     public void testDHParameterGenerationNonStandardSizes()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
         /* Test non-standard sizes (requires dynamic generation).
-         * Skip in FIPS mode as FIPS 186-4 only allows 1024, 2048,
-         * and 3072-bit DH parameter generation */
+         * Skip in FIPS mode, non-FFDHE sizes are rejected at init()
+         * time (covered by testDHParameterGenerationUnsupportedSizesFIPS) */
         if (Fips.enabled) {
             return;
         }
@@ -218,10 +273,10 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
             }
             catch (RuntimeException e) {
                 /* Dynamic parameter generation may not be supported for all
-                 * sizes, especially in FIPS builds or when wolfSSL enforces
-                 * minimum parameter sizes. Prime generation for non-standard
-                 * sizes may also fail on resource-constrained devices like
-                 * Android. Skip if generation fails. */
+                 * sizes, especially when wolfSSL enforces minimum parameter
+                 * sizes. Prime generation for non-standard sizes may also
+                 * fail on resource-constrained devices like Android. Skip
+                 * if generation fails. */
                 if (e.getMessage() != null &&
                     (e.getMessage().contains("Bad function argument") ||
                      e.getMessage().contains("prime generation failure"))) {
@@ -374,6 +429,46 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         assertNotNull(spec);
         assertEquals(2048, spec.getP().bitLength());
         assertEquals(256, spec.getL());
+    }
+
+    @Test
+    public void testDHParameterGenerationWithDHGenParameterSpecInvalidSize()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* Unsupported prime sizes in DHGenParameterSpec should be rejected
+         * at init() time */
+        AlgorithmParameterGenerator paramGen =
+            AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
+        assertNotNull(paramGen);
+
+        /* Non-positive prime size rejected in all modes */
+        try {
+            DHGenParameterSpec genSpec = new DHGenParameterSpec(0, 0);
+            paramGen.init(genSpec, rand);
+
+            fail("AlgorithmParameterGenerator.init should throw " +
+                 "InvalidAlgorithmParameterException for 0-bit " +
+                 "prime size");
+
+        } catch (InvalidAlgorithmParameterException e) {
+            /* expected */
+        }
+
+        /* In FIPS mode, sizes without an FFDHE group rejected at init() */
+        if (Fips.enabled) {
+            try {
+                DHGenParameterSpec genSpec =
+                    new DHGenParameterSpec(1536, 256);
+                paramGen.init(genSpec, rand);
+
+                fail("AlgorithmParameterGenerator.init should throw " +
+                     "InvalidAlgorithmParameterException for 1536-bit " +
+                     "prime size in FIPS mode");
+
+            } catch (InvalidAlgorithmParameterException e) {
+                /* expected */
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR adds up-front size validation to the wolfJCE DH `AlgorithmParameterGenerator`:

  - Non-positive sizes are rejected with `InvalidParameterException` in all modes
  - In FIPS mode, only sizes with pre-computed FFDHE groups (2048/3072/4096/6144/8192) are accepted. Dynamic generation via `wc_DhGenerateParams()` is not used in FIPS mode, as it has edge case issues with non-standard sizes in some FIPS bundles
  - Non-FIPS builds defer size support to native `wc_DhGenerateParams()`, which varies with build options (e.g. `WOLFSSL_NO_DH186`) and fails gracefully at generation time

`Dh.generateDhParams()` gets the same FIPS-mode size restriction (1024/2048/3072, the sizes native `wc_DhGenerateParams()` accepts) as defense in depth.

#### Fixes SunJCE test: `crypto/provider/KeyAgreement/SupportedDHParamGens.java`

This test runs DH parameter generation for sizes 512/768/832/1024/2048. On a FIPS wolfCrypt build, the non-FFDHE sizes were previously passed straight into native `wc_DhGenerateParams()`, whose error path for unsupported sizes is unreliable in some FIPS bundles and could take down the test JVM (jtreg reported `Error. Agent communication error: java.io.EOFException`). With this change those sizes are rejected at `init()` time with `InvalidParameterException`, which the test explicitly treats as "key size not supported" and skips, so all five runs now pass (2048 continues to use the FFDHE named group).