### PR TITLE
Reduce PR workflow time and runner usage

### DIFF
--- a/.github/actions/build-wolfssl-cached/action.yml
+++ b/.github/actions/build-wolfssl-cached/action.yml
@@ -1,0 +1,83 @@
+name: 'Build wolfSSL (cached)'
+description: 'Restore a cached native wolfSSL install keyed on the
+  wolfSSL commit, configure flags, OS/arch and compiler, building
+  and saving the exact keyed commit on a cache miss'
+
+# The configure string is passed in once and used for both the cache
+# key and the build, so the key and the built contents cannot drift
+# apart. The compiler version is part of the key so a runner-image
+# toolchain bump rotates the cache; sanitizer-instrumented builds in
+# particular must match the runtime (libasan) of the current image.
+#
+# The install prefix is fixed to build-dir by the wrapped
+# actions-build-autotools-project action, so the cache path is
+# hard-coded to match rather than exposed as an input.
+
+inputs:
+  configure:
+    description: 'Full wolfSSL ./configure arguments'
+    required: true
+  ref:
+    description: 'wolfSSL git ref to build. The default master is
+      resolved to a commit SHA so the cache key and the built contents
+      cannot drift if master advances mid-run; any other value is
+      expected to be an immutable release tag and is used as-is.'
+    required: false
+    default: 'master'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve wolfSSL cache key
+      id: wolfssl-key
+      shell: bash
+      env:
+        WOLFSSL_CONFIGURE: ${{ inputs.configure }}
+        WOLFSSL_REF: ${{ inputs.ref }}
+      run: |
+        if [ "$WOLFSSL_REF" = "master" ]; then
+          REF=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$REF" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+        else
+          REF="$WOLFSSL_REF"
+        fi
+        CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+          shasum -a 256 | cut -c1-16)
+        CC_HASH=$(cc --version 2>/dev/null | head -n1 | \
+          shasum -a 256 | cut -c1-8)
+        KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}"
+        KEY="$KEY-cc$CC_HASH-$REF-$CFG_HASH"
+        echo "ref=$REF" >> "$GITHUB_OUTPUT"
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+    - name: Restore cached wolfSSL install
+      id: cache-wolfssl
+      uses: actions/cache/restore@v4
+      with:
+        path: build-dir
+        key: ${{ steps.wolfssl-key.outputs.key }}
+
+    # Build the exact ref the cache key was computed from
+    - name: Build native wolfSSL
+      if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+      uses: wolfSSL/actions-build-autotools-project@v1
+      with:
+        repository: wolfSSL/wolfssl
+        ref: ${{ steps.wolfssl-key.outputs.ref }}
+        path: wolfssl
+        configure: ${{ inputs.configure }}
+        check: false
+        install: true
+
+    # Save right after building (not at job end) so a later test
+    # failure does not prevent the cache from being populated.
+    - name: Save wolfSSL install to cache
+      if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: build-dir
+        key: ${{ steps.wolfssl-key.outputs.key }}

--- a/.github/actions/setup-junit/action.yml
+++ b/.github/actions/setup-junit/action.yml
@@ -1,0 +1,51 @@
+name: 'Setup JUnit'
+description: 'Cache and download the JUnit jars used by ant test, verify
+  their checksums, and export JUNIT_HOME'
+
+# shasum is used instead of sha256sum because it is available on both
+# the Linux and macOS hosted runners.
+#
+# The v2 cache key retires the junit-jars-v1 entries that older
+# workflows populated without checksum verification, so every entry
+# under this key is guaranteed to have passed the checks below.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore cached JUnit dependencies
+      id: cache-junit
+      uses: actions/cache/restore@v4
+      with:
+        path: junit
+        key: junit-jars-v2
+
+    - name: Download junit-4.13.2.jar
+      if: steps.cache-junit.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        wget --directory-prefix=$GITHUB_WORKSPACE/junit \
+          https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+        echo "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3  $GITHUB_WORKSPACE/junit/junit-4.13.2.jar" \
+          | shasum -a 256 -c -
+
+    - name: Download hamcrest-all-1.3.jar
+      if: steps.cache-junit.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        wget --directory-prefix=$GITHUB_WORKSPACE/junit \
+          https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+        echo "4877670629ab96f34f5f90ab283125fcd9acb7e683e66319a68be6eb2cca60de  $GITHUB_WORKSPACE/junit/hamcrest-all-1.3.jar" \
+          | shasum -a 256 -c -
+
+    # Save right after verifying (not at job end) so a later test
+    # failure does not prevent the cache from being populated.
+    - name: Save JUnit dependencies to cache
+      if: steps.cache-junit.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: junit
+        key: junit-jars-v2
+
+    - name: Set JUNIT_HOME
+      shell: bash
+      run: echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"

