### PR TITLE
Add OID alias for EC KeyFactory

### DIFF
--- a/README_JCE.md
+++ b/README_JCE.md
@@ -248,7 +248,7 @@ The JCE provider currently supports the following algorithms:
 
     KeyFactory
         RSA
-        EC
+        EC (alias: 1.2.840.10045.2.1)
         DH (aliases: DiffieHellman, 1.2.840.113549.1.3.1)
 
     CertPathValidator Class

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -655,6 +655,8 @@ public final class WolfCryptProvider extends Provider {
         if (FeatureDetect.EccEnabled()) {
             put("KeyFactory.EC",
                 "com.wolfssl.provider.jce.WolfCryptECKeyFactory");
+            put("Alg.Alias.KeyFactory.1.2.840.10045.2.1", "EC");
+            put("Alg.Alias.KeyFactory.OID.1.2.840.10045.2.1", "EC");
         }
         if (FeatureDetect.DhEnabled()) {
             put("KeyFactory.DH",

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptECKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptECKeyFactoryTest.java
@@ -180,6 +180,46 @@ public class WolfCryptECKeyFactoryTest {
     }
 
     @Test
+    public void testECKeyFactoryOidAlias() throws Exception {
+
+        if (!FeatureDetect.EccEnabled()) {
+            return;
+        }
+
+        /* Test that we can get an EC KeyFactory instance using the EC
+         * public key OID, in both plain and OID.-prefixed alias forms */
+        KeyFactory kf = KeyFactory.getInstance("1.2.840.10045.2.1", "wolfJCE");
+        assertNotNull("KeyFactory should not be null", kf);
+        assertEquals("Provider should be wolfJCE", "wolfJCE",
+            kf.getProvider().getName());
+
+        KeyFactory kfPrefixed = KeyFactory.getInstance(
+            "OID.1.2.840.10045.2.1", "wolfJCE");
+        assertNotNull("KeyFactory should not be null", kfPrefixed);
+        assertEquals("Provider should be wolfJCE", "wolfJCE",
+            kfPrefixed.getProvider().getName());
+
+        /* Verify OID-based KeyFactory can convert keys */
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "wolfJCE");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        PublicKey pubKey = kf.generatePublic(
+            new X509EncodedKeySpec(kp.getPublic().getEncoded()));
+        assertNotNull("Converted public key should not be null", pubKey);
+        assertTrue("Should be ECPublicKey", pubKey instanceof ECPublicKey);
+        assertEquals("Converted public key algorithm should be EC",
+            "EC", pubKey.getAlgorithm());
+
+        PrivateKey privKey = kf.generatePrivate(
+            new PKCS8EncodedKeySpec(kp.getPrivate().getEncoded()));
+        assertNotNull("Converted private key should not be null", privKey);
+        assertTrue("Should be ECPrivateKey", privKey instanceof ECPrivateKey);
+        assertEquals("Converted private key algorithm should be EC",
+            "EC", privKey.getAlgorithm());
+    }
+
+    @Test
     public void testPKCS8PrivateKeyConversion() throws Exception {
 
         if (!FeatureDetect.EccEnabled()) {


### PR DESCRIPTION
This PR registers `Alg.Alias.KeyFactory.1.2.840.10045.2.1 = EC` in WolfCryptProvider, matching the alias already registered for `KeyPairGenerator.EC`. Adds an OID alias test to `WolfCryptECKeyFactoryTest` and documents the alias in README_JCE.md.

#### Fixes SunJCE test: `security/ec/OidInstance.java`

The test (JDK-8279801) verifies that EC `KeyFactory`, `KeyPairGenerator`, and `AlgorithmParameters` can be instantiated by OID `1.2.840.10045.2.1`. wolfJCE registered `KeyFactory.EC` without the OID alias, so in environments where wolfJCE is the EC KeyFactory provider (e.g. FIPS containers without SunEC), `KeyFactory.getInstance("1.2.840.10045.2.1")` threw `NoSuchAlgorithmException`. With the alias registered the lookup resolves to wolfJCE and the test passes.