### PR TITLE
Fix wolfJCE compatibility with current wolfSSL FIPS Ready

### DIFF
--- a/jni/jni_aesgcm.c
+++ b/jni/jni_aesgcm.c
@@ -68,7 +68,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesInit
     int ret = 0;
     Aes* aes = NULL;
     (void)this;
-    
+
     aes = (Aes*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
         /* getNativeStruct may throw exception, if so stop and return */
@@ -170,6 +170,11 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesGcmEncrypt
     byte* out = NULL;
     jbyteArray outArr = NULL;
 
+#if defined(HAVE_FIPS) && FIPS_VERSION_GT(5,0) && \
+    !defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED)
+    byte ivOut[GCM_NONCE_MAX_SZ];
+#endif
+
     aes = (Aes*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
         /* getNativeStruct may throw exception, if so stop and return */
@@ -212,8 +217,26 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesGcmEncrypt
     }
 
     if (ret == 0) {
+#if defined(HAVE_FIPS) && FIPS_VERSION_GT(5,0) && \
+    !defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED)
+        /* wolfSSL 5.9.2+ FIPS builds (FIPS Ready and module WCv6.0.0+)
+         * no longer export one-shot wc_AesGcmEncrypt() with an external
+         * IV, unless built with WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED. */
+        if (ivSz > GCM_NONCE_MAX_SZ) {
+            /* IV larger than ivOut, and not supported by FIPS */
+            ret = BAD_FUNC_ARG;
+        }
+        else {
+            ret = wc_AesGcmSetExtIV(aes, iv, ivSz);
+            if (ret == 0) {
+                ret = wc_AesGcmEncrypt_ex(aes, out, in, inLen, ivOut, ivSz,
+                    authTag, authTagSz, authIn, authInSz);
+            }
+        }
+#else
         ret = wc_AesGcmEncrypt(aes, out, in, inLen, iv, ivSz,
             authTag, authTagSz, authIn, authInSz);
+#endif
     }
 
     /* Create new jbyteArray to return output */

