### PR TITLE
Robustness fixes across wolfJCE PKIX, ASN.1, and JNI HMAC

### DIFF
--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -156,6 +156,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSetKey
     Hmac* hmac = NULL;
     byte* key  = NULL;
     word32 keySz = 0;
+    jboolean keyIsCopy = JNI_FALSE;
 
     hmac = (Hmac*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
@@ -163,19 +164,41 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSetKey
         return;
     }
 
-    key   = getByteArray(env, key_object);
-    keySz = getByteArrayLength(env, key_object);
+    if (key_object != NULL) {
+        key = (byte*)(*env)->GetByteArrayElements(env, key_object, &keyIsCopy);
+        if ((*env)->ExceptionOccurred(env)) {
+            return;
+        }
+        keySz = getByteArrayLength(env, key_object);
+    }
 
-    ret = (!hmac || !key)
-        ? BAD_FUNC_ARG
-        : wc_HmacSetKey(hmac, type, key, keySz);
+    if (hmac == NULL || key == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = wc_HmacSetKey(hmac, type, key, keySz);
+    }
 
-    if (ret != 0)
+    if (ret != 0) {
         throwWolfCryptExceptionFromError(env, ret);
+    }
 
     LogStr("HmacInit(hmac=%p) = %d\n", hmac, ret);
 