--- a/.github/workflows/android_gradle.yml
+++ b/.github/workflows/android_gradle.yml
@@ -57,7 +57,8 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache AVD snapshot for faster emulator boot
+      # Cache AVD snapshot for faster emulator boot. The v2 key retires
+      # snapshots saved before the settle script below was added.
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -65,9 +66,15 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-wolfcryptjni-30-x86_64-google_apis-v1
+          key: avd-wolfcryptjni-30-x86_64-google_apis-v2
 
-      # Create AVD and generate snapshot for caching
+      # Create AVD and generate snapshot for caching. Wait for the
+      # system to fully settle (boot complete plus the input service
+      # registered) before the emulator exits and the snapshot is
+      # saved. Snapshots saved mid-boot resume into a half-settled
+      # system on restore, where the emulator-runner action's keyguard
+      # dismiss (input keyevent 82) intermittently fails with
+      # "No service published for: input".
       - name: Create AVD and generate snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2.37.0
@@ -78,7 +85,12 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: echo "Generated AVD snapshot for caching"
+          script: |
+            adb wait-for-device
+            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done'
+            adb shell 'while ! service check input | grep -q found; do sleep 1; done'
+            sleep 15
+            echo "Generated AVD snapshot for caching"
 
       # Run instrumented tests on Android emulator
       - name: Run Android Instrumented Tests

--- a/.github/workflows/android_gradle.yml
+++ b/.github/workflows/android_gradle.yml
@@ -7,8 +7,8 @@ on:
     branches: [ 'master' ]
 
 concurrency:
-  group: android-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: android-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_wolfcryptjni:

--- a/.github/workflows/android_gradle_fipsready.yml
+++ b/.github/workflows/android_gradle_fipsready.yml
@@ -7,8 +7,8 @@ on:
     branches: [ 'master' ]
 
 concurrency:
-  group: android-fips-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: android-fips-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_wolfcryptjni_fipsready:

--- a/.github/workflows/android_gradle_fipsready.yml
+++ b/.github/workflows/android_gradle_fipsready.yml
@@ -102,7 +102,8 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache AVD snapshot for faster emulator boot
+      # Cache AVD snapshot for faster emulator boot. The v2 key retires
+      # snapshots saved before the settle script below was added.
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -110,9 +111,15 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-wolfcryptjni-fips-30-x86_64-google_apis-v1
+          key: avd-wolfcryptjni-fips-30-x86_64-google_apis-v2
 
-      # Create AVD and generate snapshot for caching
+      # Create AVD and generate snapshot for caching. Wait for the
+      # system to fully settle (boot complete plus the input service
+      # registered) before the emulator exits and the snapshot is
+      # saved. Snapshots saved mid-boot resume into a half-settled
+      # system on restore, where the emulator-runner action's keyguard
+      # dismiss (input keyevent 82) intermittently fails with
+      # "No service published for: input".
       - name: Create AVD and generate snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2.37.0
@@ -123,7 +130,12 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: echo "Generated AVD snapshot for caching"
+          script: |
+            adb wait-for-device
+            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done'
+            adb shell 'while ! service check input | grep -q found; do sleep 1; done'
+            sleep 15
+            echo "Generated AVD snapshot for caching"
 
       # Launch app briefly to capture FIPS in-core hash from logcat.
       # The FIPS error callback prints the expected verifyCore hash on

--- a/.github/workflows/comment-style-check.yml
+++ b/.github/workflows/comment-style-check.yml
@@ -8,6 +8,11 @@ on:
       - '**/*.c'
       - '**/*.h'
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-comment-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/filtered-providers.yml
+++ b/.github/workflows/filtered-providers.yml
@@ -19,20 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download junit-4.13.2.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
+          cache: 'maven'
 
       # The filtered-providers sources are pure Java
       # (com.wolfssl.security.providers.*) and the tests exercise JDK
@@ -54,9 +49,9 @@ jobs:
         run: ant test-filtered-providers
 
       # ----- Maven: tests + classified jar (auto-skips on Java 8) ---------