--- a/jni/jni_ed25519.c
+++ b/jni/jni_ed25519.c
@@ -27,6 +27,9 @@
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/version.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 #include <wolfssl/wolfcrypt/ed25519.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/memory.h>
@@ -321,7 +324,9 @@ Java_com_wolfssl_wolfcrypt_Ed25519_wc_1ed25519_1export_1private(
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_ed25519_export_private(ed25519, output, &outputSz);
+    PRIVATE_KEY_LOCK();
 
     if (ret == 0) {
         result = (*env)->NewByteArray(env, outputSz);
@@ -389,7 +394,9 @@ Java_com_wolfssl_wolfcrypt_Ed25519_wc_1ed25519_1export_1private_1only(
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_ed25519_export_private_only(ed25519, output, &outputSz);
+    PRIVATE_KEY_LOCK();
 
     if (ret == 0) {
         result = (*env)->NewByteArray(env, outputSz);

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -1021,6 +1021,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmEncrypt_1fips__
     byte* authTag = NULL;
     byte* authIn  = NULL;
 
+#if FIPS_VERSION_GT(5,0) && \
+    !defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED)
+    byte ivOut[GCM_NONCE_MAX_SZ];
+#endif
+
     aes = (Aes*) getNativeStruct(env, aes_object);
     if ((*env)->ExceptionOccurred(env)) {
         /* prevent additional JNI calls with pending exception */
@@ -1039,9 +1044,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmEncrypt_1fips__
     }
 
     #if FIPS_VERSION_GT(5,0)
+        #ifdef WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED
         ret = wc_AesGcmEncrypt_fips(aes, out, in, (word32)size, iv,
             (word32) ivSz, authTag, (word32)authTagSz, authIn,
             (word32)authInSz);
+        #else
+        /* wolfSSL 5.9.2+ FIPS builds (FIPS Ready and module WCv6.0.0+)
+         * no longer export one-shot wc_AesGcmEncrypt_fips() with an external
+         * IV, unless built with WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED. */
+        if (ivSz < 0 || ivSz > GCM_NONCE_MAX_SZ) {
+            /* IV larger than ivOut, and not supported by FIPS */
+            ret = BAD_FUNC_ARG;
+        }
+        else {
+            ret = wc_AesGcmSetExtIV_fips(aes, iv, (word32)ivSz);
+            if (ret == 0) {
+                /* Unsuffixed name, FIPS v7 has no
+                 * wc_AesGcmEncrypt_ex_fips(), newer FIPS maps this to
+                 * the _fips variant in fips.h */
+                ret = wc_AesGcmEncrypt_ex(aes, out, in, (word32)size,
+                    ivOut, (word32)ivSz, authTag, (word32)authTagSz,
+                    authIn, (word32)authInSz);
+            }
+        }
+        #endif
     #else
         ret = AesGcmEncrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
             authTag, (word32)authTagSz, authIn, (word32)authInSz);
@@ -1083,6 +1109,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmEncrypt_1fips__
     byte* authTag = NULL;
     byte* authIn  = NULL;
 
+#if FIPS_VERSION_GT(5,0) && \
+    !defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED)
+    byte ivOut[GCM_NONCE_MAX_SZ];
+#endif
+
     aes = (Aes*) getNativeStruct(env, aes_object);
     if ((*env)->ExceptionOccurred(env)) {
         /* prevent additional JNI calls with pending exception */
@@ -1102,8 +1133,29 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmEncrypt_1fips__
     }
     else {
     #if FIPS_VERSION_GT(5,0)
+        #ifdef WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED
         ret = wc_AesGcmEncrypt_fips(aes, out, in, (word32)size, iv,
             (word32)ivSz, authTag, (word32)authTagSz, authIn, (word32)authInSz);
+        #else
+        /* wolfSSL 5.9.2+ FIPS builds (FIPS Ready and module WCv6.0.0+)
+         * no longer export one-shot wc_AesGcmEncrypt_fips() with an external
+         * IV, unless built with WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED. */
+        if (ivSz < 0 || ivSz > GCM_NONCE_MAX_SZ) {
+            /* IV larger than ivOut, and not supported by FIPS */
+            ret = BAD_FUNC_ARG;
+        }
+        else {
+            ret = wc_AesGcmSetExtIV_fips(aes, iv, (word32)ivSz);
+            if (ret == 0) {
+                /* Unsuffixed name, FIPS v7 has no
+                 * wc_AesGcmEncrypt_ex_fips(), newer FIPS maps this to
+                 * the _fips variant in fips.h */
+                ret = wc_AesGcmEncrypt_ex(aes, out, in, (word32)size,
+                    ivOut, (word32)ivSz, authTag, (word32)authTagSz,
+                    authIn, (word32)authInSz);
+            }
+        }
+        #endif
     #else
         ret = AesGcmEncrypt_fips(aes, out, in, (word32)size, iv, (word32)ivSz,
             authTag, (word32)authTagSz, authIn, (word32)authInSz);

--- a/jni/jni_mldsa.c
+++ b/jni/jni_mldsa.c
@@ -28,6 +28,9 @@
 #endif
 
 #include <wolfssl/version.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 #include <wolfssl/wolfcrypt/types.h>
 
 #if defined(HAVE_DILITHIUM) || defined(WOLFSSL_HAVE_MLDSA)
@@ -686,7 +689,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1dilithium_1exp
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlDsaKey_ExportPrivRaw(key, output, &outputSz);
+    PRIVATE_KEY_LOCK();
     if (ret == 0) {
         result = (*env)->NewByteArray(env, outputSz);
         if (result != NULL) {
@@ -880,7 +885,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1Dilithium_1Key
     }
 
     /* Two-pass: first call with NULL output to get required size. */
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlDsaKey_KeyToDer(key, NULL, 0);
+    PRIVATE_KEY_LOCK();
     if (ret <= 0) {
         throwWolfCryptExceptionFromError(env, ret);
         return NULL;
@@ -895,7 +902,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1Dilithium_1Key
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlDsaKey_KeyToDer(key, output, outputSz);
+    PRIVATE_KEY_LOCK();
     if (ret > 0) {
         result = (*env)->NewByteArray(env, ret);
         if (result != NULL) {
@@ -1138,7 +1147,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1dilithium_1make_1key
         ret = BAD_FUNC_ARG;
     }
     else {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_MlDsaKey_MakeKeyFromSeed(key, seed);
+        PRIVATE_KEY_LOCK();
     }
 
     if (ret != 0) {
@@ -1938,7 +1949,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1Dilithium_1Pri
     }
 
     /* Two-pass: first call with NULL output to get required size. */
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlDsaKey_PrivateKeyToDer(key, NULL, 0);
+    PRIVATE_KEY_LOCK();
     if (ret <= 0) {
         throwWolfCryptExceptionFromError(env, ret);
         return NULL;
@@ -1953,7 +1966,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlDsa_wc_1Dilithium_1Pri
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlDsaKey_PrivateKeyToDer(key, output, outputSz);
+    PRIVATE_KEY_LOCK();
     if (ret > 0) {
         result = (*env)->NewByteArray(env, ret);
         if (result != NULL) {

--- a/jni/jni_mlkem.c
+++ b/jni/jni_mlkem.c
@@ -27,6 +27,9 @@
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/version.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/memory.h>
 #ifdef WOLFSSL_HAVE_MLKEM
@@ -444,7 +447,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlKem_wc_1mlkem_1decapsu
     }
     XMEMSET(output, 0, ssSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlKemKey_Decapsulate(key, output, ct, ctSz);
+    PRIVATE_KEY_LOCK();
 
     if (ret == 0) {
         result = (*env)->NewByteArray(env, ssSz);
@@ -571,7 +576,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_MlKem_wc_1mlkem_1export_
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_MlKemKey_EncodePrivateKey(key, output, outputSz);
+    PRIVATE_KEY_LOCK();
 
     if (ret == 0) {
         result = (*env)->NewByteArray(env, outputSz);

--- a/jni/jni_pwdbased.c
+++ b/jni/jni_pwdbased.c
@@ -27,6 +27,9 @@
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/version.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <com_wolfssl_wolfcrypt_Pwdbased.h>
@@ -67,8 +70,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Pwdbased_wc_1PKCS12_1PBK
         salt = (byte*)(*env)->GetByteArrayElements(env, saltBuf, NULL);
     }
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_PKCS12_PBKDF(outKey, pass, passBufLen, salt, sBufLen,
                           iterations, kLen, typeH, id);
+    PRIVATE_KEY_LOCK();
     if (ret == 0) {
         result = (*env)->NewByteArray(env, kLen);
         if (result != NULL) {
@@ -151,8 +156,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Pwdbased_wc_1PBKDF2
         salt = (byte*)(*env)->GetByteArrayElements(env, saltBuf, NULL);
     }
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_PBKDF2(outKey, pass, passBufLen, salt, sBufLen,
                     iterations, kLen, hashType);
+    PRIVATE_KEY_LOCK();
     if (ret == 0) {
         result = (*env)->NewByteArray(env, kLen);
         if (result != NULL) {

--- a/jni/jni_slhdsa.c
+++ b/jni/jni_slhdsa.c
@@ -28,6 +28,9 @@
 #endif
 
 #include <wolfssl/version.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 #include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_HAVE_SLHDSA
@@ -1236,7 +1239,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_SlhDsa_wc_1SlhDsaKey_1ex
     }
     XMEMSET(output, 0, outputSz);
 
+    PRIVATE_KEY_UNLOCK();
     ret = wc_SlhDsaKey_ExportPrivate(key, output, &outputSz);
+    PRIVATE_KEY_LOCK();
     if (ret == 0) {
         result = (*env)->NewByteArray(env, outputSz);
         if (result != NULL) {

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLCertManager.java
@@ -45,7 +45,7 @@ import java.security.cert.CertificateEncodingException;
  *
  * @author  wolfSSL
  */
-public class WolfSSLCertManager {
+public class WolfSSLCertManager extends WolfObject {
     private boolean active = false;
     private long cmPtr = 0;
 
@@ -55,65 +55,7 @@ public class WolfSSLCertManager {
     /* lock around native WOLFSSL_CERT_MANAGER pointer use */
     private final Object cmLock = new Object();
 
-    /*
-     * Loads JNI library.
-     *
-     * Must run before the static native method call below, which happens
-     * during class initialization. Without this, touching this class
-     * before any other native-backed class throws UnsatisfiedLinkError
-     * from the class initializer and permanently poisons this class in
-     * the JVM.
-     *
-     * The native library is expected to be called "wolfcryptjni", and must
-     * be on the system library search path.
-     *
-     * "wolfcryptjni" links against the wolfSSL native C library ("wolfssl"),
-     * and for Windows compatibility "wolfssl" needs to be explicitly loaded
-     * first here.
-     *
-     * Library loading can be skipped by setting the System property
-     * "wolfssl.skipLibraryLoad" to "true". This allows applications to
-     * load native libraries manually using System.load() before accessing
-     * any wolfSSL classes.
-     */
-    static {
-        int fipsLoaded = 0;
-
-        String skipLoad = System.getProperty("wolfssl.skipLibraryLoad");
-        if (skipLoad != null && skipLoad.equalsIgnoreCase("true")) {
-            /* User indicated they will load native libraries manually */
-        }
-        else {
-            String osName = System.getProperty("os.name");
-            if (osName != null && osName.toLowerCase().contains("win")) {
-                try {
-                    /* Default wolfCrypt FIPS library on Windows is compiled
-                     * as "wolfssl-fips" by Visual Studio solution */
-                    System.loadLibrary("wolfssl-fips");
-                    fipsLoaded = 1;
-                } catch (UnsatisfiedLinkError e) {
-                    /* wolfCrypt FIPS not available */
-                }
-
-                if (fipsLoaded == 0) {
-                    /* FIPS library not loaded, try normal libwolfssl */
-                    System.loadLibrary("wolfssl");
-                }
-            }
-
-            /* Load wolfcryptjni library */
-            System.loadLibrary("wolfcryptjni");
-        }
-
-        /* Run FIPS CAST up front if we are in FIPS mode. Referencing Fips
-         * triggers WolfObject static initialization, which calls native
-         * wolfCrypt init. runAllCast_fips() only runs the CASTs once. */
-        if (Fips.enabled) {
-            Fips.runAllCast_fips();
-        }
-    }
-
-    /** Flag to allow loading certs with date errors */
+    /** Flag to allow loading certs with date errors. */
     public static final int WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY =
         getWOLFSSL_LOAD_FLAG_DATE_ERR_OKAY();
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParameterGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParameterGeneratorTest.java
@@ -46,6 +46,7 @@ import javax.crypto.spec.DHGenParameterSpec;
 import javax.crypto.spec.DHParameterSpec;
 
 import com.wolfssl.wolfcrypt.Fips;
+import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
@@ -79,9 +80,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
 
         AlgorithmParameterGenerator paramGen;
 
-        /* DH should be available */
-        paramGen = AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
-        assertNotNull(paramGen);
+        /* DH should be available, unless not compiled into native wolfSSL */
+        if (FeatureDetect.DhEnabled()) {
+            paramGen = AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
+            assertNotNull(paramGen);
+        }
 
         /* Getting a garbage algorithm should throw an exception */
         try {
@@ -100,6 +103,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     public void testDHParameterGenerationFFDHESizes()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test standard FFDHE sizes: 2048, 3072, 4096, 6144, 8192 */
         int[] ffdheSizes = { 2048, 3072, 4096, 6144, 8192 };
@@ -144,6 +152,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Test standard FFDHE sizes with SecureRandom */
         int[] ffdheSizes = { 2048, 3072, 4096, 6144, 8192 };
 
@@ -186,6 +199,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* In FIPS mode, sizes without a pre-computed FFDHE group must be
          * rejected at init() time, before reaching native
          * wc_DhGenerateParams() */
@@ -216,6 +234,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Non-positive sizes must be rejected at init() time in all
          * modes */
         int[] invalidSizes = { 0, -1, -2048 };
@@ -239,6 +262,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     public void testDHParameterGenerationNonStandardSizes()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test non-standard sizes (requires dynamic generation).
          * Skip in FIPS mode, non-FFDHE sizes are rejected at init()
@@ -292,6 +320,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Test that default size is 2048 bits when no size is specified */
         AlgorithmParameterGenerator paramGen =
             AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
@@ -308,6 +341,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHParameterGenerationWithDHGenParameterSpec()
         throws NoSuchProviderException, NoSuchAlgorithmException, Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test that DHGenParameterSpec is supported and properly sets
          * both prime size and exponent size */
@@ -335,6 +373,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     public void testDHParameterGenerationWithInvalidAlgorithmParameterSpec()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Test that non-DHGenParameterSpec AlgorithmParameterSpec is
          * rejected */
         AlgorithmParameterGenerator paramGen =
@@ -359,6 +402,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHParameterGenerationWithDHGenParameterSpecMultipleSizes()
         throws NoSuchProviderException, NoSuchAlgorithmException, Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test DHGenParameterSpec with various FFDHE sizes and
          * exponent sizes */
@@ -413,6 +461,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     public void testDHParameterGenerationWithDHGenParameterSpecNullRandom()
         throws NoSuchProviderException, NoSuchAlgorithmException, Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Test that DHGenParameterSpec works with null SecureRandom
          * (should use default) */
         AlgorithmParameterGenerator paramGen =
@@ -434,6 +487,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHParameterGenerationWithDHGenParameterSpecInvalidSize()
         throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Unsupported prime sizes in DHGenParameterSpec should be rejected
          * at init() time */
@@ -475,6 +533,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     public void testDHParameterGenerationWithDHGenParameterSpecNullSpec()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Test that null DHGenParameterSpec is rejected */
         AlgorithmParameterGenerator paramGen =
             AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
@@ -492,6 +555,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHParameterGenerationInteropWithSunJCE()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test interoperability with SunJCE provider.
          * Generate parameters with wolfJCE and verify they work with
@@ -531,6 +599,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHParametersFromWolfJCEMatchStandardProvider()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Generate params with both providers and verify format
          * compatibility */
@@ -576,6 +649,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* For FFDHE standard sizes, parameters should be deterministic
          * (same size should produce same p and g) */
         AlgorithmParameterGenerator paramGen1 =
@@ -602,6 +680,11 @@ public class WolfCryptAlgorithmParameterGeneratorTest {
     @Test
     public void testDHGenParameterSpecInteropWithSunJCE()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test that our DHGenParameterSpec behavior matches SunJCE.
          * Both should accept DHGenParameterSpec and generate parameters

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
@@ -47,6 +47,7 @@ import java.security.spec.MGF1ParameterSpec;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 
+import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
@@ -74,9 +75,11 @@ public class WolfCryptAlgorithmParametersTest {
 
         AlgorithmParameters params;
 
-        /* DH should be available */
-        params = AlgorithmParameters.getInstance("DH", "wolfJCE");
-        assertNotNull(params);
+        /* DH should be available, unless not compiled into native wolfSSL */
+        if (FeatureDetect.DhEnabled()) {
+            params = AlgorithmParameters.getInstance("DH", "wolfJCE");
+            assertNotNull(params);
+        }
 
         /* Getting a garbage algorithm should throw an exception */
         try {
@@ -94,6 +97,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersInitWithDHParameterSpec()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Create known DH parameters */
         BigInteger p = new BigInteger(
@@ -130,6 +138,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersInitWithDHParameterSpecIncludingL()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         BigInteger p = new BigInteger(
             "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
             "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
@@ -162,6 +175,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersInitWithInvalidParameterSpec()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -182,6 +200,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersGetParameterSpecWithWrongClass()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         BigInteger p = new BigInteger("123456789");
         BigInteger g = BigInteger.valueOf(2);
@@ -217,6 +240,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersGetParameterSpecWithNull()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         BigInteger p = new BigInteger("123456789");
         BigInteger g = BigInteger.valueOf(2);
         DHParameterSpec spec = new DHParameterSpec(p, g);
@@ -241,6 +269,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersGetParameterSpecBeforeInit()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -259,6 +292,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersEncodingDER()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         BigInteger p = new BigInteger(
             "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
@@ -303,6 +341,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersEncodingWithFormat()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         BigInteger p = new BigInteger("123456789");
         BigInteger g = BigInteger.valueOf(2);
         DHParameterSpec spec = new DHParameterSpec(p, g);
@@ -331,6 +374,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersEncodingUnsupportedFormat()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         BigInteger p = new BigInteger("123456789");
         BigInteger g = BigInteger.valueOf(2);
         DHParameterSpec spec = new DHParameterSpec(p, g);
@@ -353,6 +401,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersEncodingBeforeInit()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -369,6 +422,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersInitWithDERBytes()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Generate parameters to get valid DER encoding */
         AlgorithmParameterGenerator paramGen =
@@ -395,6 +453,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersInitWithDERBytesAndFormat()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         AlgorithmParameterGenerator paramGen =
             AlgorithmParameterGenerator.getInstance("DH", "wolfJCE");
@@ -430,6 +493,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersInitWithInvalidDERBytes()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -449,6 +517,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersInitWithUnsupportedFormat()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -466,6 +539,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersToString()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         BigInteger p = new BigInteger("123456789");
         BigInteger g = BigInteger.valueOf(2);
@@ -486,6 +564,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersToStringBeforeInit()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         AlgorithmParameters params =
             AlgorithmParameters.getInstance("DH", "wolfJCE");
 
@@ -501,6 +584,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersInteropWithSunJCE()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Generate parameters with wolfJCE */
         AlgorithmParameterGenerator wolfParamGen =
@@ -548,6 +636,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersRoundTrip()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test multiple round trips: spec -> params -> encoded ->
          * params -> spec.
@@ -1360,6 +1453,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersDERTruncatedSequence()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* SEQUENCE tag with length larger than data */
         byte[] bad = new byte[] { 0x30, 0x20 };
 
@@ -1376,6 +1474,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersDERBadSequenceTag()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Wrong tag (0x31 = SET instead of 0x30 = SEQUENCE) */
         byte[] bad = new byte[] {
@@ -1398,6 +1501,11 @@ public class WolfCryptAlgorithmParametersTest {
     public void testDHParametersDERBadIntegerLength()
         throws Exception {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* SEQUENCE with p INTEGER length exceeding boundary */
         byte[] bad = new byte[] {
             0x30, 0x06,
@@ -1418,6 +1526,11 @@ public class WolfCryptAlgorithmParametersTest {
     @Test
     public void testDHParametersDERMissingGenerator()
         throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* SEQUENCE with only one INTEGER (missing g) */
         byte[] bad = new byte[] {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -2062,8 +2062,10 @@ public class WolfCryptCipherTest {
 
         for (int i = 0; i < aesGcmVectors.length; i++) {
 
-            /* skip AES-128 vector if not compiled in native library */
-            if ((i == 0) && (!FeatureDetect.Aes128Enabled())) {
+            /* skip AES-128 vector if not compiled in native library, or
+             * if using wolfCrypt FIPS since this vector uses 1-byte IV */
+            if ((i == 0) &&
+                (!FeatureDetect.Aes128Enabled() || Fips.enabled)) {
                 continue;
             }
 
@@ -2168,8 +2170,10 @@ public class WolfCryptCipherTest {
             GCMParameterSpec spec = new GCMParameterSpec(
                 (vTag.length * 8), aesGcmVectors[i].getIV());
 
-            /* skip AES-128 vector if not compiled in native library */
-            if ((i == 0) && (!FeatureDetect.Aes128Enabled())) {
+            /* skip AES-128 vector if not compiled in native library, or
+             * if using wolfCrypt FIPS since this vector uses 1-byte IV */
+            if ((i == 0) &&
+                (!FeatureDetect.Aes128Enabled() || Fips.enabled)) {
                 continue;
             }
 
@@ -2331,7 +2335,8 @@ public class WolfCryptCipherTest {
 
         /* Try to pick a vector based on what is compiled in natively,
          * doesn't matter too much which vector we get */
-        if (FeatureDetect.Aes128Enabled()) {
+        if (FeatureDetect.Aes128Enabled() && !Fips.enabled) {
+            /* skipped when using wolfCrypt FIPS, vector has 1-byte IV */
             vect = aesGcmVectors[0];
         }
         else if (FeatureDetect.Aes192Enabled() && !Fips.enabled) {
@@ -2436,7 +2441,8 @@ public class WolfCryptCipherTest {
 
         /* Try to pick a vector based on what is compiled in natively,
          * doesn't matter too much which vector we get */
-        if (FeatureDetect.Aes128Enabled()) {
+        if (FeatureDetect.Aes128Enabled() && !Fips.enabled) {
+            /* skipped when using wolfCrypt FIPS, vector has 1-byte IV */
             vect = aesGcmVectors[0];
         }
         else if (FeatureDetect.Aes192Enabled() && !Fips.enabled) {
@@ -2536,8 +2542,10 @@ public class WolfCryptCipherTest {
 
         for (int i = 0; i < aesGcmVectors.length; i++) {
 
-            /* skip AES-128 vector if not compiled in native library */
-            if ((i == 0) && (!FeatureDetect.Aes128Enabled())) {
+            /* skip AES-128 vector if not compiled in native library, or
+             * if using wolfCrypt FIPS since this vector uses 1-byte IV */
+            if ((i == 0) &&
+                (!FeatureDetect.Aes128Enabled() || Fips.enabled)) {
                 continue;
             }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -80,6 +80,7 @@ import java.security.spec.ECFieldFp;
 import com.wolfssl.wolfcrypt.Ecc;
 import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.Dh;
+import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
 
@@ -186,6 +187,11 @@ public class WolfCryptKeyAgreementTest {
 
         /* try to get all available options we expect to have */
         for (int i = 0; i < wolfJCEAlgos.length; i++) {
+            if (wolfJCEAlgos[i].equals("DiffieHellman") &&
+                !FeatureDetect.DhEnabled()) {
+                /* skip DH if not compiled in native wolfSSL */
+                continue;
+            }
             KeyAgreement.getInstance(wolfJCEAlgos[i], "wolfJCE");
         }
 
@@ -379,6 +385,11 @@ public class WolfCryptKeyAgreementTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidParameterSpecException, InvalidKeyException,
                InvalidAlgorithmParameterException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* engineDoPhase() must reject small-subgroup and out-of-range peer
          * DH public keys (SP 800-56A) before use. */
@@ -1251,6 +1262,12 @@ public class WolfCryptKeyAgreementTest {
      */
     @Test
     public void testDHKeySerialization() throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         /* Generate DH keypair */
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
         kpg.initialize(2048);

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyPairGeneratorTest.java
@@ -227,8 +227,11 @@ public class WolfCryptKeyPairGeneratorTest {
         assertNotNull(kpg);
         kpg = KeyPairGenerator.getInstance("RSA", "wolfJCE");
         assertNotNull(kpg);
-        kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
-        assertNotNull(kpg);
+        if (FeatureDetect.DhEnabled()) {
+            /* DH is only registered when compiled in native wolfSSL */
+            kpg = KeyPairGenerator.getInstance("DH", "wolfJCE");
+            assertNotNull(kpg);
+        }
         kpg = KeyPairGenerator.getInstance("RSASSA-PSS", "wolfJCE");
         assertNotNull(kpg);
 
@@ -582,6 +585,11 @@ public class WolfCryptKeyPairGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         int testDHKeySizes[] = { 512, 1024, 2048 };
 
         for (int i = 0; i < testDHKeySizes.length; i++) {
@@ -605,6 +613,11 @@ public class WolfCryptKeyPairGeneratorTest {
     public void testKeyPairGeneratorDhInitWithKeySize()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test that DH KeyPairGenerator supports initialize(int) with
          * FFDHE standard key sizes (2048, 3072, 4096, 6144, 8192) */
@@ -662,6 +675,11 @@ public class WolfCryptKeyPairGeneratorTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
 
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
         KeyPairGenerator kpg =
             KeyPairGenerator.getInstance("DH", "wolfJCE");
 
@@ -676,6 +694,11 @@ public class WolfCryptKeyPairGeneratorTest {
     public void testKeyPairGeneratorDhMultipleKeyGen()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                InvalidAlgorithmParameterException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         KeyPairGenerator kpg =
             KeyPairGenerator.getInstance("DH", "wolfJCE");
@@ -695,6 +718,11 @@ public class WolfCryptKeyPairGeneratorTest {
     @Test
     public void testKeyPairGeneratorDhDefaultKeySize()
         throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
 
         /* Test that DH KeyPairGenerator works with default parameters
          * without explicit initialization. This matches SunJCE behavior. */

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMlKemKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMlKemKeyFactoryTest.java
@@ -710,10 +710,15 @@ public class WolfCryptMlKemKeyFactoryTest {
             else {
                 System.setProperty(prop, savedSys);
             }
-            /* Security properties cannot be removed; restore prior value or
-             * neutralize to empty (treated as the default). */
+            /* Security properties cannot be removed, restore prior value
+             * or "expandedKey", which matches the wolfJCE default when
+             * unset and is parseable by all JDK ML-KEM implementations.
+             * Do not restore to empty string, SunJCE ML-KEM on JDK 25+
+             * throws IllegalArgumentException on an empty value. Do not
+             * restore to "seed", some JDK 25 builds cannot parse
+             * seed-form keys from other providers. */
             java.security.Security.setProperty(prop,
-                savedSec == null ? "" : savedSec);
+                savedSec == null ? "expandedKey" : savedSec);
         }
     }
 }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.Map;
+import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
@@ -3021,6 +3023,15 @@ public class WolfSSLKeyStoreTest {
         wksSpi.engineProbe(null);
     }
 
+    /* Get internal KEK cache map via reflection */
+    private static Map<?, ?> getKekCacheMap(WolfSSLKeyStore wks)
+        throws Exception {
+
+        Field field = WolfSSLKeyStore.class.getDeclaredField("kekCache");
+        field.setAccessible(true);
+        return (Map<?, ?>)field.get(wks);
+    }
+
     @Test
     public void testKekCacheDisabledByDefault() throws Exception {
 
@@ -3030,38 +3041,20 @@ public class WolfSSLKeyStoreTest {
         assertTrue("KEK cache should be disabled by default",
             (enabled == null) || !enabled.equalsIgnoreCase("true"));
 
-        /* Create and populate KeyStore */
-        KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-        store.load(null, storePass.toCharArray());
-        store.setKeyEntry("rsaKey", serverKeyRsa, storePass.toCharArray(),
-            new Certificate[] { serverCertRsa });
+        /* Use WolfSSLKeyStore directly to inspect KEK cache */
+        WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+        wksSpi.engineLoad(null, storePass.toCharArray());
+        wksSpi.engineSetKeyEntry("rsaKey", serverKeyRsa,
+            storePass.toCharArray(), new Certificate[] { serverCertRsa });
 
-        /* Warm up the getKey() path once before timing. */
-        store.getKey("rsaKey", storePass.toCharArray());
-
-        /* Time first getKey(). Use nanoTime() (monotonic, high-resolution)
-         * rather than currentTimeMillis() (wall-clock, coarse). */
-        long start = System.nanoTime();
-        Key key1 = store.getKey("rsaKey", storePass.toCharArray());
-        long first = System.nanoTime() - start;
-
-        /* Time second getKey() - should be similar since cache is disabled */
-        start = System.nanoTime();
-        Key key2 = store.getKey("rsaKey", storePass.toCharArray());
-        long second = System.nanoTime() - start;
-
+        Key key1 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
+        Key key2 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
         assertNotNull(key1);
         assertNotNull(key2);
 
-        /* Without a cache both calls re-derive the KEK (PBKDF2), so the second
-         * should not be dramatically faster than the first (within ~30%). */
-        long firstMs = first / 1000000L;
-        if (firstMs > 5) {
-            long secondMs = second / 1000000L;
-            assertTrue("Without cache, times should be similar (first=" +
-                firstMs + "ms, second=" + secondMs + "ms)",
-                second > first * 0.3);
-        }
+        /* Cache stays empty when disabled */
+        assertTrue("KEK cache should remain empty when disabled",
+            getKekCacheMap(wksSpi).isEmpty());
     }
 
     @Test
@@ -3078,30 +3071,28 @@ public class WolfSSLKeyStoreTest {
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
             Security.setProperty("wolfjce.keystore.kekCacheTtlSec", "300");
 
-            /* Create and populate KeyStore */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
-            store.setKeyEntry("rsaKey", serverKeyRsa, storePass.toCharArray(),
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
+            wksSpi.engineSetKeyEntry("rsaKey", serverKeyRsa,
+                storePass.toCharArray(),
                 new Certificate[] { serverCertRsa });
 
-            /* First getKey() - populates cache */
-            long start = System.currentTimeMillis();
-            Key key1 = store.getKey("rsaKey", storePass.toCharArray());
-            long first = System.currentTimeMillis() - start;
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertTrue("KEK cache should start empty", cache.isEmpty());
 
-            /* Second getKey() - should be much faster (cache hit) */
-            start = System.currentTimeMillis();
-            Key key2 = store.getKey("rsaKey", storePass.toCharArray());
-            long second = System.currentTimeMillis() - start;
-
+            /* First getKey() populates cache */
+            Key key1 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
             assertNotNull(key1);
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
+
+            /* Cache hit, no new entry added */
+            Key key2 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
             assertNotNull(key2);
             assertEquals(key1, key2);
-
-            /* Cache hit should be faster. */
-            assertTrue("Cache hit should be faster: " +
-                "first=" + first + "ms, second=" + second + "ms",
-                first > 0 && (first > 50 ? second < first : true));
+            assertEquals("KEK cache should still hold one entry",
+                1, cache.size());
 
         } finally {
             /* Restore original properties */
@@ -3129,33 +3120,31 @@ public class WolfSSLKeyStoreTest {
             /* Enable cache */
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
 
-            /* Create and populate KeyStore with SecretKey */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
 
             KeyGenerator keyGen = KeyGenerator.getInstance("AES");
             keyGen.init(256);
             SecretKey secretKey = keyGen.generateKey();
-            store.setKeyEntry("aesKey", secretKey, storePass.toCharArray(),
-                null);
+            wksSpi.engineSetKeyEntry("aesKey", secretKey,
+                storePass.toCharArray(), null);
 
-            /* First getKey() */
-            long start = System.currentTimeMillis();
-            Key key1 = store.getKey("aesKey", storePass.toCharArray());
-            long first = System.currentTimeMillis() - start;
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertTrue("KEK cache should start empty", cache.isEmpty());
 
-            /* Second getKey() - cache hit */
-            start = System.currentTimeMillis();
-            Key key2 = store.getKey("aesKey", storePass.toCharArray());
-            long second = System.currentTimeMillis() - start;
-
+            /* First getKey() populates cache */
+            Key key1 = wksSpi.engineGetKey("aesKey", storePass.toCharArray());
             assertNotNull(key1);
-            assertNotNull(key2);
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
 
-            /* Cache hit should be faster */
-            assertTrue("SecretKey cache hit should be faster: " +
-                "first=" + first + "ms, second=" + second + "ms",
-                first > 50 ? second < first / 5 : true);
+            /* Cache hit, no new entry added */
+            Key key2 = wksSpi.engineGetKey("aesKey", storePass.toCharArray());
+            assertNotNull(key2);
+            assertEquals(key1, key2);
+            assertEquals("KEK cache should still hold one entry",
+                1, cache.size());
 
         } finally {
             if (origEnabled != null) {
@@ -3178,43 +3167,37 @@ public class WolfSSLKeyStoreTest {
             /* Enable cache */
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
 
-            /* Create KeyStore with two entries */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
-            store.setKeyEntry("rsaKey1", serverKeyRsa, storePass.toCharArray(),
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
+            wksSpi.engineSetKeyEntry("rsaKey1", serverKeyRsa,
+                storePass.toCharArray(),
                 new Certificate[] { serverCertRsa });
-            store.setKeyEntry("eccKey1", serverKeyEcc, storePass.toCharArray(),
-                eccServerChain);
+            wksSpi.engineSetKeyEntry("eccKey1", serverKeyEcc,
+                storePass.toCharArray(), eccServerChain);
 
-            /* Populate cache for both entries */
-            Key key1 = store.getKey("rsaKey1", storePass.toCharArray());
+            /* Populate cache, one KEK per entry */
+            Key key1 = wksSpi.engineGetKey("rsaKey1", storePass.toCharArray());
             assertNotNull(key1);
-            Key key2 = store.getKey("eccKey1", storePass.toCharArray());
+            Key key2 = wksSpi.engineGetKey("eccKey1", storePass.toCharArray());
             assertNotNull(key2);
 
-            /* Verify second call is fast (cache hit) */
-            long start = System.currentTimeMillis();
-            store.getKey("eccKey1", storePass.toCharArray());
-            long cachedTime = System.currentTimeMillis() - start;
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertEquals("KEK cache should hold two entries",
+                2, cache.size());
 
             /* Delete first entry - should clear entire cache */
-            store.deleteEntry("rsaKey1");
+            wksSpi.engineDeleteEntry("rsaKey1");
+            assertFalse(wksSpi.engineContainsAlias("rsaKey1"));
+            assertTrue("KEK cache should be empty after deleteEntry",
+                cache.isEmpty());
 
-            /* Verify first entry is deleted */
-            assertFalse(store.containsAlias("rsaKey1"));
-
-            /* Get second key again - should be slow (cache was cleared) */
-            start = System.currentTimeMillis();
-            Key key2Again = store.getKey("eccKey1", storePass.toCharArray());
-            long uncachedTime = System.currentTimeMillis() - start;
+            /* Second key still retrievable, repopulates cache */
+            Key key2Again = wksSpi.engineGetKey("eccKey1",
+                storePass.toCharArray());
             assertNotNull(key2Again);
-
-            /* Verify it was slower. Use 2x threshold since timing can vary
-             * significantly on CI systems with fast storage. */
-            assertTrue("Cache should have been cleared, but timing suggests " +
-                "it wasn't (cached: " + cachedTime + "ms, uncached: " +
-                uncachedTime + "ms)",
-                uncachedTime > cachedTime * 2);
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
 
         } finally {
             if (origEnabled != null) {
@@ -3238,47 +3221,37 @@ public class WolfSSLKeyStoreTest {
             /* Enable cache */
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
 
-            /* Create KeyStore with two entries */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
-            store.setKeyEntry("rsaKey1", serverKeyRsa, storePass.toCharArray(),
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
+            wksSpi.engineSetKeyEntry("rsaKey1", serverKeyRsa,
+                storePass.toCharArray(),
                 new Certificate[] { serverCertRsa });
-            store.setKeyEntry("eccKey1", serverKeyEcc, storePass.toCharArray(),
-                eccServerChain);
+            wksSpi.engineSetKeyEntry("eccKey1", serverKeyEcc,
+                storePass.toCharArray(), eccServerChain);
 
-            /* Populate cache for both entries */
-            Key key1 = store.getKey("rsaKey1", storePass.toCharArray());
+            /* Populate cache, one KEK per entry */
+            Key key1 = wksSpi.engineGetKey("rsaKey1", storePass.toCharArray());
             assertNotNull(key1);
-            Key key2 = store.getKey("eccKey1", storePass.toCharArray());
+            Key key2 = wksSpi.engineGetKey("eccKey1", storePass.toCharArray());
             assertNotNull(key2);
 
-            /* Verify second call is fast (cache hit) */
-            long start = System.nanoTime();
-            store.getKey("eccKey1", storePass.toCharArray());
-            long cachedNs = System.nanoTime() - start;
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertEquals("KEK cache should hold two entries",
+                2, cache.size());
 
             /* Overwrite first entry - should clear entire cache */
-            store.setKeyEntry("rsaKey1", serverKeyEcc, storePass.toCharArray(),
-                eccServerChain);
+            wksSpi.engineSetKeyEntry("rsaKey1", serverKeyEcc,
+                storePass.toCharArray(), eccServerChain);
+            assertTrue("KEK cache should be empty after setKeyEntry",
+                cache.isEmpty());
 
-            /* Get second key again - should be slow (cache was cleared) */
-            start = System.nanoTime();
-            Key key2Again = store.getKey("eccKey1", storePass.toCharArray());
-            long uncachedNs = System.nanoTime() - start;
+            /* Second key still retrievable, repopulates cache */
+            Key key2Again = wksSpi.engineGetKey("eccKey1",
+                storePass.toCharArray());
             assertNotNull(key2Again);
-
-            /* Only verify timing if cached operation was fast enough to
-             * indicate a real cache hit. On loaded CI systems, even cached
-             * operations can be slow due to system overhead, making timing
-             * comparisons unreliable. */
-            long cachedMs = cachedNs / 1_000_000;
-            long uncachedMs = uncachedNs / 1_000_000;
-            if (cachedMs < 3) {
-                assertTrue("Cache should have been cleared, but timing " +
-                    "suggests it wasn't (cached: " + cachedMs + "ms, " +
-                    "uncached: " + uncachedMs + "ms)",
-                    uncachedMs > cachedMs * 2);
-            }
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
 
         } finally {
             if (origEnabled != null) {
@@ -3301,35 +3274,37 @@ public class WolfSSLKeyStoreTest {
             /* Enable cache */
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
 
-            /* Create first KeyStore and populate cache */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
-            store.setKeyEntry("rsaKey", serverKeyRsa, storePass.toCharArray(),
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
+            wksSpi.engineSetKeyEntry("rsaKey", serverKeyRsa,
+                storePass.toCharArray(),
                 new Certificate[] { serverCertRsa });
 
             /* Populate cache */
-            Key key1 = store.getKey("rsaKey", storePass.toCharArray());
+            Key key1 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
             assertNotNull(key1);
+
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
 
             /* Save to byte array */
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            store.store(baos, storePass.toCharArray());
+            wksSpi.engineStore(baos, storePass.toCharArray());
             byte[] storeData = baos.toByteArray();
 
             /* Load from byte array - should clear cache */
             ByteArrayInputStream bais = new ByteArrayInputStream(storeData);
-            store.load(bais, storePass.toCharArray());
+            wksSpi.engineLoad(bais, storePass.toCharArray());
+            assertTrue("KEK cache should be empty after load",
+                cache.isEmpty());
 
-            /* Get key - first call after load should take PBKDF2 time */
-            long start = System.currentTimeMillis();
-            Key key2 = store.getKey("rsaKey", storePass.toCharArray());
-            long elapsed = System.currentTimeMillis() - start;
-
+            /* Key should still be retrievable, repopulates cache */
+            Key key2 = wksSpi.engineGetKey("rsaKey", storePass.toCharArray());
             assertNotNull(key2);
-            /* After load, should need full PBKDF2 (cache was cleared) */
-            /* Use >= 5ms threshold for CI timing variability */
-            assertTrue("After load, getKey should take PBKDF2 time: " +
-                elapsed + "ms", elapsed >= 5);
+            assertEquals("KEK cache should hold one entry after getKey",
+                1, cache.size());
 
         } finally {
             if (origEnabled != null) {
@@ -3396,33 +3371,39 @@ public class WolfSSLKeyStoreTest {
             /* Enable cache */
             Security.setProperty("wolfjce.keystore.kekCacheEnabled", "true");
 
-            /* Create KeyStore with multiple entries using same password */
-            KeyStore store = KeyStore.getInstance(storeType, storeProvider);
-            store.load(null, storePass.toCharArray());
+            /* Use WolfSSLKeyStore directly to inspect KEK cache */
+            WolfSSLKeyStore wksSpi = new WolfSSLKeyStore();
+            wksSpi.engineLoad(null, storePass.toCharArray());
 
-            store.setKeyEntry("rsaKey", serverKeyRsa, storePass.toCharArray(),
+            wksSpi.engineSetKeyEntry("rsaKey", serverKeyRsa,
+                storePass.toCharArray(),
                 new Certificate[] { serverCertRsa });
-            store.setKeyEntry("eccKey", serverKeyEcc, storePass.toCharArray(),
-                eccServerChain);
+            wksSpi.engineSetKeyEntry("eccKey", serverKeyEcc,
+                storePass.toCharArray(), eccServerChain);
 
-            /* Populate cache for both entries */
-            Key rsaKey = store.getKey("rsaKey", storePass.toCharArray());
-            Key eccKey = store.getKey("eccKey", storePass.toCharArray());
-
+            /* Populate cache, one entry per KeyStore entry salt */
+            Key rsaKey = wksSpi.engineGetKey("rsaKey",
+                storePass.toCharArray());
+            Key eccKey = wksSpi.engineGetKey("eccKey",
+                storePass.toCharArray());
             assertNotNull(rsaKey);
             assertNotNull(eccKey);
 
-            /* Both keys should be retrievable again quickly */
-            long start = System.currentTimeMillis();
-            Key rsaKey2 = store.getKey("rsaKey", storePass.toCharArray());
-            Key eccKey2 = store.getKey("eccKey", storePass.toCharArray());
-            long elapsed = System.currentTimeMillis() - start;
+            Map<?, ?> cache = getKekCacheMap(wksSpi);
+            assertEquals("KEK cache should hold one entry per KeyStore " +
+                "entry", 2, cache.size());
 
+            /* Cache hits, no new entries */
+            Key rsaKey2 = wksSpi.engineGetKey("rsaKey",
+                storePass.toCharArray());
+            Key eccKey2 = wksSpi.engineGetKey("eccKey",
+                storePass.toCharArray());
             assertNotNull(rsaKey2);
             assertNotNull(eccKey2);
-
-            assertTrue("Multiple cache hits should be fast: " +
-                elapsed + "ms", elapsed < 100);
+            assertEquals(rsaKey, rsaKey2);
+            assertEquals(eccKey, eccKey2);
+            assertEquals("KEK cache should still hold two entries",
+                2, cache.size());
 
         } finally {
             if (origEnabled != null) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
@@ -307,8 +307,9 @@ public class AesGcmTest {
         byte[] plain = null;
         byte[] tag = new byte[t3.length];
 
-        /* skip test if AES-128 is not compiled in native library */
-        if (!FeatureDetect.Aes128Enabled()) {
+        /* skip test if AES-128 is not compiled in native library, or if
+         * using wolfCrypt FIPS since this test uses a 1-byte IV */
+        if (!FeatureDetect.Aes128Enabled() || Fips.enabled) {
             return;
         }
 
@@ -478,8 +479,7 @@ public class AesGcmTest {
         byte[] plain = null;
         byte[] tag = new byte[t1.length];
 
-        /* skip test if AES-192 is not compiled in native library, or if
-         * using wolfCrypt FIPS since it only supports 12-byte IVs */
+        /* skip test if AES-256 is not compiled in native library */
         if (!FeatureDetect.Aes256Enabled()) {
             return;
         }
@@ -549,14 +549,64 @@ public class AesGcmTest {
     }
 
     @Test
+    public void testAesGcmFipsIvSizeRestriction() throws WolfCryptException {
+
+        byte[] tag = new byte[t1.length];
+        byte[] shortIv = new byte[] { (byte)0xca };
+
+        /* wolfCrypt FIPS 140-3 (v5.1+) restricts AES-GCM external IV
+         * sizes to 8, 12 or 16 bytes, wolfcryptjni uses
+         * wc_AesGcmSetExtIV() + wc_AesGcmEncrypt_ex() on those versions.
+         * FIPS v2 uses one-shot encrypt which supports any IV size,
+         * skip there and when not using FIPS. */
+        if (!Fips.enabled || (Fips.fipsVersion < 5) ||
+            !FeatureDetect.Aes256Enabled()) {
+            return;
+        }
+
+        AesGcm enc = new AesGcm();
+        try {
+            enc.setKey(k1);
+
+            /* 12-byte IV should work in FIPS mode, verify known answer */
+            byte[] cipher = enc.encrypt(p, iv1, tag, a);
+            assertNotNull(cipher);
+            assertArrayEquals(c1, cipher);
+            assertArrayEquals(t1, tag);
+
+            /* 1-byte IV should throw exception in FIPS mode */
+            try {
+                enc.encrypt(p, shortIv, tag, a);
+                fail("AES-GCM encrypt with 1-byte IV should fail when " +
+                     "using wolfCrypt FIPS");
+            } catch (WolfCryptException e) {
+                /* expected */
+            }
+
+            /* Oversized IV (64 bytes) should throw exception in FIPS
+             * mode */
+            try {
+                enc.encrypt(p, new byte[64], tag, a);
+                fail("AES-GCM encrypt with 64-byte IV should fail when " +
+                     "using wolfCrypt FIPS");
+            } catch (WolfCryptException e) {
+                /* expected */
+            }
+        } finally {
+            enc.releaseNativeStruct();
+        }
+    }
+
+    @Test
     public void testReleaseAndReinitObjectAes128() throws WolfCryptException {
 
         byte[] cipher = null;
         byte[] plain = null;
         byte[] tag = new byte[t3.length];
 
-        /* skip test if AES-128 is not compiled in native library */
-        if (!FeatureDetect.Aes128Enabled()) {
+        /* skip test if AES-128 is not compiled in native library, or if
+         * using wolfCrypt FIPS since this test uses a 1-byte IV */
+        if (!FeatureDetect.Aes128Enabled() || Fips.enabled) {
             return;
         }
 
@@ -708,8 +758,9 @@ public class AesGcmTest {
         byte[] plain = null;
         byte[] tag = new byte[t3.length];
 
-        /* skip test if AES-128 is not compiled in native library */
-        if (!FeatureDetect.Aes128Enabled()) {
+        /* skip test if AES-128 is not compiled in native library, or if
+         * using wolfCrypt FIPS since this test uses a 1-byte IV */
+        if (!FeatureDetect.Aes128Enabled() || Fips.enabled) {
             return;
         }
 
@@ -833,8 +884,9 @@ public class AesGcmTest {
         final LinkedBlockingQueue<Integer> results = new LinkedBlockingQueue<>();
         final byte[] rand2kBuf = new byte[2048];
 
-        /* skip test if AES-128 is not compiled in native library */
-        if (!FeatureDetect.Aes128Enabled()) {
+        /* skip test if AES-128 is not compiled in native library, or if
+         * using wolfCrypt FIPS since this test uses a 1-byte IV */
+        if (!FeatureDetect.Aes128Enabled() || Fips.enabled) {
             return;
         }
 


### PR DESCRIPTION
This PR updates wolfCrypt JNI/JCE for recent native wolfSSL FIPS changes, primarily from wolfSSL/wolfssl#10920:

- **AES-GCM** (wolfSSL/wolfssl#10920, commit `40623dada`): one-shot `wc_AesGcmEncrypt()` with an external IV is no longer exported by FIPS modules. Use `wc_AesGcmSetExtIV()` + `wc_AesGcmEncrypt_ex()` on FIPS v5.1+.
- **DH** (wolfSSL/wolfssl#10920, commit `b4a932684`): new FIPS module flavors imply `--disable-dh`. Skip DH tests when native wolfSSL is built without DH.
- **Private key lock** (wolfCrypt FIPS WCv6.0.0-RC4 module sources): add missing `PRIVATE_KEY_UNLOCK()`/`PRIVATE_KEY_LOCK()` around PBKDF2 and Ed25519/ML-DSA/ML-KEM/SLH-DSA key export JNI calls.