-    releaseByteArray(env, key_object, key, JNI_ABORT);
+    if (key != NULL) {
+        /* Zero native key copy before release. Skip when not a copy,
+         * key then points at the caller's array and must not be cleared */
+        if (keyIsCopy == JNI_TRUE) {
+        #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+            !defined(WOLFSSL_NO_FORCE_ZERO)
+            wc_ForceZero(key, keySz);
+        #else
+            XMEMSET(key, 0, keySz);
+        #endif
+        }
+        (*env)->ReleaseByteArrayElements(env, key_object, (jbyte*)key,
+            JNI_ABORT);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptASN1Util.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptASN1Util.java
@@ -621,7 +621,7 @@ public class WolfCryptASN1Util {
 
         if ((firstByte & 0x80) == 0) {
             /* Short form */
-            return new int[] {firstByte, offset};
+            length = firstByte;
         }
         else {
             /* Long form */
@@ -645,9 +645,15 @@ public class WolfCryptASN1Util {
             for (int i = 0; i < numBytes; i++) {
                 length = (length << 8) | (data[offset++] & 0xff);
             }
-
-            return new int[] {length, offset};
         }
+
+        /* Reject negative length or content extending beyond buffer */
+        if (length < 0 || length > data.length - offset) {
+            throw new IllegalArgumentException(
+                "Invalid DER length: exceeds available data");
+        }
+
+        return new int[] {length, offset};
     }
 
     /**

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathBuilder.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathBuilder.java
@@ -574,6 +574,16 @@ public class WolfCryptPKIXCertPathBuilder extends CertPathBuilderSpi {
 
         /* Build path from target to trust anchor */
         while (true) {
+            /* Enforce maxPathLength as per-iteration depth budget so oversized
+             * chain is rejected before signature checks. maxPathLength of -1
+             * means unlimited. */
+            if ((maxPathLength >= 0) && ((path.size() - 1) > maxPathLength)) {
+                throw new CertPathBuilderException(
+                    "Certificate path exceeds maximum length: " +
+                    maxPathLength + " (found " + (path.size() - 1) +
+                    " intermediate CA certificate(s))");
+            }
+
             /* Check if current cert is issued by a trust anchor */
             TrustAnchor anchor = isIssuedByTrustAnchor(current, anchors);
             if (anchor != null) {
@@ -657,20 +667,6 @@ public class WolfCryptPKIXCertPathBuilder extends CertPathBuilderSpi {
                 throw new CertPathBuilderException(
                     "No valid issuer found for certificate: " +
                     current.getSubjectX500Principal().getName());
-            }
-        }
-
-        /* Check path length constraint after path is complete.
-         * maxPathLength is maximum number of intermediate CA certificates
-         * allowed between end entity and trust anchor. maxPathLength of
-         * -1 means unlimited (no constraints). */
-        if (maxPathLength >= 0) {
-            int numCACerts = path.size() - 1; /* exclude target cert */
-            if (numCACerts > maxPathLength) {
-                throw new CertPathBuilderException(
-                    "Certificate path exceeds maximum length: " +
-                    maxPathLength + " (found " + numCACerts +
-                    " intermediate CA certificate(s))");
             }
         }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPssParameters.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPssParameters.java
@@ -78,7 +78,7 @@ public class WolfCryptPssParameters extends AlgorithmParametersSpi {
         try {
             this.pssSpec = decodePssParameters(params);
             validatePSSParameters(this.pssSpec);
-        } catch (InvalidParameterSpecException e) {
+        } catch (InvalidParameterSpecException | IllegalArgumentException e) {
             throw new IOException(
                 "Failed to decode PSS parameters: " + e.getMessage(), e);
         }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
@@ -799,6 +799,38 @@ public class WolfCryptAlgorithmParametersTest {
         assertEquals(64, retrievedSpec.getSaltLength());
     }
 
+    /*
+     * Malformed PSS parameters with an out of range DER field length must be
+     * rejected with IOException, not an OutOfMemoryError or
+     * NegativeArraySizeException from an oversized allocation.
+     */
+    @Test
+    public void testRSAPSSParametersRejectOversizedFieldLength()
+        throws Exception {
+
+        /* Context field [2] claims Integer.MAX_VALUE content bytes */
+        byte[] maxLen = new byte[] {
+            0x30, 0x0A, (byte)0xa2, (byte)0x84, 0x7F, (byte)0xFF,
+            (byte)0xFF, (byte)0xFF, 0x00, 0x00, 0x00, 0x00 };
+
+        /* Context field [2] claims Integer.MIN_VALUE (negative) bytes */
+        byte[] negLen = new byte[] {
+            0x30, 0x0A, (byte)0xa2, (byte)0x84, (byte)0x80, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+        for (byte[] bad : new byte[][] { maxLen, negLen }) {
+            AlgorithmParameters params =
+                AlgorithmParameters.getInstance("RSASSA-PSS", "wolfJCE");
+            try {
+                params.init(bad);
+                fail("init with out of range field length should throw " +
+                    "IOException");
+            } catch (IOException e) {
+                /* expected */
+            }
+        }
+    }
+
     @Test
     public void testRSAPSSParametersEncodingDERWithDefaults()
         throws Exception {

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathBuilderTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathBuilderTest.java
@@ -4591,6 +4591,56 @@ public class WolfCryptPKIXCertPathBuilderTest {
     }
 
     /**
+     * Test that the Java fallback builder enforces maxPathLength as a
+     * per-iteration depth budget, rejecting a chain that exceeds the limit.
+     * The fallback chain has one intermediate CA, so maxPathLength=0 must be
+     * rejected before the path completes.
+     */
+    @Test
+    public void testFallbackBuilderRejectsPathExceedingMaxLength()
+        throws Exception {
+
+        Assume.assumeTrue("Only applies when native check_time not supported",
+            !WolfSSLX509StoreCtx.isStoreCheckTimeSupported());
+
+        PKIXBuilderParameters params = createExpiredCertParams(1426399200000L);
+        params.setMaxPathLength(0);
+
+        CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX", provider);
+        try {
+            cpb.build(params);
+            fail("Expected CertPathBuilderException when fallback path " +
+                "exceeds maxPathLength");
+        } catch (CertPathBuilderException e) {
+            assertNotNull("Exception message should not be null",
+                e.getMessage());
+            assertTrue("Expected maxPathLength violation, got: " +
+                e.getMessage(),
+                e.getMessage().contains("exceeds maximum length"));
+        }
+    }
+
+    /**
+     * Test that the Java fallback builder accepts a chain whose length equals
+     * maxPathLength exactly. The fallback chain has one intermediate CA, so
+     * maxPathLength=1 must not be rejected by the depth budget.
+     */
+    @Test
+    public void testFallbackBuilderAcceptsPathAtMaxLength()
+        throws Exception {
+
+        Assume.assumeTrue("Only applies when native check_time not supported",
+            !WolfSSLX509StoreCtx.isStoreCheckTimeSupported());
+
+        PKIXBuilderParameters params = createExpiredCertParams(1426399200000L);
+        params.setMaxPathLength(1);
+
+        CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX", provider);
+        CertPathBuilderResult result = cpb.build(params);
+        assertNotNull("Builder should accept path at maxPathLength", result);
+    }
+
+    /**
      * Test end-to-end builder + validator with a valid custom date. Builds a
      * path with expired certs using a date within their validity, then
      * validates the result.

--- a/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
@@ -171,6 +171,34 @@ public class HmacTest {
         }
     }
 
+    /*
+     * setKey() must not modify the caller's key array. The JNI layer zeroes
+     * only its own native copy of the key before release. This guards the
+     * JNI_ABORT release mode, the zeroed native copy must never be written
+     * back to the caller's array.
+     */
+    @Test
+    public void hmacSetKeyShouldNotModifyKey() {
+        byte[] key = new byte[32];
+        for (int i = 0; i < key.length; i++) {
+            key[i] = (byte)(0x41 + ((i * 7) % 26));
+        }
+        byte[] keyCopy = key.clone();
+
+        Hmac hmac = new Hmac();
+        try {
+            hmac.setKey(Hmac.SHA256, key);
+        } catch (WolfCryptException e) {
+            if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {
+                return;
+            }
+            throw e;
+        }
+
+        assertArrayEquals("setKey must not modify caller key array",
+            keyCopy, key);
+    }
+
     @Test
     public void sha384HmacShouldMatch() {
         String[] keyVector = new String[] {


### PR DESCRIPTION
This PR includes three Fenrir fixes:

- **F-5034**: Clear the temporary native copy of the HMAC key in `wc_HmacSetKey` before it is released back to the JVM, and only when the JNI layer handed back a copy. This matches the array-release handling used elsewhere in `jni_hmac.c`.

- **F-5067**: Validate the decoded length in `decodeDERLengthWithOffset` against the bytes actually remaining in the buffer, rejecting a negative or out-of-range length before it is used to size a byte array.

- **F-5223**: Enforce `maxPathLength` as a per-iteration depth budget in the PKIX `buildPath` fallback. The limit is now checked at the top of the build loop, so an over-length chain is rejected before further signature verifications rather than after walking the entire chain. This matches the per-iteration depth budget used by SunCertPathBuilder and preserves the existing accept and reject decisions.