-      - name: mvn test (filtered-providers tests only)
-        run: mvn test -Dmain.tests.skip=true
-
+      # A single mvn package runs the compile, test, and package phases
+      # in one lifecycle pass. A separate mvn test step would run the
+      # filtered-providers test suite twice.
       - name: mvn package (filtered-providers tests + jars)
         run: mvn package -Dmain.tests.skip=true
 

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -1,4 +1,4 @@
-name: Common Linux test logic
+name: Facebook Infer static analysis
 
 on:
   workflow_call:
@@ -12,9 +12,6 @@ on:
       jdk_version:
         required: true
         type: string
-      wolfssl_configure:
-        required: true
-        type: string
 
 jobs:
   build_wolfcryptjni:
@@ -22,32 +19,45 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Download Facebook Infer
+      # Infer runs javac directly over the Java sources (see
+      # scripts/infer.sh), so this job does not need native wolfSSL,
+      # the JNI library, JUnit, or the test suite. Tests for this
+      # configuration run in the main CI matrix (linux-zulu-all).
+
+      # Cache the extracted Infer release (~100MB download per run).
+      - name: Restore cached Infer
+        id: cache-infer
+        uses: actions/cache/restore@v4
+        with:
+          path: infer-linux64-v1.1.0
+          key: infer-v1.1.0-${{ runner.os }}-${{ runner.arch }}
+
+      # Download Facebook Infer, verifying the release tarball checksum
       - name: Download Infer
-        run: wget https://github.com/facebook/infer/releases/download/v1.1.0/infer-linux64-v1.1.0.tar.xz
+        if: steps.cache-infer.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/facebook/infer/releases/download/v1.1.0/infer-linux64-v1.1.0.tar.xz
+          echo "5f5d453814422e93e2a70998d8946b09a2721628ff427f67ff0123dea87461d4  infer-linux64-v1.1.0.tar.xz" \
+            | shasum -a 256 -c -
       - name: Extract Infer
+        if: steps.cache-infer.outputs.cache-hit != 'true'
         run: tar -xvf infer-linux64-v1.1.0.tar.xz
-      - name: Symlink Infer
-        run: ln -s "$GITHUB_WORKSPACE/infer-linux64-v1.1.0/bin/infer" /usr/local/bin/infer
+
+      - name: Add Infer to PATH
+        run: echo "$GITHUB_WORKSPACE/infer-linux64-v1.1.0/bin" >> "$GITHUB_PATH"
       - name: Test Infer get version
         run: infer --version
 
-      # Download Junit JARs
-      - name: Download junit-4.13.2.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      # Build native wolfSSL
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
+      # Save only after the version sanity check above passes, and
+      # before the analysis runs, so a failed Infer run (issues found)
+      # does not prevent the cache from being populated but a broken
+      # extraction is never cached.
+      - name: Save Infer to cache
+        if: steps.cache-infer.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: ${{ inputs.wolfssl_configure }}
-          check: false
-          install: true
+          path: infer-linux64-v1.1.0
+          key: infer-v1.1.0-${{ runner.os }}-${{ runner.arch }}
 
       # Setup Java
       - name: Setup java
