### PR TITLE
JCE: align certpath algorithm constraints and AES-GCM IV reuse with SunJCE

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
+++ b/jni/include/com_wolfssl_wolfcrypt_FeatureDetect.h
@@ -433,6 +433,22 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_SlhDsaKeyGen
 
 /*
  * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    MlDsaLevelEnabled
+ * Signature: (I)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_MlDsaLevelEnabled
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
+ * Method:    SlhDsaParamEnabled
+ * Signature: (I)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_SlhDsaParamEnabled
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_FeatureDetect
  * Method:    LmsEnabled
  * Signature: ()Z
  */

--- a/jni/jni_mldsa.c
+++ b/jni/jni_mldsa.c
@@ -1980,3 +1980,30 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1Dilithium_1Pri
     return result;
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_MlDsaLevelEnabled
+  (JNIEnv* env, jclass jcl, jint level)
+{
+    (void)env;
+    (void)jcl;
+#if defined(HAVE_DILITHIUM) || defined(WOLFSSL_HAVE_MLDSA)
+    jboolean enabled = JNI_FALSE;
+    wc_MlDsaKey* key = NULL;
+
+    key = (wc_MlDsaKey*)XMALLOC(sizeof(wc_MlDsaKey), NULL,
+        DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        if (wc_MlDsaKey_Init(key, NULL, INVALID_DEVID) == 0) {
+            if (wc_MlDsaKey_SetParams(key, (byte)level) == 0) {
+                enabled = JNI_TRUE;
+            }
+            wc_MlDsaKey_Free(key);
+        }
+        XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    return enabled;
+#else
+    (void)level;
+    return JNI_FALSE;
+#endif
+}

--- a/jni/jni_slhdsa.c
+++ b/jni/jni_slhdsa.c
@@ -1685,3 +1685,29 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_SlhDsa_wc_1SlhDsaKey_1check_1k
     throwNotCompiledInException(env);
 #endif
 }
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_FeatureDetect_SlhDsaParamEnabled
+  (JNIEnv* env, jclass jcl, jint param)
+{
+    (void)env;
+    (void)jcl;
+#ifdef WOLFSSL_HAVE_SLHDSA
+    jboolean enabled = JNI_FALSE;
+    SlhDsaKey* key = NULL;
+
+    key = (SlhDsaKey*)XMALLOC(sizeof(SlhDsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        if (wc_SlhDsaKey_Init(key, (enum SlhDsaParam)param, NULL,
+            INVALID_DEVID) == 0) {
+            enabled = JNI_TRUE;
+            wc_SlhDsaKey_Free(key);
+        }
+        XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    return enabled;
+#else
+    (void)param;
+    return JNI_FALSE;
+#endif
+}

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -67,6 +67,9 @@ import com.wolfssl.wolfcrypt.AesCts;
 import com.wolfssl.wolfcrypt.Des3;
 import com.wolfssl.wolfcrypt.Rsa;
 import com.wolfssl.wolfcrypt.Rng;
+import com.wolfssl.wolfcrypt.Sha256;
+import com.wolfssl.wolfcrypt.Sha512;
+import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.wolfcrypt.WolfCrypt;
 import com.wolfssl.wolfcrypt.WolfCryptError;
 import com.wolfssl.wolfcrypt.WolfCryptException;
@@ -152,10 +155,17 @@ public class WolfCryptCipher extends CipherSpi {
     /* AAD data for AES-GCM, populated via engineUpdateAAD() */
     private byte[] aadData = null;
 
-    /* Last (key, IV) used for a completed AES-GCM encryption, tracked to
-     * reject GCM nonce reuse. */
-    private byte[] lastGcmEncryptKey = null;
+    /* Last (key, IV) set for AES-GCM encryption at init time, tracked to
+     * reject GCM nonce reuse on re-initialization. A digest of the encoded
+     * key (SHA-512, or SHA-256 when SHA-512 is not compiled in) is stored
+     * instead of the key bytes to avoid keeping an extra copy of key
+     * material in memory. */
+    private byte[] lastGcmEncryptKeyHash = null;
     private byte[] lastGcmEncryptIv = null;
+
+    /* Set when an AES-GCM encryption completes, cleared by init. A second
+     * encryption without re-init would reuse the same key and IV */
+    private boolean gcmEncryptNeedsReinit = false;
 
     /* Has update/final been called yet, gates setting of AAD for GCM */
     private boolean operationStarted = false;
@@ -1046,6 +1056,131 @@ public class WolfCryptCipher extends CipherSpi {
         }
     }
 
+    /**
+     * Reject AES-GCM encrypt init with the same key+IV as the last encrypt
+     * init used (GCM nonce reuse).
+     *
+     * Only the pair from the most recent encrypt init is tracked, so any
+     * intermediate encrypt init (key-only with a fresh random IV, or a
+     * different explicit IV) erases the memory of a previously used pair
+     * and a caller can deliberately reuse an earlier (key, IV) pair. This
+     * is a best-effort guard against accidental reuse, kept for SunJCE
+     * interoperability. Callers that opt out this way own IV uniqueness
+     * themselves.
+     *
+     * Called from wolfCryptCipherInit(). The new pair is recorded by
+     * recordGcmKeyIv() only after wolfCryptSetKey() accepts the key, so
+     * a failed init does not erase the tracked pair. Encrypting again
+     * without re-init is rejected separately via gcmEncryptNeedsReinit.
+     *
+     * @param key key this Cipher is being initialized with
+     *
+     * @throws InvalidAlgorithmParameterException if key and IV match the
+     *         previous AES-GCM encrypt initialization
+     */
+    private void checkGcmKeyIvReuse(Key key)
+        throws InvalidAlgorithmParameterException {
+
+        byte[] keyEnc = null;
+
+        if ((this.cipherMode != CipherMode.WC_GCM) ||
+            (this.direction != OpMode.WC_ENCRYPT) || (key == null)) {
+            return;
+        }
+
+        keyEnc = key.getEncoded();
+        if (keyEnc == null) {
+            /* wolfCryptSetKey() will reject this key */
+            return;
+        }
+
+        try {
+            if (this.lastGcmEncryptIv != null &&
+                MessageDigest.isEqual(this.lastGcmEncryptIv, this.iv) &&
+                MessageDigest.isEqual(this.lastGcmEncryptKeyHash,
+                    hashKeyForGcmTracking(keyEnc))) {
+                throw new InvalidAlgorithmParameterException(
+                    "Cannot reuse iv for GCM encryption");
+            }
+        } finally {
+            zeroArray(keyEnc);
+        }
+    }
+
+    /**
+     * Compute digest of encoded key bytes for GCM (key, IV) reuse
+     * tracking. A digest is stored and compared instead of the raw key
+     * bytes to avoid keeping an extra copy of key material in memory.
+     *
+     * SHA-512 is preferred to keep this compatible with CNSA 2.0
+     * deployments, which restrict hashing to SHA-384/SHA-512. SHA-256 is
+     * used as fallback when SHA-512 is not compiled into native wolfSSL.
+     *
+     * @param keyEnc encoded key bytes
+     *
+     * @return digest of keyEnc
+     */
+    private static byte[] hashKeyForGcmTracking(byte[] keyEnc) {
+
+        if (FeatureDetect.Sha512Enabled()) {
+            Sha512 sha = new Sha512();
+
+            try {
+                sha.update(keyEnc);
+                return sha.digest();
+            } finally {
+                sha.releaseNativeStruct();
+            }
+        }
+        else {
+            Sha256 sha = new Sha256();
+
+            try {
+                sha.update(keyEnc);
+                return sha.digest();
+            } finally {
+                sha.releaseNativeStruct();
+            }
+        }
+    }
+
+    /**
+     * Record the (key, IV) pair used for this AES-GCM encrypt init,
+     * checked against by checkGcmKeyIvReuse() on the next encrypt init.
+     *
+     * Called from wolfCryptCipherInit() after wolfCryptSetKey() has
+     * accepted the key.
+     *
+     * @param key key this Cipher was initialized with
+     */
+    private void recordGcmKeyIv(Key key) {
+
+        byte[] keyEnc = null;
+
+        if ((this.cipherMode != CipherMode.WC_GCM) ||
+            (this.direction != OpMode.WC_ENCRYPT) || (key == null)) {
+            return;
+        }
+
+        keyEnc = key.getEncoded();
+        if (keyEnc == null) {
+            return;
+        }
+
+        try {
+            zeroArray(this.lastGcmEncryptKeyHash);
+            this.lastGcmEncryptKeyHash = hashKeyForGcmTracking(keyEnc);
+        } finally {
+            zeroArray(keyEnc);
+        }
+        zeroArray(this.lastGcmEncryptIv);
+        if (this.iv == null) {
+            this.lastGcmEncryptIv = null;
+        } else {
+            this.lastGcmEncryptIv = this.iv.clone();
+        }
+    }
+
     /* called by engineInit() functions */
     private void wolfCryptCipherInit(int opmode, Key key,
             AlgorithmParameterSpec spec, SecureRandom random)
@@ -1057,9 +1192,12 @@ public class WolfCryptCipher extends CipherSpi {
         InitializeNativeStructs();
         wolfCryptSetDirection(opmode);
         wolfCryptSetIV(spec, random);
+        checkGcmKeyIvReuse(key);
         wolfCryptSetKey(key);
+        recordGcmKeyIv(key);
         this.operationStarted = false;
         this.cipherInitialized = true;
+        this.gcmEncryptNeedsReinit = false;
     }
 
     @Override
@@ -1196,6 +1334,15 @@ public class WolfCryptCipher extends CipherSpi {
         if (input.length < (inputOffset + len)) {
             throw new IllegalArgumentException(
                 "Input buffer length smaller than inputOffset + len");
+        }
+
+        /* A second GCM encryption without re-init would reuse the same
+         * key and IV, fail here at update() time like SunJCE does */
+        if ((this.cipherMode == CipherMode.WC_GCM) &&
+            (this.direction == OpMode.WC_ENCRYPT) &&
+            this.gcmEncryptNeedsReinit) {
+            throw new IllegalStateException(
+                "Must use either different key or iv for GCM encryption");
         }
 
         this.operationStarted = true;
@@ -1396,40 +1543,19 @@ public class WolfCryptCipher extends CipherSpi {
                 if (cipherMode == CipherMode.WC_GCM) {
                     if (this.direction == OpMode.WC_ENCRYPT) {
 
-                        byte[] keyEnc;
-                        if (this.storedKey == null) {
-                            keyEnc = null;
-                        } else {
-                            keyEnc = this.storedKey.getEncoded();
-                        }
-
-                        /* Prevent reusing the same key and IV for GCM
-                         * encryption to protect against catastrophic security
-                         * degradation. */
-                        if (this.lastGcmEncryptIv != null &&
-                            MessageDigest.isEqual(
-                                this.lastGcmEncryptIv, this.iv) &&
-                            MessageDigest.isEqual(
-                                this.lastGcmEncryptKey, keyEnc)) {
-                            zeroArray(keyEnc);
+                        /* A second encryption without re-init would reuse
+                         * the same key and IV (GCM nonce reuse) */
+                        if (this.gcmEncryptNeedsReinit) {
                             throw new IllegalStateException(
-                                "Cannot reuse the same key and IV for " +
-                                "AES-GCM encryption, re-initialize with a " +
-                                "fresh IV");
+                                "Must use either different key or iv for " +
+                                "GCM encryption");
                         }
 
                         byte[] tag = new byte[this.gcmTagLen];
                         tmpOut = this.aesGcm.encrypt(tmpIn, this.iv, tag,
                                     this.aadData);
 
-                        /* Record this (key, IV) as used for GCM encryption */
-                        zeroArray(this.lastGcmEncryptKey);
-                        this.lastGcmEncryptKey = keyEnc;
-                        if (this.iv == null) {
-                            this.lastGcmEncryptIv = null;
-                        } else {
-                            this.lastGcmEncryptIv = this.iv.clone();
-                        }
+                        this.gcmEncryptNeedsReinit = true;
 
                         /* Concatenate auth tag to end of ciphertext */
                         byte[] totalOut = new byte[tmpOut.length + tag.length];
@@ -2123,7 +2249,7 @@ public class WolfCryptCipher extends CipherSpi {
             }
 
             zeroArray(this.iv);
-            zeroArray(this.lastGcmEncryptKey);
+            zeroArray(this.lastGcmEncryptKeyHash);
             zeroArray(this.lastGcmEncryptIv);
 
             this.storedKey = null;

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathBuilder.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathBuilder.java
@@ -149,17 +149,18 @@ public class WolfCryptPKIXCertPathBuilder extends CertPathBuilderSpi {
 
         /* Check signature algorithm against disabled list */
         sigAlg = cert.getSigAlgName();
-        if (WolfCryptUtil.isAlgorithmDisabled(sigAlg, propertyName)) {
-            log("Algorithm constraints check failed on signature algorithm: " +
-                sigAlg);
+        if (WolfCryptUtil.isAlgorithmDisabledForCertPath(sigAlg,
+            propertyName)) {
+            log("Algorithm constraints check failed on signature " +
+                "algorithm: " + sigAlg);
             throw new CertPathBuilderException(
-                "Algorithm constraints check failed on signature algorithm: " +
-                sigAlg);
+                "Algorithm constraints check failed on signature " +
+                "algorithm: " + sigAlg);
         }
 
         /* Check public key algorithm and size against constraints */
         pubKey = cert.getPublicKey();
-        if (!WolfCryptUtil.isKeyAllowed(pubKey, propertyName)) {
+        if (!WolfCryptUtil.isKeyAllowedForCertPath(pubKey, propertyName)) {
             log("Algorithm constraints check failed on public key: " +
                 pubKey.getAlgorithm());
             throw new CertPathBuilderException(
@@ -206,7 +207,7 @@ public class WolfCryptPKIXCertPathBuilder extends CertPathBuilderSpi {
                 "Trust anchor has no public key to check algo constraints");
         }
 
-        if (!WolfCryptUtil.isKeyAllowed(pubKey, propertyName)) {
+        if (!WolfCryptUtil.isKeyAllowedForCertPath(pubKey, propertyName)) {
             log("Algorithm constraints check failed on trust " +
                 "anchor public key: " + pubKey.getAlgorithm());
             throw new CertPathBuilderException(
@@ -273,7 +274,8 @@ public class WolfCryptPKIXCertPathBuilder extends CertPathBuilderSpi {
             }
 
             if (signerKey != null &&
-                !WolfCryptUtil.isKeyAllowed(signerKey, propertyName)) {
+                !WolfCryptUtil.isKeyAllowedForCertPath(signerKey,
+                    propertyName)) {
 
                 String certName =
                     path.get(i).getSubjectX500Principal().getName();

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -401,16 +401,19 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
 
         /* Check signature algorithm against disabled list */
         sigAlg = cert.getSigAlgName();
-        if (WolfCryptUtil.isAlgorithmDisabled(sigAlg, propertyName)) {
-            log("Algorithm constraints check failed on sig algo: " + sigAlg);
+        if (WolfCryptUtil.isAlgorithmDisabledForCertPath(sigAlg,
+            propertyName)) {
+            log("Algorithm constraints check failed on signature " +
+                "algorithm: " + sigAlg);
             throw new CertPathValidatorException(
-                "Algorithm constraints check failed on sig algo: " + sigAlg,
+                "Algorithm constraints check failed on signature " +
+                "algorithm: " + sigAlg,
                 null, path, certIdx, BasicReason.ALGORITHM_CONSTRAINED);
         }
 
         /* Check public key algorithm and size against constraints */
         pubKey = cert.getPublicKey();
-        if (!WolfCryptUtil.isKeyAllowed(pubKey, propertyName)) {
+        if (!WolfCryptUtil.isKeyAllowedForCertPath(pubKey, propertyName)) {
             log("Algorithm constraints check failed on public key: " +
                 pubKey.getAlgorithm());
             throw new CertPathValidatorException(
@@ -456,12 +459,12 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
                 "algo constraints");
         }
 
-        if (!WolfCryptUtil.isKeyAllowed(pubKey, propertyName)) {
-            log("Algo constraints check failed on trust anchor public key: " +
-                pubKey.getAlgorithm());
+        if (!WolfCryptUtil.isKeyAllowedForCertPath(pubKey, propertyName)) {
+            log("Algorithm constraints check failed on trust anchor " +
+                "public key: " + pubKey.getAlgorithm());
             throw new CertPathValidatorException(
-                "Algo constraints check failed on trust anchor public key: " +
-                pubKey.getAlgorithm(), null, null, -1,
+                "Algorithm constraints check failed on trust anchor " +
+                "public key: " + pubKey.getAlgorithm(), null, null, -1,
                 BasicReason.ALGORITHM_CONSTRAINED);
         }
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -23,9 +23,14 @@ package com.wolfssl.provider.jce;
 
 import java.security.Provider;
 import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.wolfcrypt.Fips;
+import com.wolfssl.wolfcrypt.MlDsa;
+import com.wolfssl.wolfcrypt.SlhDsa;
 import com.wolfssl.wolfcrypt.WolfCryptError;
 import com.wolfssl.wolfcrypt.WolfSSLX509StoreCtx;
 
@@ -1221,10 +1226,113 @@ public final class WolfCryptProvider extends Provider {
                 "com.wolfssl.provider.jce.WolfSSLKeyStore");
         }
 
+        /* Unregister PQC parameter sets not compiled into native wolfSSL */
+        removeUnsupportedPQCParamSets();
+
         /* If using a FIPS version of wolfCrypt, allow private key to be
          * exported for use. Only applicable to FIPS 140-3 */
         if (Fips.enabled) {
             Fips.setPrivateKeyReadEnable(1, Fips.WC_KEYTYPE_ALL);
+        }
+    }
+
+    /**
+     * Remove services for PQC parameter sets that are not compiled into
+     * the native wolfSSL library.
+     *
+     * Native wolfSSL can be built with a subset of ML-DSA levels or
+     * SLH-DSA parameter sets (ex: --enable-slhdsa=128f,sha2-128f). The
+     * family-level feature detection used at registration time cannot see
+     * that granularity, so services for unsupported sets are removed here.
+     */
+    private void removeUnsupportedPQCParamSets() {
+
+        String[] mlDsaSets = {
+            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"
+        };
+
+        int[] mlDsaLevels = {
+            MlDsa.ML_DSA_44, MlDsa.ML_DSA_65, MlDsa.ML_DSA_87
+        };
+
+        String[] slhDsaSets = {
+            "SLH-DSA-SHA2-128s",  "SLH-DSA-SHA2-128f",
+            "SLH-DSA-SHA2-192s",  "SLH-DSA-SHA2-192f",
+            "SLH-DSA-SHA2-256s",  "SLH-DSA-SHA2-256f",
+            "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f",
+            "SLH-DSA-SHAKE-192s", "SLH-DSA-SHAKE-192f",
+            "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"
+        };
+
+        int[] slhDsaParams = {
+            SlhDsa.SLH_DSA_SHA2_128S,  SlhDsa.SLH_DSA_SHA2_128F,
+            SlhDsa.SLH_DSA_SHA2_192S,  SlhDsa.SLH_DSA_SHA2_192F,
+            SlhDsa.SLH_DSA_SHA2_256S,  SlhDsa.SLH_DSA_SHA2_256F,
+            SlhDsa.SLH_DSA_SHAKE_128S, SlhDsa.SLH_DSA_SHAKE_128F,
+            SlhDsa.SLH_DSA_SHAKE_192S, SlhDsa.SLH_DSA_SHAKE_192F,
+            SlhDsa.SLH_DSA_SHAKE_256S, SlhDsa.SLH_DSA_SHAKE_256F
+        };
+
+        for (int i = 0; i < mlDsaSets.length; i++) {
+            if (!FeatureDetect.MlDsaLevelEnabled(mlDsaLevels[i])) {
+                removeParamSetServices(mlDsaSets[i]);
+            }
+        }
+        for (int i = 0; i < slhDsaSets.length; i++) {
+            if (!FeatureDetect.SlhDsaParamEnabled(slhDsaParams[i])) {
+                removeParamSetServices(slhDsaSets[i]);
+            }
+        }
+
+        /* Generic KeyPairGenerator services generate their default param
+         * set when not explicitly initialized, remove them when that default
+         * is not available */
+        if (!FeatureDetect.MlDsaLevelEnabled(MlDsa.ML_DSA_65)) {
+            remove("KeyPairGenerator.ML-DSA");
+        }
+        if (!FeatureDetect.SlhDsaParamEnabled(SlhDsa.SLH_DSA_SHA2_128F)) {
+            remove("KeyPairGenerator.SLH-DSA");
+        }
+    }
+
+    /**
+     * Remove all services and aliases registered for a single PQC param
+     * set name, including pre-hash signature variants.
+     *
+     * @param paramSet parameter set name (ex: "SLH-DSA-SHA2-128s")
+     */
+    private void removeParamSetServices(String paramSet) {
+
+        List<Object> toRemove = new ArrayList<Object>();
+
+        for (Map.Entry<Object, Object> entry : entrySet()) {
+            Object k = entry.getKey();
+            if (!(k instanceof String)) {
+                continue;
+            }
+            String name = (String)k;
+
+            /* Service registrations (Signature. / KeyPairGenerator. /
+             * KeyFactory.) and pre-hash signature variants */
+            if (name.endsWith("." + paramSet) ||
+                name.contains("." + paramSet + "-WITH-")) {
+                toRemove.add(k);
+                continue;
+            }
+
+            /* Aliases resolving to this parameter set */
+            if (name.startsWith("Alg.Alias.")) {
+                Object v = entry.getValue();
+                if (v instanceof String &&
+                    (((String)v).equals(paramSet) ||
+                     ((String)v).startsWith(paramSet + "-WITH-"))) {
+                    toRemove.add(k);
+                }
+            }
+        }
+
+        for (Object k : toRemove) {
+            remove(k);
         }
     }
 }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
@@ -44,12 +44,21 @@ import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import javax.crypto.interfaces.DHPublicKey;
+
+import com.wolfssl.wolfcrypt.MlDsa;
+import com.wolfssl.wolfcrypt.SlhDsa;
 
 /**
  * Utility class containing helper functions for wolfCrypt JCE provider.
@@ -410,18 +419,68 @@ public class WolfCryptUtil {
      * For example, "MD2withRSA" will check for "MD2withRSA", "MD2", and
      * "RSA" in the disabled algorithms list.
      *
+     * Entries may carry qualifiers after the algorithm name (ex:
+     * "SHA1 jdkCA &amp; usage TLSServer"). This method treats all qualifiers
+     * as if their conditions hold, keeping the entry active (fail closed).
+     * Callers checking algorithms for CertPath validation should use
+     * isAlgorithmDisabledForCertPath() instead, which skips entries that can
+     * never apply to that context.
+     *
+     * Include directives (ex: "include jdk.disabled.namedCurves") are
+     * expanded to the entries of the referenced property.
+     *
      * @param algorithm Algorithm name to check (e.g., "MD2", "MD5",
      *                  "SHA1withRSA", "MD2withRSA")
      * @param propertyName Security property name to check against
-     *                     (e.g., "jdk.certpath.disabledAlgorithms")
+     *                     (ex: "jdk.certpath.disabledAlgorithms")
      *
      * @return true if algorithm is disabled, false otherwise
      */
     public static boolean isAlgorithmDisabled(String algorithm,
         String propertyName) {
 
+        return isAlgorithmDisabled(algorithm, propertyName, false);
+    }
+
+    /**
+     * Check if a given algorithm is disabled for CertPath validation based
+     * on a security property.
+     *
+     * Same as isAlgorithmDisabled(), except entries restricted to usage
+     * contexts that can never apply to validation done through the standard
+     * CertPath API (TLSServer, TLSClient, SignedJAR) are skipped, matching
+     * JDK behavior. All other qualifiers (jdkCA, denyAfter, unrecognized)
+     * are treated as if their conditions hold, keeping the entry active
+     * (fail closed).
+     *
+     * @param algorithm Algorithm name to check (e.g., "MD2", "MD5",
+     *                  "SHA1withRSA", "MD2withRSA")
+     * @param propertyName Security property name to check against
+     *                     (ex: "jdk.certpath.disabledAlgorithms")
+     *
+     * @return true if algorithm is disabled, false otherwise
+     */
+    public static boolean isAlgorithmDisabledForCertPath(String algorithm,
+        String propertyName) {
+
+        return isAlgorithmDisabled(algorithm, propertyName, true);
+    }
+
+    /**
+     * Internal implementation of the disabled algorithm checks above.
+     *
+     * @param algorithm Algorithm name to check
+     * @param propertyName Security property name to check against
+     * @param certPathContext true when checking for CertPath validation,
+     *        skips entries scoped to usage contexts that can never apply
+     *        there
+     *
+     * @return true if algorithm is disabled, false otherwise
+     */
+    private static boolean isAlgorithmDisabled(String algorithm,
+        String propertyName, boolean certPathContext) {
+
         List<String> disabledList = null;
-        String disabledAlgos = null;
 
         if (algorithm == null || algorithm.isEmpty()) {
             return false;
@@ -431,14 +490,11 @@ public class WolfCryptUtil {
             return false;
         }
 
-        disabledAlgos = Security.getProperty(propertyName);
-        if (disabledAlgos == null || disabledAlgos.isEmpty()) {
+        /* Get property entries, with include directives expanded */
+        disabledList = getExpandedDisabledEntries(propertyName);
+        if (disabledList.isEmpty()) {
             return false;
         }
-
-        /* Remove spaces after commas, split into List */
-        disabledAlgos = disabledAlgos.replaceAll(", ", ",");
-        disabledList = Arrays.asList(disabledAlgos.split(","));
 
         /* Decompose composite algorithm names like "MD2withRSA" into
          * constituent parts and check each. Common formats:
@@ -460,12 +516,24 @@ public class WolfCryptUtil {
             /* Skip key-size constraints such as "RSA keySize < 1024". Those
              * are size limits enforced by isKeyAllowed(), not signature name
              * disables. */
-            if (disabled.toLowerCase().contains("keysize")) {
+            if (disabled.toLowerCase(Locale.ROOT).contains("keysize")) {
+                continue;
+            }
+
+            /* For CertPath callers, skip entries scoped to usage contexts
+             * that never apply there (ex: "SHA1 jdkCA & usage TLSServer") */
+            if (certPathContext && !disabledEntryAppliesToCertPath(disabled)) {
                 continue;
             }
 
             /* Check the full algorithm name (case-insensitive) */
             if (disabledName.equalsIgnoreCase(algorithm)) {
+                return true;
+            }
+
+            /* Match the full entry too, curve entries can contain a
+             * space (ex: "X9.62 c2tnb191v1") */
+            if (disabled.trim().equalsIgnoreCase(algorithm)) {
                 return true;
             }
 
@@ -475,9 +543,73 @@ public class WolfCryptUtil {
                     return true;
                 }
             }
+
+            /* Known PQ family entries also disable all of their parameter
+             * sets (ex "ML-DSA" disables "ML-DSA-44"). */
+            if (isPQFamilyName(disabledName)) {
+                String prefix = disabledName + "-";
+                if (algorithm.regionMatches(true, 0, prefix, 0,
+                    prefix.length())) {
+                    return true;
+                }
+                for (String part : parts) {
+                    if (part.regionMatches(true, 0, prefix, 0,
+                        prefix.length())) {
+                        return true;
+                    }
+                }
+            }
         }
 
         return false;
+    }
+
+    /**
+     * Get the entries of a disabled-algorithms security property, with
+     * include directives (ex: "include jdk.disabled.namedCurves") expanded
+     * to the entries of the referenced property, matching JDK behavior.
+     * Each property is expanded at most once to guard against include
+     * cycles.
+     *
+     * @param propertyName Security property name to read
+     *
+     * @return list of trimmed entries, empty list if property is not set
+     */
+    private static List<String> getExpandedDisabledEntries(
+        String propertyName) {
+
+        List<String> entries = new ArrayList<String>();
+        Deque<String> pending = new ArrayDeque<String>();
+        Set<String> expanded = new HashSet<String>();
+        String propValue = null;
+
+        pending.add(propertyName);
+
+        while (!pending.isEmpty()) {
+            String prop = pending.removeFirst();
+
+            /* Expand each property at most once, guards include cycles */
+            if (!expanded.add(prop)) {
+                continue;
+            }
+
+            propValue = Security.getProperty(prop);
+            if (propValue == null || propValue.isEmpty()) {
+                continue;
+            }
+
+            for (String entry : propValue.split(",")) {
+                entry = entry.trim();
+                if (entry.regionMatches(true, 0, "include ", 0, 8)) {
+                    pending.add(entry.substring(8).trim());
+                }
+                else if (!entry.isEmpty()) {
+                    entries.add(entry);
+                }
+            }
+        }
+
+        return entries;
     }
 
     /**
@@ -506,6 +638,77 @@ public class WolfCryptUtil {
         }
 
         return tokens[0].trim();
+    }
+
+    /**
+     * Determine if a single disabled-algorithms list entry applies to generic
+     * CertPath validation.
+     *
+     * Qualifiers after the algorithm name are ANDed together
+     * (ex: "SHA1 jdkCA &amp; usage TLSServer"). A usage qualifier that
+     * names only contexts which can never apply to CertPath validation
+     * (TLSServer, TLSClient, SignedJAR) can never be satisfied, which
+     * makes the whole ANDed entry non-applicable, matching JDK behavior.
+     * All other qualifiers (jdkCA, denyAfter, malformed or unrecognized) are
+     * treated as if their conditions hold (fail closed).
+     *
+     * @param entry a single disabled-algorithms list entry
+     *
+     * @return false if the entry can never apply to generic CertPath
+     *         validation, true otherwise (fail closed)
+     */
+    private static boolean disabledEntryAppliesToCertPath(String entry) {
+
+        int idx = 0;
+        String qualifiers = null;
+        String[] groups = null;
+        String[] usageTokens = null;
+        boolean allRecognized = false;
+
+        if (entry == null) {
+            return true;
+        }
+
+        /* Leading algorithm name ends at first space, rest is qualifiers */
+        entry = entry.trim();
+        idx = entry.indexOf(' ');
+        if (idx < 0) {
+            /* Bare algorithm name, no qualifiers */
+            return true;
+        }
+        qualifiers = entry.substring(idx + 1).trim();
+
+        /* Split ANDed qualifier groups */
+        groups = qualifiers.split("&");
+
+        for (String group : groups) {
+            usageTokens = group.trim().split("\\s+");
+
+            if (usageTokens.length < 2 ||
+                !usageTokens[0].equalsIgnoreCase("usage")) {
+                /* Not a usage qualifier, treat as satisfied (fail closed) */
+                continue;
+            }
+
+            /* An unrecognized usage context keeps entry active (fail closed) */
+            allRecognized = true;
+            for (int i = 1; i < usageTokens.length; i++) {
+                if (!usageTokens[i].equalsIgnoreCase("TLSServer") &&
+                    !usageTokens[i].equalsIgnoreCase("TLSClient") &&
+                    !usageTokens[i].equalsIgnoreCase("SignedJAR")) {
+                    allRecognized = false;
+                    break;
+                }
+            }
+
+            if (allRecognized) {
+                /* Usage condition can never hold here, and conditions are
+                 * ANDed, so the entry can never apply */
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -676,10 +879,13 @@ public class WolfCryptUtil {
      * for specified algorithm.
      *
      * Parses constraints like "RSA keySize &lt; 1024" from the security
-     * property and returns the minimum allowed key size.
+     * property and returns the minimum allowed key size. Entries are
+     * matched on their leading algorithm name, any algorithm name may be
+     * used. Only the "&lt;" and "&lt;=" operators are supported, entries
+     * using other operators are ignored.
      *
-     * @param algo Algorithm to search for key size limitation for, options
-     *             are "RSA", "DH", "DSA", and "EC".
+     * @param algo Algorithm to search for key size limitation for
+     *             (ex: "RSA", "DH", "DSA", "EC")
      * @param propertyName Security property name to check
      *                     (e.g., "jdk.certpath.disabledAlgorithms")
      *
@@ -688,12 +894,32 @@ public class WolfCryptUtil {
     public static int getDisabledAlgorithmsKeySizeLimit(String algo,
         String propertyName) {
 
+        return getDisabledAlgorithmsKeySizeLimit(algo, propertyName, false);
+    }
+
+    /**
+     * Internal implementation of getDisabledAlgorithmsKeySizeLimit().
+     *
+     * Matches entries on their leading algorithm name so that, for
+     * example, an "ECDH keySize" entry does not set the "DH" limit.
+     *
+     * @param algo Algorithm to search for key size limitation for
+     *        (ex: "RSA", "DH", "DSA", "EC")
+     * @param propertyName Security property name to check
+     * @param certPathContext true when checking for CertPath validation,
+     *        skips entries scoped to usage contexts that can never apply
+     *        there
+     *
+     * @return minimum key size allowed, or 0 if not set in property
+     */
+    private static int getDisabledAlgorithmsKeySizeLimit(String algo,
+        String propertyName, boolean certPathContext) {
+
         int ret = 0;
         List<String> disabledList = null;
-        Pattern p = Pattern.compile("\\d+");
+        Pattern p = Pattern.compile("keySize\\s*<(=?)\\s*(\\d+)",
+            Pattern.CASE_INSENSITIVE);
         Matcher match = null;
-        String needle = null;
-        String disabledAlgos = null;
 
         if (algo == null || algo.isEmpty()) {
             return ret;
@@ -703,42 +929,38 @@ public class WolfCryptUtil {
             return ret;
         }
 
-        disabledAlgos = Security.getProperty(propertyName);
-        if (disabledAlgos == null) {
-            return ret;
-        }
+        /* Get property entries, with include directives expanded */
+        disabledList = getExpandedDisabledEntries(propertyName);
 
-        switch (algo) {
-            case "RSA":
-                needle = "RSA keySize <";
-                break;
-            case "DH":
-                needle = "DH keySize <";
-                break;
-            case "DSA":
-                needle = "DSA keySize <";
-                break;
-            case "EC":
-                needle = "EC keySize <";
-                break;
-            default:
-                return ret;
-        }
+        for (String s : disabledList) {
+            /* Match on the leading algorithm name only, so "ECDH keySize"
+             * does not match algo "DH" */
+            String disabledName = extractDisabledAlgorithmName(s);
+            if (disabledName == null || !disabledName.equalsIgnoreCase(algo)) {
+                continue;
+            }
 
-        /* Remove spaces after commas, split into List */
-        disabledAlgos = disabledAlgos.replaceAll(", ", ",");
-        disabledList = Arrays.asList(disabledAlgos.split(","));
+            /* For CertPath callers, skip entries scoped to usage contexts
+             * that never apply there */
+            if (certPathContext && !disabledEntryAppliesToCertPath(s)) {
+                continue;
+            }
 
-        for (String s: disabledList) {
-            if (s.contains(needle)) {
-                match = p.matcher(s);
-                if (match.find()) {
-                    try {
-                        ret = Integer.parseInt(match.group());
-                    } catch (NumberFormatException e) {
-                        /* Number exceeds Integer.MAX_VALUE, ignore malformed
-                         * number and leave ret unchanged. */
+            match = p.matcher(s);
+            if (match.find()) {
+                try {
+                    int limit = Integer.parseInt(match.group(2));
+                    if (match.group(1).equals("=") &&
+                        limit < Integer.MAX_VALUE) {
+                        /* "keySize <= N" disables through N, minimum allowed
+                         * size is N + 1 */
+                        limit = limit + 1;
                     }
+                    /* Keep the strictest of multiple matching entries */
+                    ret = Math.max(ret, limit);
+                } catch (NumberFormatException e) {
+                    /* Number exceeds Integer.MAX_VALUE, ignore malformed
+                     * number and leave ret unchanged. */
                 }
             }
         }
@@ -747,20 +969,58 @@ public class WolfCryptUtil {
     }
 
     /**
-     * Check if a public key meets the size constraints specified in a
-     * security property.
+     * Check if a public key meets size constraints in a security property.
      *
-     * Extracts the key size based on key type (RSA, EC, DSA) and compares
-     * against minimum size constraints from the security property.
+     * Extracts key size based on key type (RSA, EC, DSA, DH) and compares
+     * against minimum size constraints from the security property. ML-DSA
+     * and SLH-DSA keys have fixed parameter sets rather than key sizes,
+     * and are checked by family and parameter set name (ex: "ML-DSA",
+     * "ML-DSA-44").
      *
      * @param key PublicKey to check
      * @param propertyName Security property name to check constraints from
-     *                     (e.g., "jdk.certpath.disabledAlgorithms")
+     *                     (ex: "jdk.certpath.disabledAlgorithms")
      *
      * @return true if key is allowed (meets size requirements), false if
      *         key size is too small or key type is unsupported
      */
     public static boolean isKeyAllowed(PublicKey key, String propertyName) {
+
+        return isKeyAllowed(key, propertyName, false);
+    }
+
+    /**
+     * Check if a public key meets size constraints specified in a security
+     * property, for use during CertPath validation.
+     *
+     * Same as isKeyAllowed(), except algorithm name checks use
+     * isAlgorithmDisabledForCertPath() semantics, skipping entries scoped
+     * to usage contexts that can never apply to CertPath validation.
+     *
+     * @param key PublicKey to check
+     * @param propertyName Security property name to check constraints from
+     *                     (ex: "jdk.certpath.disabledAlgorithms")
+     *
+     * @return true if key is allowed (meets size requirements), false if
+     *         key size is too small or key type is unsupported
+     */
+    public static boolean isKeyAllowedForCertPath(PublicKey key,
+        String propertyName) {
+
+        return isKeyAllowed(key, propertyName, true);
+    }
+
+    /**
+     * Internal implementation of key constraint checks above.
+     *
+     * @param key PublicKey to check
+     * @param propertyName Security property name to check constraints from
+     * @param certPathContext true when checking for CertPath validation
+     *
+     * @return true if key is allowed, false otherwise
+     */
+    private static boolean isKeyAllowed(PublicKey key, String propertyName,
+        boolean certPathContext) {
 
         int keySize = 0;
         int minSize = 0;
@@ -781,7 +1041,8 @@ public class WolfCryptUtil {
         if (key instanceof RSAPublicKey) {
             RSAPublicKey rsaKey = (RSAPublicKey)key;
             keySize = rsaKey.getModulus().bitLength();
-            minSize = getDisabledAlgorithmsKeySizeLimit("RSA", propertyName);
+            minSize = getDisabledAlgorithmsKeySizeLimit("RSA", propertyName,
+                certPathContext);
         }
         else if (key instanceof ECPublicKey) {
             ECPublicKey ecKey = (ECPublicKey)key;
@@ -790,18 +1051,63 @@ public class WolfCryptUtil {
                 /* EC key size is the order bit length */
                 keySize = params.getOrder().bitLength();
             }
-            minSize = getDisabledAlgorithmsKeySizeLimit("EC", propertyName);
+
+            /* Check named curve against disabled entries when the curve name
+             * can be determined, covers curves included from
+             * jdk.disabled.namedCurves. Keys whose curve cannot be determined
+             * are checked by size only. The "X9.62 " form matches JDK entries
+             * like "X9.62 c2tnb191v1". Skip curve resolution when the property
+             * has no entries, avoids native key translation with nothing to
+             * check against. */
+            String disabledProp = Security.getProperty(propertyName);
+            if (disabledProp != null && !disabledProp.isEmpty()) {
+                String curve = getECCurveName(ecKey);
+                if (curve != null &&
+                    (isAlgorithmDisabled(curve, propertyName,
+                        certPathContext) ||
+                     isAlgorithmDisabled("X9.62 " + curve, propertyName,
+                        certPathContext))) {
+                    return false;
+                }
+            }
+
+            minSize = getDisabledAlgorithmsKeySizeLimit("EC", propertyName,
+                certPathContext);
         }
         else if (key instanceof DSAPublicKey) {
             DSAPublicKey dsaKey = (DSAPublicKey)key;
             if (dsaKey.getParams() != null) {
                 keySize = dsaKey.getParams().getP().bitLength();
             }
-            minSize = getDisabledAlgorithmsKeySizeLimit("DSA", propertyName);
+            minSize = getDisabledAlgorithmsKeySizeLimit("DSA", propertyName,
+                certPathContext);
+        }
+        else if (key instanceof DHPublicKey) {
+            DHPublicKey dhKey = (DHPublicKey)key;
+            if (dhKey.getParams() != null) {
+                keySize = dhKey.getParams().getP().bitLength();
+            }
+            minSize = getDisabledAlgorithmsKeySizeLimit("DH", propertyName,
+                certPathContext);
+        }
+        else if (key instanceof WolfCryptMlDsaPublicKey) {
+            /* ML-DSA uses fixed parameter sets, no key size constraints */
+            return isPQKeyAllowed(algorithm,
+                MlDsa.getParamSetName(
+                    ((WolfCryptMlDsaPublicKey)key).getLevel()),
+                propertyName, certPathContext);
+        }
+        else if (key instanceof WolfCryptSlhDsaPublicKey) {
+            /* SLH-DSA uses fixed parameter sets, no key size constraints */
+            return isPQKeyAllowed(algorithm,
+                SlhDsa.getParamSetName(
+                    ((WolfCryptSlhDsaPublicKey)key).getParam()),
+                propertyName, certPathContext);
         }
         else {
             /* Unsupported key type, check if algorithm itself is disabled */
-            return !isAlgorithmDisabled(algorithm, propertyName);
+            return !isAlgorithmDisabled(algorithm, propertyName,
+                certPathContext);
         }
 
         /* If minimum size constraint exists and key is smaller, reject */
@@ -810,11 +1116,99 @@ public class WolfCryptUtil {
         }
 
         /* Check if algorithm name is disabled */
-        if (isAlgorithmDisabled(algorithm, propertyName)) {
+        if (isAlgorithmDisabled(algorithm, propertyName, certPathContext)) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Get the named curve of an EC public key, when determinable.
+     *
+     * wolfJCE keys carry the curve name in their parameters. Keys from
+     * other providers are re-resolved through the wolfJCE EC KeyFactory
+     * to detect the curve.
+     *
+     * @param ecKey EC public key to get curve name of
+     *
+     * @return curve name (ex: "SECP256R1"), or null if the curve could
+     *         not be determined
+     */
+    private static String getECCurveName(ECPublicKey ecKey) {
+
+        ECParameterSpec params = ecKey.getParams();
+
+        if (params instanceof WolfCryptECParameterSpec) {
+            return ((WolfCryptECParameterSpec)params).getStoredCurveName();
+        }
+
+        /* Key from other provider, re-resolve through the wolfJCE EC
+         * KeyFactory to detect the curve */
+        try {
+            Key translated =
+                new WolfCryptECKeyFactory().engineTranslateKey(ecKey);
+            if (translated instanceof ECPublicKey) {
+                params = ((ECPublicKey)translated).getParams();
+                if (params instanceof WolfCryptECParameterSpec) {
+                    return ((WolfCryptECParameterSpec)params)
+                        .getStoredCurveName();
+                }
+            }
+        } catch (Exception e) {
+            /* Unable to translate key, curve name unknown. */
+            log("Unable to resolve EC curve name for disabled algo check:" +
+                e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Check a post-quantum public key against disabled algorithm entries
+     * by family and parameter set name.
+     *
+     * @param family family algorithm name (ex: "ML-DSA")
+     * @param paramSet parameter set name (ex: "ML-DSA-44"), null is
+     *        treated as not allowed (fail closed)
+     * @param propertyName Security property name to check against
+     * @param certPathContext true when checking for CertPath validation
+     *
+     * @return true if key is allowed, false otherwise
+     */
+    private static boolean isPQKeyAllowed(String family, String paramSet,
+        String propertyName, boolean certPathContext) {
+
+        if (paramSet == null) {
+            /* Unknown parameter set, fail closed */
+            return false;
+        }
+
+        if (isAlgorithmDisabled(family, propertyName, certPathContext)) {
+            return false;
+        }
+
+        if (isAlgorithmDisabled(paramSet, propertyName, certPathContext)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if an algorithm name is a known post-quantum family name.
+     * A disabled-algorithms entry with a family name also disables all
+     * parameter sets of that family.
+     *
+     * @param name algorithm name to check
+     *
+     * @return true if name is a PQ family name, false otherwise
+     */
+    private static boolean isPQFamilyName(String name) {
+
+        return name.equalsIgnoreCase("ML-DSA") ||
+               name.equalsIgnoreCase("SLH-DSA") ||
+               name.equalsIgnoreCase("ML-KEM");
     }
 
     /**

--- a/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/FeatureDetect.java
@@ -419,6 +419,33 @@ public class FeatureDetect {
     public static native boolean SlhDsaKeyGenEnabled();
 
     /**
+     * Tests if given ML-DSA level is compiled into native wolfSSL.
+     *
+     * Probes native key initialization at runtime, so the result exactly
+     * matches what key operations will accept, including level-restricted
+     * native wolfSSL builds.
+     *
+     * @param level ML-DSA level, one of MlDsa.ML_DSA_44/65/87
+     *
+     * @return true if the level is compiled in and usable, otherwise false
+     */
+    public static native boolean MlDsaLevelEnabled(int level);
+
+    /**
+     * Tests if given SLH-DSA parameter set is compiled into native wolfSSL.
+     *
+     * Probes native key initialization at runtime, so the result exactly
+     * matches what key operations will accept, including parameter set
+     * restricted native wolfSSL builds (ex: --enable-slhdsa=128f,sha2-128f).
+     *
+     * @param param SLH-DSA parameter set, one of SlhDsa.SLH_DSA_*
+     *
+     * @return true if the parameter set is compiled in and usable,
+     *         otherwise false
+     */
+    public static native boolean SlhDsaParamEnabled(int param);
+
+    /**
      * Tests if LMS/HSS (RFC 8554) is compiled into the native wolfSSL
      * library.
      *

--- a/src/main/java/com/wolfssl/wolfcrypt/MlDsa.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/MlDsa.java
@@ -54,6 +54,28 @@ public class MlDsa extends NativeStruct {
     /** ML-DSA external mu length, in bytes (FIPS 204). */
     public static final int ML_DSA_MU_LEN = 64;
 
+    /**
+     * Get the standard algorithm name for an ML-DSA level.
+     *
+     * @param level ML-DSA level, one of ML_DSA_44/65/87
+     *
+     * @return standard algorithm name (e.g. "ML-DSA-44"), or null
+     *         if level is unknown
+     */
+    public static String getParamSetName(int level) {
+
+        switch (level) {
+            case ML_DSA_44:
+                return "ML-DSA-44";
+            case ML_DSA_65:
+                return "ML-DSA-65";
+            case ML_DSA_87:
+                return "ML-DSA-87";
+            default:
+                return null;
+        }
+    }
+
     private WolfCryptState state = WolfCryptState.UNINITIALIZED;
 
     /** Lock around object state. */

--- a/src/main/java/com/wolfssl/wolfcrypt/SlhDsa.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/SlhDsa.java
@@ -75,6 +75,46 @@ public class SlhDsa extends NativeStruct {
     /** FIPS 205 maximum context length, in bytes. */
     public static final int SLH_DSA_MAX_CONTEXT_LEN = 255;
 
+    /**
+     * Get the standard algorithm name for an SLH-DSA parameter set.
+     *
+     * @param param SLH-DSA parameter set, one of SLH_DSA_*
+     *
+     * @return standard algorithm name (e.g. "SLH-DSA-SHA2-128s"), or
+     *         null if param is unknown
+     */
+    public static String getParamSetName(int param) {
+
+        switch (param) {
+            case SLH_DSA_SHAKE_128S:
+                return "SLH-DSA-SHAKE-128s";
+            case SLH_DSA_SHAKE_128F:
+                return "SLH-DSA-SHAKE-128f";
+            case SLH_DSA_SHAKE_192S:
+                return "SLH-DSA-SHAKE-192s";
+            case SLH_DSA_SHAKE_192F:
+                return "SLH-DSA-SHAKE-192f";
+            case SLH_DSA_SHAKE_256S:
+                return "SLH-DSA-SHAKE-256s";
+            case SLH_DSA_SHAKE_256F:
+                return "SLH-DSA-SHAKE-256f";
+            case SLH_DSA_SHA2_128S:
+                return "SLH-DSA-SHA2-128s";
+            case SLH_DSA_SHA2_128F:
+                return "SLH-DSA-SHA2-128f";
+            case SLH_DSA_SHA2_192S:
+                return "SLH-DSA-SHA2-192s";
+            case SLH_DSA_SHA2_192F:
+                return "SLH-DSA-SHA2-192f";
+            case SLH_DSA_SHA2_256S:
+                return "SLH-DSA-SHA2-256s";
+            case SLH_DSA_SHA2_256F:
+                return "SLH-DSA-SHA2-256f";
+            default:
+                return null;
+        }
+    }
+
     /* Lowest and highest valid native enum SlhDsaParam values. */
     private static final int PARAM_MIN = 0;
     private static final int PARAM_MAX = 11;

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
@@ -55,6 +55,64 @@ public class WolfSSLCertManager {
     /* lock around native WOLFSSL_CERT_MANAGER pointer use */
     private final Object cmLock = new Object();
 
+    /*
+     * Loads JNI library.
+     *
+     * Must run before the static native method call below, which happens
+     * during class initialization. Without this, touching this class
+     * before any other native-backed class throws UnsatisfiedLinkError
+     * from the class initializer and permanently poisons this class in
+     * the JVM.
+     *
+     * The native library is expected to be called "wolfcryptjni", and must
+     * be on the system library search path.
+     *
+     * "wolfcryptjni" links against the wolfSSL native C library ("wolfssl"),
+     * and for Windows compatibility "wolfssl" needs to be explicitly loaded
+     * first here.
+     *
+     * Library loading can be skipped by setting the System property
+     * "wolfssl.skipLibraryLoad" to "true". This allows applications to
+     * load native libraries manually using System.load() before accessing
+     * any wolfSSL classes.
+     */
+    static {
+        int fipsLoaded = 0;
+
+        String skipLoad = System.getProperty("wolfssl.skipLibraryLoad");
+        if (skipLoad != null && skipLoad.equalsIgnoreCase("true")) {
+            /* User indicated they will load native libraries manually */
+        }
+        else {
+            String osName = System.getProperty("os.name");
+            if (osName != null && osName.toLowerCase().contains("win")) {
+                try {
+                    /* Default wolfCrypt FIPS library on Windows is compiled
+                     * as "wolfssl-fips" by Visual Studio solution */
+                    System.loadLibrary("wolfssl-fips");
+                    fipsLoaded = 1;
+                } catch (UnsatisfiedLinkError e) {
+                    /* wolfCrypt FIPS not available */
+                }
+
+                if (fipsLoaded == 0) {
+                    /* FIPS library not loaded, try normal libwolfssl */
+                    System.loadLibrary("wolfssl");
+                }
+            }
+
+            /* Load wolfcryptjni library */
+            System.loadLibrary("wolfcryptjni");
+        }
+
+        /* Run FIPS CAST up front if we are in FIPS mode. Referencing Fips
+         * triggers WolfObject static initialization, which calls native
+         * wolfCrypt init. runAllCast_fips() only runs the CASTs once. */
+        if (Fips.enabled) {
+            Fips.runAllCast_fips();
+        }
+    }
+
     /** Flag to allow loading certs with date errors */
     public static final int WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY =
         getWOLFSSL_LOAD_FLAG_DATE_ERR_OKAY();

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -2636,18 +2636,23 @@ public class WolfCryptCipherTest {
         assertEquals("Output size for zero-length input should be tag length",
             TAG_LENGTH_BYTES, cipher.getOutputSize(0));
 
-        /* Test ENCRYPT with small input, re-init to reset state */
+        /* Test ENCRYPT with small input. Each encrypt re-init needs a
+         * fresh IV, same key and IV is rejected */
+        iv[0] = (byte) 0x03;
+        spec = new GCMParameterSpec(TAG_LENGTH_BYTES * 8, iv);
         cipher.init(Cipher.ENCRYPT_MODE, key, spec);
         assertEquals("Output size should be input length plus tag length",
             10 + TAG_LENGTH_BYTES, cipher.getOutputSize(10));
 
         /* Test ENCRYPT with block boundary input */
+        iv[0] = (byte) 0x04;
+        spec = new GCMParameterSpec(TAG_LENGTH_BYTES * 8, iv);
         cipher.init(Cipher.ENCRYPT_MODE, key, spec);
         assertEquals("Output size should be input length plus tag length " +
             "at block boundary", 16 + TAG_LENGTH_BYTES,
             cipher.getOutputSize(16));
 
-        /* Test DECRYPT with tag included */
+        /* Test DECRYPT with tag included (no IV reuse restriction) */
         cipher.init(Cipher.DECRYPT_MODE, key, spec);
         assertEquals("Output size for decryption should be input length " +
             "minus tag length", 10,
@@ -2655,6 +2660,8 @@ public class WolfCryptCipherTest {
 
         /* Test ENCRYPT after partial update */
         byte[] partialInput = new byte[5];
+        iv[0] = (byte) 0x05;
+        spec = new GCMParameterSpec(TAG_LENGTH_BYTES * 8, iv);
         cipher.init(Cipher.ENCRYPT_MODE, key, spec);
         cipher.update(partialInput); /* Process some data */
         assertEquals("Output size after update should account for remaining " +
@@ -7440,6 +7447,106 @@ public class WolfCryptCipherTest {
         dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
         assertArrayEquals(pt, dec.doFinal(ct));
         assertArrayEquals(pt, dec.doFinal(ct));
+    }
+
+    private static boolean isAndroid() {
+        String runtimeName = System.getProperty("java.runtime.name");
+        return (runtimeName != null) && runtimeName.contains("Android");
+    }
+
+    /**
+     * Test that AES-GCM rejects encrypt re-initialization with the same
+     * key and IV, and that a key-only init (fresh random IV) replaces the
+     * tracked pair, matching SunJCE behavior.
+     */
+    @Test
+    public void testGCMEncryptRejectsSameKeyIvReinit() throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            return;
+        }
+
+        byte[] keyBytes = new byte[16];
+        byte[] iv = new byte[12];
+        byte[] pt = "GCM same key+IV re-init test".getBytes();
+
+        secureRandom.nextBytes(keyBytes);
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
+        secureRandom.nextBytes(iv);
+
+        /* Android's Cipher framework performs SPI selection at each
+         * init() and may use a fresh CipherSpi instance, so per instance
+         * (key, IV) reuse tracking cannot span re-inits there. Skip the
+         * re-init rejection checks on Android. */
+        if (!isAndroid()) {
+            /* Re-init with the same key and IV after an encryption must
+             * be rejected at init time */
+            Cipher c = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+            c.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+            c.doFinal(pt);
+            try {
+                c.init(Cipher.ENCRYPT_MODE, key,
+                    new GCMParameterSpec(128, iv));
+                fail("GCM encrypt init with same key and IV should throw");
+            } catch (InvalidAlgorithmParameterException e) {
+                /* expected */
+            }
+
+            /* Also rejected without a completed encryption in between */
+            Cipher c2 = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+            c2.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+            try {
+                c2.init(Cipher.ENCRYPT_MODE, key,
+                    new GCMParameterSpec(128, iv));
+                fail("GCM encrypt init with same key and IV should throw");
+            } catch (InvalidAlgorithmParameterException e) {
+                /* expected */
+            }
+        }
+
+        /* A key-only init generates a fresh random IV and replaces the
+         * tracked pair, so a following init with an explicit IV is accepted. */
+        Cipher c3 = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+        c3.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+        byte[] ct1 = c3.doFinal(pt);
+        c3.init(Cipher.ENCRYPT_MODE, key);
+        c3.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+        byte[] ct2 = c3.doFinal(pt);
+        assertArrayEquals("Same key, IV and plaintext should match", ct1, ct2);
+
+        if (!isAndroid()) {
+            /* A failed init (bad key) must not erase the tracked pair */
+            Cipher c4 = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+            c4.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+            try {
+                c4.init(Cipher.ENCRYPT_MODE,
+                    new SecretKeySpec(new byte[7], "AES"),
+                    new GCMParameterSpec(128, iv));
+                fail("init with 7-byte AES key should throw");
+            } catch (Exception e) {
+                /* expected, invalid AES key length */
+            }
+            try {
+                c4.init(Cipher.ENCRYPT_MODE, key,
+                    new GCMParameterSpec(128, iv));
+                fail("Same key and IV re-init should throw after failed " +
+                    "init");
+            } catch (InvalidAlgorithmParameterException e) {
+                /* expected */
+            }
+        }
+
+        /* update() after a completed GCM encryption must fail like
+         * doFinal() does, matching SunJCE */
+        Cipher c5 = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+        c5.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+        c5.doFinal(pt);
+        try {
+            c5.update(pt);
+            fail("update() after completed GCM encryption should throw");
+        } catch (IllegalStateException e) {
+            /* expected */
+        }
     }
 
     /**

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -1532,5 +1532,43 @@ public class WolfCryptKeyPairGeneratorTest {
             scope.close();
         }
     }
+
+    /**
+     * Every registered PQC KeyPairGenerator service must be able to generate
+     * a key pair. Native wolfSSL can be built with a subset of ML-DSA levels
+     * or SLH-DSA parameter sets, in which case the provider must not register
+     * services for the missing sets, and getInstance() throws
+     * NoSuchAlgorithmException instead of key generation failing at runtime.
+     */
+    @Test
+    public void testPQCParamSetRegistrationMatchesNative()
+        throws Exception {
+
+        String[] algos = {
+            "ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+            "SLH-DSA",
+            "SLH-DSA-SHA2-128s",  "SLH-DSA-SHA2-128f",
+            "SLH-DSA-SHA2-192s",  "SLH-DSA-SHA2-192f",
+            "SLH-DSA-SHA2-256s",  "SLH-DSA-SHA2-256f",
+            "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f",
+            "SLH-DSA-SHAKE-192s", "SLH-DSA-SHAKE-192f",
+            "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"
+        };
+
+        for (String algo : algos) {
+            KeyPairGenerator kpg = null;
+
+            try {
+                kpg = KeyPairGenerator.getInstance(algo, "wolfJCE");
+            } catch (NoSuchAlgorithmException e) {
+                /* Not registered, param set not compiled into native wolfSSL */
+                continue;
+            }
+
+            assertNotNull("Registered KeyPairGenerator " + algo +
+                " must be able to generate a key pair",
+                kpg.generateKeyPair());
+        }
+    }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
@@ -1438,6 +1438,134 @@ public class WolfCryptPKIXCertPathValidatorTest {
         }
     }
 
+    /* SHA1withRSA test chain (RSA 2048) for usage-qualifier constraint
+     * testing. CA is self-signed, EE is signed by the CA, both with
+     * SHA1withRSA. Valid 2026-07-15 through 2036-07-12. */
+    private static final String sha1TestCaPem =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIDTTCCAjWgAwIBAgIUZNwK3fw2T2OWCzdXOvIWGg1JhKUwDQYJKoZIhvcNAQEF\n" +
+        "BQAwNjEVMBMGA1UECgwMd29sZlNTTCBUZXN0MR0wGwYDVQQDDBR3b2xmSkNFIFNI\n" +
+        "QTEgVGVzdCBDQTAeFw0yNjA3MTUxOTQ1NDhaFw0zNjA3MTIxOTQ1NDhaMDYxFTAT\n" +
+        "BgNVBAoMDHdvbGZTU0wgVGVzdDEdMBsGA1UEAwwUd29sZkpDRSBTSEExIFRlc3Qg\n" +
+        "Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCbJGY3iHyVrp/qRzGa\n" +
+        "Vaaw/zJOXccpcRipgarox6Y8n/c/3JXQxRf/CbJF9aRNdeZXCdFEx+rjk42ANkgt\n" +
+        "gYW92QxYox3/kwKK9p8z0Sx+NQ6frV2CQrRcCnqrf9q2AR7lmMmIY0KbzHw/ONQ9\n" +
+        "GmsQwurafvqVKJawcm+aMoR81wTk2pOqosZizyGWfasMWh3IMj2i2/9QwskA3VV9\n" +
+        "x+6nTx2ro9/pb8qO7QF8bw4IaYdqGPv1QuaHAyjhIgkZnBqb57nLi/TxN7R5tHhm\n" +
+        "rN8iPSfRUlHvcpjEuPXSmOPVtlPWj0BTPzPHAHGjyq3w0sLjb32Tfq0jHa2AxI2e\n" +
+        "LQe9AgMBAAGjUzBRMB0GA1UdDgQWBBQo/AVZlIKOq/krmTg2gTNd7797ezAfBgNV\n" +
+        "HSMEGDAWgBQo/AVZlIKOq/krmTg2gTNd7797ezAPBgNVHRMBAf8EBTADAQH/MA0G\n" +
+        "CSqGSIb3DQEBBQUAA4IBAQAbH5ciuh+DKqFk8p6QkJDLnnNKJbiU2UKAaZA4TwLQ\n" +
+        "uLdHtjKK2VBK9LFVnJ+bULKEc2ceGATssQ/N6QjpOIQEMdAqGvzRhLZv6kAqqe8M\n" +
+        "2i1IFwYZX7Y3Ol1gn7vhzuS76AuHc4W/vrrmQQApGB6SioLP8f0HRD0erGmpVzvu\n" +
+        "dS1P3so8BLUGcZtCJIJBk/jin1c7POlsvUwn1wrGC1gXutqvKlKYaC+siJcozJlk\n" +
+        "4tFUUwgopN7CPlQYM6RHY+DWriW6rmEQp+ABUAbw6kLDtBs4h1CWBjeJklYEObH7\n" +
+        "nH5HCzZCPTjKQ8qvQNiW4xl4ZxfjItY0Ij3AvIZIZ1ug\n" +
+        "-----END CERTIFICATE-----\n";
+
+    private static final String sha1TestEePem =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIDPDCCAiSgAwIBAgIUGqf56ThWW7atVoAWjObdEdvf0pYwDQYJKoZIhvcNAQEF\n" +
+        "BQAwNjEVMBMGA1UECgwMd29sZlNTTCBUZXN0MR0wGwYDVQQDDBR3b2xmSkNFIFNI\n" +
+        "QTEgVGVzdCBDQTAeFw0yNjA3MTUxOTQ1NDhaFw0zNjA3MTIxOTQ1NDhaMDYxFTAT\n" +
+        "BgNVBAoMDHdvbGZTU0wgVGVzdDEdMBsGA1UEAwwUd29sZkpDRSBTSEExIFRlc3Qg\n" +
+        "RUUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCHSuxiOy8OE0UaTEHL\n" +
+        "EmpiXS2qGsGFhNhzfz9CgnmTs8rWWM4zexxoOjtM2n7+Y8oLnqIPNeMtqNaG4fm+\n" +
+        "bzggPkUsTL3OFETCyZyEat1t5YGJ/zufBVeF4I9xUDiqXLHK/g43uf4l2Jy4hulf\n" +
+        "gQImauE7a3hdNRKLFtcIgRX17nQrVsUrZ9yPalwaBtXq8HLApph+KNjqWf2k/k35\n" +
+        "IGg+zfIqogvy73492/btevCXeeW0a/lt0DJJ+9aOw8RWri0y14A+B+eA467JWWHo\n" +
+        "zwFjux5xPuxHnnPxf9/3QCmdel3O7aqcWywM7gAIDqv0uQ1gaBZkSZDMsv8VRq+W\n" +
+        "/fPbAgMBAAGjQjBAMB0GA1UdDgQWBBTZhVCfOJkNWRyZ8dnXV7Q4GnKUmDAfBgNV\n" +
+        "HSMEGDAWgBQo/AVZlIKOq/krmTg2gTNd7797ezANBgkqhkiG9w0BAQUFAAOCAQEA\n" +
+        "iDgnhsDpvkMeAMjreTq8Cnm9PMBfULAlxoOgzcSrecgi6ZLsROGiK97hX34mUaX3\n" +
+        "jatTDOpSRpPHeWxGOgKytXhmsHxkXeaZbn2AG3aWsWEZ9MjGVtmo2v8gL/64O3Tq\n" +
+        "sDZgZlENw0X05iGhOebSZwWHAXblieTqI30w69nJcChTit8F6nyvbatiykPknnGW\n" +
+        "/EVlicBy0C2rGyGB0lt4KCcTKdmvRe0FjhqTCHeZ5aR+Glt6bMJVH2qXWL37AZ7B\n" +
+        "wV3u7i1H44KXIxliMXOWEgV+fUmBjLAB+1rgLF19wmlPhMujwCgE/tLJMGM+gHO/\n" +
+        "MRwbWhzWQ3ULF/oy96RYpA==\n" +
+        "-----END CERTIFICATE-----\n";
+
+    /**
+     * Usage-qualified SHA1 entries in jdk.certpath.disabledAlgorithms
+     * (JDK factory default form) must not reject a SHA1-signed chain during
+     * CertPath validation. A bare SHA1 entry must still reject it.
+     */
+    @Test
+    public void testUsageQualifiedSHA1AllowedForCertPath() throws Exception {
+
+        String origProperty = null;
+        CertificateFactory cf = null;
+        X509Certificate caCert = null;
+        X509Certificate eeCert = null;
+        Set<TrustAnchor> anchors = null;
+        PKIXParameters params = null;
+        CertPath path = null;
+        CertPathValidator validator = null;
+
+        /* Save original security property value */
+        origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+
+        try {
+            cf = CertificateFactory.getInstance("X.509");
+            caCert = (X509Certificate)cf.generateCertificate(
+                new ByteArrayInputStream(sha1TestCaPem.getBytes()));
+            eeCert = (X509Certificate)cf.generateCertificate(
+                new ByteArrayInputStream(sha1TestEePem.getBytes()));
+
+            anchors = new HashSet<TrustAnchor>();
+            anchors.add(new TrustAnchor(caCert, null));
+
+            params = new PKIXParameters(anchors);
+            params.setRevocationEnabled(false);
+
+            /* Fixed date inside the chain validity window (2027-01-01
+             * UTC), keeps the test independent of wall clock and timezone */
+            params.setDate(new Date(1798761600000L));
+
+            List<Certificate> certList = new ArrayList<Certificate>();
+            certList.add(eeCert);
+            path = cf.generateCertPath(certList);
+
+            validator = CertPathValidator.getInstance("PKIX", "wolfJCE");
+
+            /* JDK factory default form: SHA1 disabled only for TLS server
+             * chains anchored to a JDK-shipped CA and for signed JARs,
+             * neither of which applies here. Validation must succeed. */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "MD2, MD5, SHA1 jdkCA & usage TLSServer, " +
+                "RSA keySize < 1024, DSA keySize < 1024, " +
+                "EC keySize < 224, include jdk.disabled.namedCurves, " +
+                "SHA1 usage SignedJAR & denyAfter 2019-01-01");
+
+            assertNotNull("SHA1 chain should validate under usage-" +
+                "qualified disabled entries",
+                validator.validate(path, params));
+
+            /* A bare SHA1 entry must still reject the chain */
+            Security.setProperty("jdk.certpath.disabledAlgorithms", "SHA1");
+
+            try {
+                validator.validate(path, params);
+                fail("Expected CertPathValidatorException for bare " +
+                     "SHA1 disabled algorithm");
+            } catch (CertPathValidatorException cpve) {
+                assertEquals("Expected BasicReason.ALGORITHM_CONSTRAINED",
+                    BasicReason.ALGORITHM_CONSTRAINED, cpve.getReason());
+            }
+
+        } finally {
+            /* Restore original security property */
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            }
+            else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
     @Test
     public void testAlgorithmConstraintsRejectsRSA() throws Exception {
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaKeyFactoryTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.TestRule;
 
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
 import java.security.PrivateKey;
@@ -41,6 +42,7 @@ import java.security.spec.InvalidKeySpecException;
 
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.FeatureDetect;
+import com.wolfssl.wolfcrypt.SlhDsa;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
 /**
@@ -163,20 +165,38 @@ public class WolfCryptSlhDsaKeyFactoryTest {
 
         KeyFactory.getInstance("SLH-DSA", "wolfJCE");
 
-        for (String n : PARAM_NAMES) {
-            KeyFactory.getInstance(n, "wolfJCE");
-        }
+        /* Per-set services and OID aliases (.20 - .31) are registered
+         * only for parameter sets compiled into native wolfSSL */
+        for (int i = 0; i < PARAM_NAMES.length; i++) {
+            String oid = "2.16.840.1.101.3.4.3." + (20 + i);
 
-        /* OID aliases .20 - .31 */
-        for (int i = 0; i < 12; i++) {
-            KeyFactory.getInstance(
-                "2.16.840.1.101.3.4.3." + (20 + i), "wolfJCE");
+            if (FeatureDetect.SlhDsaParamEnabled(PARAM_IDS[i])) {
+                KeyFactory.getInstance(PARAM_NAMES[i], "wolfJCE");
+                KeyFactory.getInstance(oid, "wolfJCE");
+            }
+            else {
+                for (String alg : new String[] { PARAM_NAMES[i], oid }) {
+                    try {
+                        KeyFactory.getInstance(alg, "wolfJCE");
+                        fail(alg + " not compiled into native wolfSSL, " +
+                            "should not be registered");
+                    } catch (NoSuchAlgorithmException e) {
+                        /* expected */
+                    }
+                }
+            }
         }
     }
 
     @Test
     public void perSetFactoryRejectsMismatchedKey() throws Exception {
         assumeReady();
+
+        /* Needs a parameter set different from kp (SLH-DSA-SHA2-128f)
+         * that is compiled into native wolfSSL, its KeyFactory service
+         * is not registered otherwise */
+        Assume.assumeTrue("SLH-DSA-SHAKE-128s not compiled in",
+            FeatureDetect.SlhDsaParamEnabled(SlhDsa.SLH_DSA_SHAKE_128S));
 
         /* A parameter-set-locked KeyFactory must reject keys of a
          * different set. kp is SLH-DSA-SHA2-128f. */
@@ -274,6 +294,16 @@ public class WolfCryptSlhDsaKeyFactoryTest {
         "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f",
         "SLH-DSA-SHAKE-192s", "SLH-DSA-SHAKE-192f",
         "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"
+    };
+
+    /* Parameter set IDs, same order as PARAM_NAMES */
+    private static final int[] PARAM_IDS = {
+        SlhDsa.SLH_DSA_SHA2_128S,  SlhDsa.SLH_DSA_SHA2_128F,
+        SlhDsa.SLH_DSA_SHA2_192S,  SlhDsa.SLH_DSA_SHA2_192F,
+        SlhDsa.SLH_DSA_SHA2_256S,  SlhDsa.SLH_DSA_SHA2_256F,
+        SlhDsa.SLH_DSA_SHAKE_128S, SlhDsa.SLH_DSA_SHAKE_128F,
+        SlhDsa.SLH_DSA_SHAKE_192S, SlhDsa.SLH_DSA_SHAKE_192F,
+        SlhDsa.SLH_DSA_SHAKE_256S, SlhDsa.SLH_DSA_SHAKE_256F
     };
 
     /* DER TLV with a definite length (content up to 0xFFFF bytes). */

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaKeyPairGeneratorTest.java
@@ -32,6 +32,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 
@@ -54,6 +55,16 @@ public class WolfCryptSlhDsaKeyPairGeneratorTest {
         "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f",
         "SLH-DSA-SHAKE-192s", "SLH-DSA-SHAKE-192f",
         "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"
+    };
+
+    /* Parameter set IDs, same order as PARAM_NAMES */
+    private static final int[] PARAM_IDS = {
+        SlhDsa.SLH_DSA_SHA2_128S,  SlhDsa.SLH_DSA_SHA2_128F,
+        SlhDsa.SLH_DSA_SHA2_192S,  SlhDsa.SLH_DSA_SHA2_192F,
+        SlhDsa.SLH_DSA_SHA2_256S,  SlhDsa.SLH_DSA_SHA2_256F,
+        SlhDsa.SLH_DSA_SHAKE_128S, SlhDsa.SLH_DSA_SHAKE_128F,
+        SlhDsa.SLH_DSA_SHAKE_192S, SlhDsa.SLH_DSA_SHAKE_192F,
+        SlhDsa.SLH_DSA_SHAKE_256S, SlhDsa.SLH_DSA_SHAKE_256F
     };
 
     /* Fast-signing sets used for the keygen round trips. */
@@ -101,15 +112,32 @@ public class WolfCryptSlhDsaKeyPairGeneratorTest {
     public void getInstanceForAllNames() throws Exception {
         assumeEnabled();
 
-        KeyPairGenerator.getInstance("SLH-DSA", "wolfJCE");
-        for (String n : PARAM_NAMES) {
-            KeyPairGenerator.getInstance(n, "wolfJCE");
+        /* Umbrella generator defaults to SHA2-128f, only registered when
+         * that parameter set is compiled into native wolfSSL */
+        if (FeatureDetect.SlhDsaParamEnabled(SlhDsa.SLH_DSA_SHA2_128F)) {
+            KeyPairGenerator.getInstance("SLH-DSA", "wolfJCE");
         }
 
-        /* OID aliases .20 - .31 */
-        for (int i = 0; i < 12; i++) {
-            KeyPairGenerator.getInstance(
-                "2.16.840.1.101.3.4.3." + (20 + i), "wolfJCE");
+        /* Per-set services and OID aliases (.20 - .31) are registered
+         * only for parameter sets compiled into native wolfSSL */
+        for (int i = 0; i < PARAM_NAMES.length; i++) {
+            String oid = "2.16.840.1.101.3.4.3." + (20 + i);
+
+            if (FeatureDetect.SlhDsaParamEnabled(PARAM_IDS[i])) {
+                KeyPairGenerator.getInstance(PARAM_NAMES[i], "wolfJCE");
+                KeyPairGenerator.getInstance(oid, "wolfJCE");
+            }
+            else {
+                for (String alg : new String[] { PARAM_NAMES[i], oid }) {
+                    try {
+                        KeyPairGenerator.getInstance(alg, "wolfJCE");
+                        fail(alg + " not compiled into native wolfSSL, " +
+                            "should not be registered");
+                    } catch (NoSuchAlgorithmException e) {
+                        /* expected */
+                    }
+                }
+            }
         }
     }
 
@@ -151,6 +179,11 @@ public class WolfCryptSlhDsaKeyPairGeneratorTest {
     @Test
     public void initializeWithIntKeySizeRejected() throws Exception {
         assumeEnabled();
+
+        /* Umbrella generator is only registered when its SHA2-128f
+         * default parameter set is compiled into native wolfSSL */
+        Assume.assumeTrue("SLH-DSA-SHA2-128f not compiled in",
+            FeatureDetect.SlhDsaParamEnabled(SlhDsa.SLH_DSA_SHA2_128F));
 
         KeyPairGenerator kpg =
             KeyPairGenerator.getInstance("SLH-DSA", "wolfJCE");

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaSignatureTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSlhDsaSignatureTest.java
@@ -38,10 +38,12 @@ import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.provider.jce.WolfCryptContextParameterSpec;
 import com.wolfssl.wolfcrypt.FeatureDetect;
+import com.wolfssl.wolfcrypt.SlhDsa;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
 /**
@@ -56,6 +58,16 @@ public class WolfCryptSlhDsaSignatureTest {
         "SLH-DSA-SHAKE-128s", "SLH-DSA-SHAKE-128f",
         "SLH-DSA-SHAKE-192s", "SLH-DSA-SHAKE-192f",
         "SLH-DSA-SHAKE-256s", "SLH-DSA-SHAKE-256f"
+    };
+
+    /* Parameter set IDs, same order as PARAM_NAMES */
+    private static final int[] PARAM_IDS = {
+        SlhDsa.SLH_DSA_SHA2_128S,  SlhDsa.SLH_DSA_SHA2_128F,
+        SlhDsa.SLH_DSA_SHA2_192S,  SlhDsa.SLH_DSA_SHA2_192F,
+        SlhDsa.SLH_DSA_SHA2_256S,  SlhDsa.SLH_DSA_SHA2_256F,
+        SlhDsa.SLH_DSA_SHAKE_128S, SlhDsa.SLH_DSA_SHAKE_128F,
+        SlhDsa.SLH_DSA_SHAKE_192S, SlhDsa.SLH_DSA_SHAKE_192F,
+        SlhDsa.SLH_DSA_SHAKE_256S, SlhDsa.SLH_DSA_SHAKE_256F
     };
 
     /* Fast-signing sets for end-to-end round trips. */
@@ -125,13 +137,26 @@ public class WolfCryptSlhDsaSignatureTest {
 
         Signature.getInstance("SLH-DSA", "wolfJCE");
 
-        for (String n : PARAM_NAMES) {
-            Signature.getInstance(n, "wolfJCE");
-        }
+        /* Per-set services and OID aliases (.20 - .31) are registered
+         * only for parameter sets compiled into native wolfSSL */
+        for (int i = 0; i < PARAM_NAMES.length; i++) {
+            String oid = "2.16.840.1.101.3.4.3." + (20 + i);
 
-        for (int i = 0; i < 12; i++) {
-            Signature.getInstance(
-                "2.16.840.1.101.3.4.3." + (20 + i), "wolfJCE");
+            if (FeatureDetect.SlhDsaParamEnabled(PARAM_IDS[i])) {
+                Signature.getInstance(PARAM_NAMES[i], "wolfJCE");
+                Signature.getInstance(oid, "wolfJCE");
+            }
+            else {
+                for (String alg : new String[] { PARAM_NAMES[i], oid }) {
+                    try {
+                        Signature.getInstance(alg, "wolfJCE");
+                        fail(alg + " not compiled into native wolfSSL, " +
+                            "should not be registered");
+                    } catch (NoSuchAlgorithmException e) {
+                        /* expected */
+                    }
+                }
+            }
         }
     }
 
@@ -344,14 +369,27 @@ public class WolfCryptSlhDsaSignatureTest {
 
         Signature.getInstance("HASH-SLH-DSA", "wolfJCE");
 
-        for (String n : PREHASH_NAMES) {
-            Signature.getInstance(n, "wolfJCE");
-        }
-
-        /* OID aliases .35 - .46, same order as PREHASH_NAMES */
+        /* Pre-hash services and OID aliases (.35 - .46, same order as
+         * PREHASH_NAMES) are registered only for parameter sets compiled
+         * into native wolfSSL */
         for (int i = 0; i < PREHASH_NAMES.length; i++) {
-            Signature.getInstance(
-                "2.16.840.1.101.3.4.3." + (35 + i), "wolfJCE");
+            String oid = "2.16.840.1.101.3.4.3." + (35 + i);
+
+            if (FeatureDetect.SlhDsaParamEnabled(PARAM_IDS[i])) {
+                Signature.getInstance(PREHASH_NAMES[i], "wolfJCE");
+                Signature.getInstance(oid, "wolfJCE");
+            }
+            else {
+                for (String alg : new String[] { PREHASH_NAMES[i], oid }) {
+                    try {
+                        Signature.getInstance(alg, "wolfJCE");
+                        fail(alg + " not compiled into native wolfSSL, " +
+                            "should not be registered");
+                    } catch (NoSuchAlgorithmException e) {
+                        /* expected */
+                    }
+                }
+            }
         }
     }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
@@ -36,12 +36,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.File;
+import java.math.BigInteger;
 import java.security.Security;
 import java.util.Arrays;
+import java.util.Locale;
 import java.security.Provider;
 import java.security.KeyStore;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import javax.crypto.spec.DHParameterSpec;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.provider.jce.WolfCryptUtil;
+import com.wolfssl.provider.jce.WolfCryptECParameterSpec;
 import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
@@ -514,6 +523,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -539,6 +550,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -564,6 +577,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -607,6 +622,511 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsAlgorithmDisabledUsageQualifiers() {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+
+        try {
+            /* JDK factory default: SHA1 disabled only for TLS server chains
+             * anchored to a JDK-shipped CA and for signed JARs, neither of
+             * which applies to CertPath validation */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "MD2, MD5, SHA1 jdkCA & usage TLSServer, " +
+                "RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, " +
+                "include jdk.disabled.namedCurves, " +
+                "SHA1 usage SignedJAR & denyAfter 2019-01-01");
+
+            assertFalse("SHA1withRSA must not be disabled by usage entries",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+            assertFalse("SHA1withECDSA must not be disabled by usage entries",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withECDSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* The generic variant has no CertPath context and must treat
+             * usage-scoped entries as active (fail closed) */
+            assertTrue("SHA1withRSA should be disabled outside CertPath",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Bare entries in the same property still apply */
+            assertTrue("MD5withRSA should be disabled (bare MD5)",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "MD5withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* TLSClient usage can never apply to CertPath validation */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 usage TLSServer TLSClient");
+            assertFalse("TLSServer/TLSClient usage entry must not apply",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Unrecognized usage context must fail closed */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 usage FutureContext");
+            assertTrue("Unrecognized usage context should fail closed",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Mixed recognized/unrecognized usage contexts fail closed */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 usage TLSServer FutureContext");
+            assertTrue("Partially recognized usage should fail closed",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Unrecognized non-usage qualifier must fail closed */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 someNewQualifier 42");
+            assertTrue("Unrecognized qualifier should fail closed",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* jdkCA alone cannot be evaluated here, fail closed */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 jdkCA");
+            assertTrue("jdkCA-only qualifier should fail closed",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* denyAfter alone cannot be evaluated here, fail closed */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA1 denyAfter 2019-01-01");
+            assertTrue("denyAfter-only qualifier should fail closed",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "SHA1withRSA", "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsAlgorithmDisabledPQFamilyNames() {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+
+        try {
+            /* Family entry disables all of its parameter sets */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "ML-DSA");
+            assertTrue("ML-DSA should be disabled",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "ML-DSA", "jdk.certpath.disabledAlgorithms"));
+            assertTrue("ML-DSA-65 should be disabled by family entry",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "ML-DSA-65", "jdk.certpath.disabledAlgorithms"));
+            assertTrue("ML-DSA-87 should be disabled for CertPath too",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "ML-DSA-87", "jdk.certpath.disabledAlgorithms"));
+
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SLH-DSA");
+            assertTrue("SLH-DSA-SHA2-128s should be disabled by family",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "SLH-DSA-SHA2-128s", "jdk.certpath.disabledAlgorithms"));
+
+            /* Parameter set entry disables only that set, not the family
+             * or other sets */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "ML-DSA-44");
+            assertTrue("ML-DSA-44 should be disabled",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "ML-DSA-44", "jdk.certpath.disabledAlgorithms"));
+            assertFalse("ML-DSA-65 should not be disabled by ML-DSA-44",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "ML-DSA-65", "jdk.certpath.disabledAlgorithms"));
+            assertFalse("ML-DSA family should not be disabled by ML-DSA-44",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "ML-DSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Prefix matching is scoped to PQ families only */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "SHA3");
+            assertFalse("SHA3 entry should not disable SHA3-256",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "SHA3-256", "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsKeyAllowedPQKeys() throws Exception {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+        PublicKey mlDsaPub = null;
+        PublicKey slhDsaPub = null;
+
+        try {
+            mlDsaPub = KeyPairGenerator.getInstance("ML-DSA-65", "wolfJCE")
+                .generateKeyPair().getPublic();
+        } catch (NoSuchAlgorithmException e) {
+            /* ML-DSA-65 not compiled into native wolfSSL */
+        }
+
+        try {
+            slhDsaPub = KeyPairGenerator.getInstance(
+                "SLH-DSA-SHA2-128s", "wolfJCE")
+                .generateKeyPair().getPublic();
+        } catch (NoSuchAlgorithmException e) {
+            /* SLH-DSA-SHA2-128s not compiled into native wolfSSL */
+        }
+
+        if (mlDsaPub == null && slhDsaPub == null) {
+            /* skip, no PQ support in native library */
+            return;
+        }
+
+        try {
+            if (mlDsaPub != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "MD2");
+                assertTrue("ML-DSA-65 key should be allowed",
+                    WolfCryptUtil.isKeyAllowed(mlDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "ML-DSA");
+                assertFalse("family entry should block ML-DSA key",
+                    WolfCryptUtil.isKeyAllowed(mlDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+                assertFalse("family entry should block for CertPath too",
+                    WolfCryptUtil.isKeyAllowedForCertPath(mlDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "ML-DSA-65");
+                assertFalse("matching parameter set entry should block key",
+                    WolfCryptUtil.isKeyAllowed(mlDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "ML-DSA-44");
+                assertTrue("different parameter set should not block key",
+                    WolfCryptUtil.isKeyAllowed(mlDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+            }
+
+            if (slhDsaPub != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "SLH-DSA");
+                assertFalse("family entry should block SLH-DSA key",
+                    WolfCryptUtil.isKeyAllowed(slhDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "SLH-DSA-SHA2-128s");
+                assertFalse("matching parameter set entry should block key",
+                    WolfCryptUtil.isKeyAllowed(slhDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "SLH-DSA-SHAKE-128s");
+                assertTrue("different parameter set should not block key",
+                    WolfCryptUtil.isKeyAllowed(slhDsaPub,
+                        "jdk.certpath.disabledAlgorithms"));
+            }
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsKeyAllowedDHKeySize() throws Exception {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+        PublicKey dhPub = null;
+
+        /* RFC 3526 group 14, 2048-bit MODP prime, generator 2 */
+        final BigInteger p = new BigInteger(
+            "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
+            "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
+            "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
+            "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED" +
+            "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D" +
+            "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F" +
+            "83655D23DCA3AD961C62F356208552BB9ED529077096966D" +
+            "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B" +
+            "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9" +
+            "DE2BCBF6955817183995497CEA956AE515D2261898FA0510" +
+            "15728E5A8AACAA68FFFFFFFFFFFFFFFF", 16);
+        final BigInteger g = BigInteger.valueOf(2);
+
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("DH", "wolfJCE");
+            kpg.initialize(new DHParameterSpec(p, g));
+            dhPub = kpg.generateKeyPair().getPublic();
+        } catch (Exception e) {
+            /* skip, DH not available in native library */
+            return;
+        }
+
+        try {
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "DH keySize < 2048");
+            assertTrue("2048-bit DH key should be allowed",
+                WolfCryptUtil.isKeyAllowed(dhPub,
+                    "jdk.certpath.disabledAlgorithms"));
+
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "DH keySize < 3072");
+            assertFalse("2048-bit DH key should be rejected",
+                WolfCryptUtil.isKeyAllowed(dhPub,
+                    "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsAlgorithmDisabledIncludeExpansion() {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+        String origCurves = Security.getProperty(
+            "jdk.disabled.namedCurves");
+
+        try {
+            Security.setProperty("jdk.disabled.namedCurves",
+                "secp112r1, sect113r1");
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "MD2, include jdk.disabled.namedCurves");
+
+            assertTrue("Included curve entry should be disabled",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "secp112r1", "jdk.certpath.disabledAlgorithms"));
+            assertTrue("Included entries apply for CertPath too",
+                WolfCryptUtil.isAlgorithmDisabledForCertPath(
+                    "sect113r1", "jdk.certpath.disabledAlgorithms"));
+            assertFalse("Curve not in included list should be allowed",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "secp256r1", "jdk.certpath.disabledAlgorithms"));
+            assertTrue("Entries next to the include still apply",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "MD2", "jdk.certpath.disabledAlgorithms"));
+
+            /* Include cycles terminate, entries still found */
+            Security.setProperty("jdk.disabled.namedCurves",
+                "sect113r1, include jdk.certpath.disabledAlgorithms");
+            assertTrue("Entries still found with include cycle",
+                WolfCryptUtil.isAlgorithmDisabled(
+                    "sect113r1", "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+            if (origCurves != null) {
+                Security.setProperty("jdk.disabled.namedCurves",
+                    origCurves);
+            } else {
+                Security.setProperty("jdk.disabled.namedCurves", "");
+            }
+        }
+    }
+
+    @Test
+    public void testGetDisabledAlgorithmsKeySizeLimitNameMatch() {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+
+        try {
+            /* Entries match on leading algorithm name, "ECDH keySize"
+             * must not set the "DH" limit */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "ECDH keySize < 4096");
+            assertEquals("ECDH entry must not set DH key size limit", 0,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "DH", "jdk.certpath.disabledAlgorithms"));
+            assertEquals("ECDH entry should set ECDH key size limit", 4096,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "ECDH", "jdk.certpath.disabledAlgorithms"));
+
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize < 1024, EC keySize < 224");
+            assertEquals(1024,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "RSA", "jdk.certpath.disabledAlgorithms"));
+            assertEquals(224,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "EC", "jdk.certpath.disabledAlgorithms"));
+
+            /* "<=" operator disables through N, minimum allowed N + 1 */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize <= 1023");
+            assertEquals("keySize <= N should yield minimum of N + 1", 1024,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "RSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Unsupported operators are ignored */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize >= 8192");
+            assertEquals("Unsupported operator should be ignored", 0,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "RSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* Strictest of multiple matching entries wins */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize < 2048, RSA keySize < 1024");
+            assertEquals("Strictest of multiple entries should win", 2048,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "RSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* keySize matching is case-insensitive, consistent with the
+             * keySize entry skip in the name check */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA KEYSIZE < 1024");
+            assertEquals("Uppercase KEYSIZE entry should set limit", 1024,
+                WolfCryptUtil.getDisabledAlgorithmsKeySizeLimit(
+                    "RSA", "jdk.certpath.disabledAlgorithms"));
+
+            /* keySize entry skip in the name check must not depend on the
+             * default locale. Turkish lowercases 'I' to dotless 'ı', which
+             * broke locale-sensitive toLowerCase() matching and caused
+             * "RSA KEYSIZE < 1024" to blanket-disable RSA. */
+            Locale origLocale = Locale.getDefault();
+            try {
+                Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    "RSA KEYSIZE < 1024");
+                assertFalse("keySize entry must be skipped in any locale",
+                    WolfCryptUtil.isAlgorithmDisabled(
+                        "SHA256withRSA", "jdk.certpath.disabledAlgorithms"));
+            } finally {
+                Locale.setDefault(origLocale);
+            }
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsKeyAllowedKeySizeUsageQualifiers() throws Exception {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+        PublicKey rsaPub = null;
+
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("RSA", "wolfJCE");
+            kpg.initialize(2048);
+            rsaPub = kpg.generateKeyPair().getPublic();
+        } catch (Exception e) {
+            /* skip, RSA key generation not available */
+            return;
+        }
+
+        try {
+            /* Usage-scoped keySize entry never applies to CertPath
+             * validation, but stays active (fail closed) for the
+             * generic check */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize < 3072 & usage TLSServer");
+            assertTrue("Usage-scoped keySize entry must not apply " +
+                "to CertPath",
+                WolfCryptUtil.isKeyAllowedForCertPath(rsaPub,
+                    "jdk.certpath.disabledAlgorithms"));
+            assertFalse("Generic check treats usage keySize as active",
+                WolfCryptUtil.isKeyAllowed(rsaPub,
+                    "jdk.certpath.disabledAlgorithms"));
+
+            /* Unqualified keySize entry applies to both */
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "RSA keySize < 3072");
+            assertFalse("Unqualified keySize entry applies to CertPath",
+                WolfCryptUtil.isKeyAllowedForCertPath(rsaPub,
+                    "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+            }
+        }
+    }
+
+    @Test
+    public void testIsKeyAllowedECNamedCurve() throws Exception {
+
+        String origProperty = Security.getProperty(
+            "jdk.certpath.disabledAlgorithms");
+        PublicKey ecPub = null;
+
+        try {
+            KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("EC", "wolfJCE");
+            kpg.initialize(new ECGenParameterSpec("secp256r1"));
+            ecPub = kpg.generateKeyPair().getPublic();
+        } catch (Exception e) {
+            /* skip, EC key generation not available */
+            return;
+        }
+
+        /* Curve name check only applies when params carry a name */
+        if (!(((ECPublicKey)ecPub).getParams()
+                instanceof WolfCryptECParameterSpec)) {
+            return;
+        }
+
+        try {
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "secp256r1");
+            assertFalse("Key on disabled named curve should be rejected",
+                WolfCryptUtil.isKeyAllowed(ecPub,
+                    "jdk.certpath.disabledAlgorithms"));
+
+            Security.setProperty("jdk.certpath.disabledAlgorithms",
+                "secp112r1, sect113r1");
+            assertTrue("Key on non-disabled curve should be allowed",
+                WolfCryptUtil.isKeyAllowed(ecPub,
+                    "jdk.certpath.disabledAlgorithms"));
+        } finally {
+            if (origProperty != null) {
+                Security.setProperty("jdk.certpath.disabledAlgorithms",
+                    origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -631,6 +1151,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -665,6 +1187,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -695,6 +1219,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -724,6 +1250,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -743,6 +1271,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }
@@ -772,6 +1302,8 @@ public class WolfCryptUtilTest {
             if (origProperty != null) {
                 Security.setProperty("jdk.certpath.disabledAlgorithms",
                     origProperty);
+            } else {
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
             }
         }
     }


### PR DESCRIPTION
This PR fixes wolfJCE behavioral divergences from SunJCE/OpenJDK found while running the SunJCE tests against wolfJCE.

  ## Changes

  - **`jdk.certpath.disabledAlgorithms` handling** (`WolfCryptUtil`): usage-scoped entries (`SHA1 jdkCA & usage TLSServer`) no longer act as blanket disables during CertPath validation, matching JDK behavior. Other qualifiers remain fail-closed. Adds `isAlgorithmDisabledForCertPath()` / `isKeyAllowedForCertPath()`, `include` directive expansion, EC named-curve checks, and hardened keySize parsing.
  - **AES-GCM key+IV reuse** (`WolfCryptCipher`): matches SunJCE semantics. Rejected at init time, re-init required between encryptions, key-only init resets tracking. F-5029 protection preserved. Tracks a key digest, not key bytes.
  - **PQ/DH key constraints** (`WolfCryptUtil`): `isKeyAllowed()` checks ML-DSA / SLH-DSA family and parameter set names, and enforces `DH keySize < N`.
  - **PQC registration gating** (`WolfCryptProvider`): services for ML-DSA levels / SLH-DSA parameter sets not compiled into native wolfSSL are un-registered, so `getInstance()` fails cleanly on restricted builds (ex: `--enable-slhdsa=128f,sha2-128f`).
  - **`WolfSSLCertManager` class init** (JNI): loads the native library in a static block before its static native call, fixing `UnsatisfiedLinkError`.

  ## SunJCE tests fixed:

  - `security/Provider/certpath/PKIXCertPathValidator/Validity.java`
  - `security/cert/CertPathValidator/nameConstraints/NameConstraintsWithoutRID.java`
  - `crypto/provider/Cipher/AES/TestCopySafe.java`