@@ -56,66 +66,6 @@ jobs:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
 
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
-      - name: Set LD_LIBRARY_PATH
-        run: |
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
-
-      # Only copy appropriate makefile for platform currently being tested
-      - name: Copy makefile
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-              cp makefile.linux makefile
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-              cp makefile.macosx makefile
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
-          fi
-        shell: bash
-
-      - name: Build JNI library
-        run: PREFIX=$GITHUB_WORKSPACE/build-dir make
-
-      # ant build-jni-debug
-      - name: Build jce-debug JAR (ant build-jni-debug)
-        run: ant build-jni-debug
-      - name: Run Java tests (ant test)
-        run: ant test
-      - name: Clean JAR
-        run: ant clean
-
-      # ant build-jni-release
-      - name: Build jce-debug JAR (ant build-jni-release)
-        run: ant build-jni-release
-      - name: Run Java tests (ant test)
-        run: ant test
-      - name: Clean JAR
-        run: ant clean
-
-      # ant build-jce-debug
-      - name: Build jce-debug JAR (ant build-jce-debug)
-        run: ant build-jce-debug
-      - name: Run Java tests (ant test)
-        run: ant test
-      - name: Clean JAR
-        run: ant clean
-
-      # ant build-jce-release
-      - name: Build jce-debug JAR (ant build-jce-release)
-        run: ant build-jce-release
-      - name: Run Java tests (ant test)
-        run: ant test
-      - name: Clean JAR
-        run: ant clean
-
-      - name: Show logs on failure
-        if: failure() || cancelled()
-        run: |
-          cat build/reports/*.txt
-
       # Run Facebook Infer
       - name: Run Facebook Infer
         run: ./scripts/infer.sh
@@ -123,4 +73,3 @@ jobs:
       - name: Shows Infer report on failure
         if: failure()
         run: cat infer-out/report.txt
-

--- a/.github/workflows/java-module-test.yml
+++ b/.github/workflows/java-module-test.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR. In-progress
+# push runs are never cancelled, though a still-queued push run may
+# be superseded by a newer queued one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Test Java 9+ module support (JPMS)
   # Verifies that module-info.java is properly compiled and the resulting
@@ -21,40 +28,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
+
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Build native wolfSSL (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: --enable-jni
-          check: false
-          install: true
+          configure: '--enable-jni'
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |
@@ -184,40 +173,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
+
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Build native wolfSSL (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: --enable-jni
-          check: false
-          install: true
+          configure: '--enable-jni'
 
       - name: Setup Java 8
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   line-length-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-32bit.yml
+++ b/.github/workflows/linux-32bit.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. In-progress
+# push runs are never cancelled, though a still-queued push run may
+# be superseded by a newer queued one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Linux 32-bit build using Zulu x86 JDK
   # Tests JNI pointer handling and 32-bit specific code paths
@@ -44,25 +51,48 @@ jobs:
           java -version
           file $(which java)
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Clone and build wolfSSL (32-bit)
+      # Cache the installed wolfSSL build. The m32 key segment keeps
+      # these 32-bit builds separate from the 64-bit cache entries.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ matrix.wolfssl_configure }}
         run: |
-          git clone --depth 1 https://github.com/wolfSSL/wolfssl.git /tmp/wolfssl
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          CC_HASH=$(cc --version 2>/dev/null | head -n1 | \
+            shasum -a 256 | cut -c1-8)
+          KEY="wolfssl-m32-${{ runner.os }}-${{ runner.arch }}"
+          KEY="$KEY-cc$CC_HASH-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: wolfssl-install
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
+      # Fetch the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
+      - name: Clone and build wolfSSL (32-bit)
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        run: |
+          git init /tmp/wolfssl
           cd /tmp/wolfssl
+          git fetch --depth 1 https://github.com/wolfSSL/wolfssl.git \
+            ${{ steps.wolfssl-key.outputs.sha }}
+          git checkout FETCH_HEAD
           ./autogen.sh
           ./configure ${{ matrix.wolfssl_configure }} \
             --prefix=$GITHUB_WORKSPACE/wolfssl-install \
@@ -70,9 +100,17 @@ jobs:
           make
           make install
 
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: wolfssl-install
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib" >> $GITHUB_ENV
 
       - name: Copy makefile

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -22,20 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download junit-4.13.2.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
+      # Cache the installed wolfSSL build. It depends only on the wolfSSL
+      # commit, configure flags, OS/arch and compiler, not on the JDK in
+      # use, so jobs across the matrix (and other workflows) can share
+      # one build.
+      - name: Build native wolfSSL (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
           configure: ${{ inputs.wolfssl_configure }}
-          check: false
-          install: true
 
       - name: Setup java
         uses: actions/setup-java@v4
@@ -43,9 +40,6 @@ jobs:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
 
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
       - name: Set LD_LIBRARY_PATH
         run: |
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR. In-progress
+# push runs are never cancelled, though a still-queued push run may
+# be superseded by a newer queued one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Oracle JDK (Linux, Mac)
   # Oracle JDK requires JAR to be signed for some classes to load/run
@@ -217,21 +224,21 @@ jobs:
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
   # ------------------ Facebook Infer static analysis -------------------
-  # Run Facebook infer over PR code, only running on Linux with one
-  # JDK/version for now.
+  # Run Facebook Infer over the Java sources, only running on Linux with
+  # one JDK/version for now. Infer only compiles the .java files with
+  # javac, so no native wolfSSL build or test run is needed here. Tests
+  # for the equivalent configuration run in linux-zulu-all above.
   fb-infer:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
         jdk_version: [ '11' ]
-        wolfssl_configure: [ '--enable-jni --enable-all' ]
-    name: Facebook Infer (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure }})
+    name: Facebook Infer (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
     uses: ./.github/workflows/infer.yml
     with:
       os: ${{ matrix.os }}
       jdk_distro: "zulu"
       jdk_version: ${{ matrix.jdk_version }}
-      wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
   # --------------------- Maven build - test pom.xml --------------------
   # Run Maven build over PR code, running on Linux and Mac with only one

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,21 +22,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Build native wolfSSL (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
           configure: ${{ inputs.wolfssl_configure }}
-          check: false
-          install: true
 
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
+          cache: 'maven'
 
       - name: Set LD_LIBRARY_PATH
         run: |
@@ -62,13 +61,10 @@ jobs:
       - name: Build JNI library
         run: PREFIX=$GITHUB_WORKSPACE/build-dir make
 
-      # Maven build
-      - name: mvn compile
-        run: mvn compile
-
-      - name: mvn test
-        run: mvn test
-
+      # Maven build. A single mvn package runs the compile, test, and
+      # package phases in one lifecycle pass. Separate compile, test,
+      # and package steps would run the whole test suite twice, once
+      # for the test step and again inside package.
       - name: mvn package
         run: mvn package
 

--- a/.github/workflows/sanitizer-common.yml
+++ b/.github/workflows/sanitizer-common.yml
@@ -19,32 +19,28 @@ on:
 jobs:
   build_wolfcryptjni:
     runs-on: ${{ inputs.os }}
+    # Full effective wolfSSL configure string, defined once so the
+    # build step and the cache key below cannot drift apart.
+    env:
+      WOLFSSL_CONFIGURE: >-
+        ${{ inputs.wolfssl_configure }}
+        CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        LDFLAGS="-fsanitize=address"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Build native wolfSSL with AddressSanitizer
-        uses: wolfSSL/actions-build-autotools-project@v1
+      # Cache the installed wolfSSL build, keyed on the full configure
+      # string (including sanitizer flags), wolfSSL commit, OS/arch and
+      # compiler. The compiler in the key matters here: the sanitizer
+      # runtime preloaded at test time must match the toolchain that
+      # built the instrumented library.
+      - name: Build native wolfSSL with AddressSanitizer (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: ${{ inputs.wolfssl_configure }} CFLAGS="-fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address"
-          check: false
-          install: true
+          configure: ${{ env.WOLFSSL_CONFIGURE }}
 
       - name: Setup java
         uses: actions/setup-java@v4
@@ -58,7 +54,6 @@ jobs:
       # This will let us catch all non-leak issues.
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
           echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:print_stats=1" >> "$GITHUB_ENV"
 

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR. In-progress
+# push runs are never cancelled, though a still-queued push run may
+# be superseded by a newer queued one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan-build:
     runs-on: ubuntu-latest
@@ -18,54 +25,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-tools
 
-      # Cache Junit JARs
-      - name: Cache Junit JARs
-        uses: actions/cache@v3
-        id: cache-junit
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Build native wolfSSL (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          path: ${{ github.workspace }}/junit
-          key: junit-cache-${{ runner.os }}-junit-4.13.2-hamcrest-1.3
-          restore-keys: |
-            junit-cache-${{ runner.os }}-
-
-      # Download Junit JARs (needed for full build)
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      # Build native wolfSSL
-      - name: Build native wolfSSL
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
           configure: '--enable-jni --enable-all'
-          check: false
-          install: true
 
-      # Setup Java
+      # Setup Java (the makefile needs JAVA_HOME for the JNI headers)
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
-      - name: Set LD_LIBRARY_PATH
-        run: |
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
-
       # Copy appropriate makefile for Linux
       - name: Copy makefile
         run: cp makefile.linux makefile
 
-      # Run scan-build over the native JNI C files
+      # Run scan-build over the native JNI C files. The default make
+      # target compiles only the native library, so no JUnit jars or
+      # LD_LIBRARY_PATH are needed since no Java builds or tests run.
       - name: Run scan-build
         env:
           PREFIX: ${{ github.workspace }}/build-dir

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -8,6 +8,11 @@ on:
       - 'build.xml'
       - 'spotbugs-exclude.xml'
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   spotbugs:
     runs-on: ubuntu-latest
@@ -23,17 +28,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Set up Ant
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ant
-
-      - name: Download JUnit
-        run: |
-          mkdir -p /tmp/junit
-          wget -q -P /tmp/junit \
-            "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar"
-          echo "JUNIT_HOME=/tmp/junit" >> $GITHUB_ENV
+      # Ant is preinstalled on the ubuntu-latest runner image, so no
+      # apt-get install is needed here.
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       - name: Download and set up SpotBugs
         run: |

--- a/.github/workflows/stable-wolfssl-releases.yml
+++ b/.github/workflows/stable-wolfssl-releases.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # First job: dynamically fetch the last 5 stable wolfSSL release tags
   get-stable-releases:
@@ -51,40 +56,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
+
+      # Cache the installed wolfSSL build. Stable release tags do not
+      # move, so these entries stay valid until a runner-image
+      # toolchain bump rotates the key.
+      - name: Build native wolfSSL ${{ matrix.wolfssl_version }} (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Build native wolfSSL ${{ matrix.wolfssl_version }}
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: wolfSSL/wolfssl
-          ref: ${{ matrix.wolfssl_version }}
-          path: wolfssl
           configure: ${{ matrix.wolfssl_configure }}
-          check: false
-          install: true
+          ref: ${{ matrix.wolfssl_version }}
 
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/undefined-sanitizer.yml
+++ b/.github/workflows/undefined-sanitizer.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. In-progress
+# push runs are never cancelled, though a still-queued push run may
+# be superseded by a newer queued one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Run UBSan build and test on Linux only for undefined behavior detection
   ubsan:
@@ -15,33 +22,29 @@ jobs:
         jdk_version: [ '21' ]
         wolfssl_configure: [ '--enable-jni --enable-debug' ]
     name: UBSan (ubuntu-latest Zulu JDK ${{ matrix.jdk_version }})
+    # Full effective wolfSSL configure string, defined once so the
+    # build step and the cache key below cannot drift apart.
+    env:
+      WOLFSSL_CONFIGURE: >-
+        ${{ matrix.wolfssl_configure }}
+        CFLAGS="-fsanitize=undefined -fno-sanitize-recover=all
+        -fno-omit-frame-pointer" LDFLAGS="-fsanitize=undefined"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      - name: Build native wolfSSL with UndefinedBehaviorSanitizer
-        uses: wolfSSL/actions-build-autotools-project@v1
+      # Cache the installed wolfSSL build, keyed on the full configure
+      # string (including sanitizer flags), wolfSSL commit, OS/arch and
+      # compiler. The compiler in the key matters here: the sanitizer
+      # runtime linked at test time must match the toolchain that built
+      # the instrumented library.
+      - name: Build native wolfSSL with UndefinedBehaviorSanitizer (cached)
+        uses: ./.github/actions/build-wolfssl-cached
         with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: ${{ matrix.wolfssl_configure }} CFLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" LDFLAGS="-fsanitize=undefined"
-          check: false
-          install: true
+          configure: ${{ env.WOLFSSL_CONFIGURE }}
 
       - name: Setup java
         uses: actions/setup-java@v4
@@ -51,7 +54,6 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
           echo "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
This PR speeds up PR CI and cuts GitHub runner usage, porting the optimizations from wolfSSL/wolfssljni#386.

### Optimizations
  - Cache installed native wolfSSL builds via a new shared `build-wolfssl-cached` composite action, keyed on wolfSSL commit, configure flags, OS/arch, and compiler version. The ~120 jobs behind the main CI matrix previously each rebuilt wolfSSL from source, now distinct configurations build once and share
  - Cancel superseded in-progress runs when a PR branch is re-pushed. In-progress push runs are never cancelled. Also fixes the Android workflows, which could previously cancel push runs on master
  - Run Infer over Java sources only, dropping its redundant native wolfSSL build and duplicate 4x ant build/test cycle, and cache the Infer release (~378MB per run), verified against a pinned SHA-256
  - Run a single `mvn package` instead of separate compile/test/package phases, which ran the test suite twice (maven.yml and filtered-providers.yml), and cache Maven dependencies
  - Drop JUnit setup and library paths from scan-build, which only compiles the native C files, and remove a redundant `apt-get install ant` from spotbugs (preinstalled on runners)
  - Consolidate copy-pasted JUnit setup into a shared `setup-junit` composite action with caching and SHA-256 verification on all downloads (several workflows previously had neither)