### PR TITLE
Fenrir fixes for wolfJCE key equality, KeyStore conversion, and EC key validation

### DIFF
--- a/.github/workflows/android_gradle.yml
+++ b/.github/workflows/android_gradle.yml
@@ -57,51 +57,20 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache AVD snapshot for faster emulator boot. The v2 key retires
-      # snapshots saved before the settle script below was added.
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-wolfcryptjni-30-x86_64-google_apis-v2
-
-      # Create AVD and generate snapshot for caching. Wait for the
-      # system to fully settle (boot complete plus the input service
-      # registered) before the emulator exits and the snapshot is
-      # saved. Snapshots saved mid-boot resume into a half-settled
-      # system on restore, where the emulator-runner action's keyguard
-      # dismiss (input keyevent 82) intermittently fails with
-      # "No service published for: input".
-      - name: Create AVD and generate snapshot
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.37.0
-        with:
-          api-level: 30
-          arch: x86_64
-          target: google_apis
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: |
-            adb wait-for-device
-            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done'
-            adb shell 'while ! service check input | grep -q found; do sleep 1; done'
-            sleep 15
-            echo "Generated AVD snapshot for caching"
-
-      # Run instrumented tests on Android emulator
+      # Cold boot with -no-snapshot. Restoring a snapshot brings back
+      # sys.boot_completed already set, so the action runs its keyguard
+      # dismiss (input keyevent 82) before the input service registers
+      # and fails with "No service published for: input".
+      # AOSP "default" image, these tests need no Play services.
       - name: Run Android Instrumented Tests
         uses: reactivecircus/android-emulator-runner@v2.37.0
-        timeout-minutes: 15
+        timeout-minutes: 20
         with:
           api-level: 30
           arch: x86_64
-          target: google_apis
+          target: default
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             adb wait-for-device
@@ -110,7 +79,11 @@ jobs:
             adb shell mkdir -p /data/local/tmp/examples/certs/crl
             adb push ./examples/certs/ /data/local/tmp/examples/
             adb logcat -c
-            cd IDE/Android && ./gradlew connectedDebugAndroidTest --no-daemon --no-watch-fs || { adb logcat -d > /tmp/logcat.txt 2>&1; echo "=== LOGCAT (errors) ==="; grep -i "exception\|error\|fatal" /tmp/logcat.txt || true; exit 1; }
+            # Shard the run, AGP returns results over gRPC with a 4MB cap
+            # that the full suite exceeds, failing with RESOURCE_EXHAUSTED
+            # even when every test passes. The action runs each line below
+            # as its own shell, so the whole loop must stay on one line.
+            cd IDE/Android && for S in 0 1; do echo "=== test shard $S of 2 ==="; ./gradlew connectedDebugAndroidTest --no-daemon --no-watch-fs -Pandroid.testInstrumentationRunnerArguments.numShards=2 -Pandroid.testInstrumentationRunnerArguments.shardIndex=$S || { adb logcat -d > /tmp/logcat.txt 2>&1; echo "=== LOGCAT (errors) ==="; grep -i "exception\|error\|fatal" /tmp/logcat.txt || true; exit 1; }; cp -r app/build/reports/androidTests/connected/debug app/build/reports/androidTests/shard-$S 2>/dev/null || true; done
             adb logcat -d > /tmp/logcat.txt 2>&1 || true
             pgrep -f '[q]emu-system' | xargs -r kill -9 2>/dev/null || true
             pgrep -f '[c]rashpad' | xargs -r kill -9 2>/dev/null || true

--- a/.github/workflows/android_gradle_fipsready.yml
+++ b/.github/workflows/android_gradle_fipsready.yml
@@ -102,54 +102,25 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache AVD snapshot for faster emulator boot. The v2 key retires
-      # snapshots saved before the settle script below was added.
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-wolfcryptjni-fips-30-x86_64-google_apis-v2
-
-      # Create AVD and generate snapshot for caching. Wait for the
-      # system to fully settle (boot complete plus the input service
-      # registered) before the emulator exits and the snapshot is
-      # saved. Snapshots saved mid-boot resume into a half-settled
-      # system on restore, where the emulator-runner action's keyguard
-      # dismiss (input keyevent 82) intermittently fails with
-      # "No service published for: input".
-      - name: Create AVD and generate snapshot
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.37.0
-        with:
-          api-level: 30
-          arch: x86_64
-          target: google_apis
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: |
-            adb wait-for-device
-            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done'
-            adb shell 'while ! service check input | grep -q found; do sleep 1; done'
-            sleep 15
-            echo "Generated AVD snapshot for caching"
-
       # Launch app briefly to capture FIPS in-core hash from logcat.
       # The FIPS error callback prints the expected verifyCore hash on
       # startup if there is a mismatch.
+      #
+      # Cold boot with -no-snapshot. Restoring a snapshot brings back
+      # sys.boot_completed already set, so the action runs its keyguard
+      # dismiss (input keyevent 82) before the input service registers
+      # and fails with "No service published for: input".
+      # AOSP "default" image, these tests need no Play services.
       - name: Capture FIPS in-core hash
         id: fips-hash
         uses: reactivecircus/android-emulator-runner@v2.37.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           api-level: 30
           arch: x86_64
-          target: google_apis
+          target: default
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             adb wait-for-device
@@ -181,16 +152,17 @@ jobs:
           (cd /tmp && echo "$(cat ${BCPROV_JAR}.sha256)  ${BCPROV_JAR}" | sha256sum -c -)
           cd examples/certs && ./convert-to-bks.sh "/tmp/${BCPROV_JAR}"
 
-      # Run instrumented tests on Android emulator
+      # Run instrumented tests on Android emulator, cold booted for the
+      # same reason as the FIPS hash capture step above.
       - name: Run Android Instrumented Tests
         uses: reactivecircus/android-emulator-runner@v2.37.0
-        timeout-minutes: 15
+        timeout-minutes: 20
         with:
           api-level: 30
           arch: x86_64
-          target: google_apis
+          target: default
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             adb wait-for-device
@@ -199,10 +171,14 @@ jobs:
             adb shell mkdir -p /data/local/tmp/examples/certs/crl
             adb push ./examples/certs/ /data/local/tmp/examples/
             adb logcat -c
-            cd IDE/Android && ./gradlew connectedDebugAndroidTest --no-daemon --no-watch-fs || { adb logcat -d > /tmp/logcat.txt 2>&1; echo "=== LOGCAT (errors) ==="; grep -i "exception\|error\|fatal" /tmp/logcat.txt || true; exit 1; }
+            # Shard the run, AGP returns results over gRPC with a 4MB cap
+            # that the full suite exceeds, failing with RESOURCE_EXHAUSTED
+            # even when every test passes. The action runs each line below
+            # as its own shell, so the whole loop must stay on one line.
+            cd IDE/Android && for S in 0 1; do echo "=== test shard $S of 2 ==="; ./gradlew connectedDebugAndroidTest --no-daemon --no-watch-fs -Pandroid.testInstrumentationRunnerArguments.numShards=2 -Pandroid.testInstrumentationRunnerArguments.shardIndex=$S || { adb logcat -d > /tmp/logcat.txt 2>&1; echo "=== LOGCAT (errors) ==="; grep -i "exception\|error\|fatal" /tmp/logcat.txt || true; exit 1; }; cp -r app/build/reports/androidTests/connected/debug app/build/reports/androidTests/shard-$S 2>/dev/null || true; done
             adb logcat -d > /tmp/logcat.txt 2>&1 || true
             # Clean up emulator processes. Safe to kill -9 since
-            # -no-snapshot-save is used (no snapshot to corrupt).
+            # -no-snapshot is used (no snapshot to corrupt).
             pgrep -f '[q]emu-system' | xargs -r kill -9 2>/dev/null || true
             pgrep -f '[c]rashpad' | xargs -r kill -9 2>/dev/null || true
             sleep 2

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
@@ -584,9 +584,12 @@ public class WolfCryptECKeyFactory extends KeyFactorySpi {
             y = validateAndConvertBigIntegerToBytes(
                 keySpec.getW().getAffineY(), "Y coordinate", curveName);
 
-            /* Import public key {x, y} into Ecc object */
+            /* Import public key {x, y} into Ecc object. Raw import only
+             * validates the point when native wolfSSL is built with
+             * WOLFSSL_VALIDATE_ECC_IMPORT, so check it explicitly. */
             ecc = new Ecc();
             ecc.importPublicRaw(x, y, curveName);
+            ecc.checkKey();
 
             /* Export as DER encoded format */
             derData = ecc.publicKeyEncode();

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptECPublicKey.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptECPublicKey.java
@@ -139,6 +139,39 @@ public class WolfCryptECPublicKey implements ECPublicKey, Destroyable {
     }
 
     /**
+     * Convert one EC point coordinate to a fixed size byte array.
+     *
+     * Native raw import reinterprets the bytes unsigned, so a negative
+     * value would silently import as value + 2^(8 * curveSize).
+     *
+     * @param value coordinate to convert
+     * @param name coordinate name used in error messages, "X" or "Y"
+     * @param curveName curve name used in error messages
+     * @param curveSize expected coordinate size in bytes
+     *
+     * @return coordinate as a curveSize byte array
+     *
+     * @throws IllegalArgumentException if the coordinate is negative or
+     *         too large for the curve
+     */
+    private static byte[] coordinateToBytes(BigInteger value, String name,
+        String curveName, int curveSize) throws IllegalArgumentException {
+
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException(name +
+                " coordinate cannot be negative");
+        }
+
+        try {
+            return Ecc.bigIntToFixedSizeByteArray(value, curveSize);
+
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(name +
+                " coordinate too large for curve " + curveName);
+        }
+    }
+
+    /**
      * Generate DER-encoded form from public point and parameters.
      *
      * @return DER-encoded X.509 public key
@@ -148,6 +181,7 @@ public class WolfCryptECPublicKey implements ECPublicKey, Destroyable {
     private byte[] generateDerFromParameters()
         throws IllegalArgumentException {
 
+        int curveSize = 0;
         byte[] xBytes = null;
         byte[] yBytes = null;
         Ecc ecc = null;
@@ -180,12 +214,18 @@ public class WolfCryptECPublicKey implements ECPublicKey, Destroyable {
             }
 
             /* Convert coordinates to byte[] */
-            xBytes = Ecc.bigIntToByteArrayNoLeadingZeros(x);
-            yBytes = Ecc.bigIntToByteArrayNoLeadingZeros(y);
+            curveSize = Ecc.getCurveSizeFromName(curveName);
+            if (curveSize <= 0) {
+                throw new IllegalArgumentException(
+                    "Unable to get curve size for " + curveName);
+            }
+            xBytes = coordinateToBytes(x, "X", curveName, curveSize);
+            yBytes = coordinateToBytes(y, "Y", curveName, curveSize);
 
             /* Import public key into Ecc using raw import */
             ecc = new Ecc();
             ecc.importPublicRaw(xBytes, yBytes, curveName);
+            ecc.checkKey();
 
             /* Export as X.509 DER */
             byte[] derEncoded = ecc.publicKeyEncode();

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -252,6 +252,7 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
         throws IllegalStateException, ShortBufferException {
 
         byte tmp[] = null;
+        byte paddedSecret[] = null;
         int returnLen = 0;
 
         if (this.state != EngineState.WC_PUBKEY_DONE)
@@ -263,107 +264,115 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
             throw new ShortBufferException("Input buffer is null");
         }
 
-        switch (this.type) {
-            case WC_DH:
+        if (offset < 0) {
+            throw new ShortBufferException(
+                "Output buffer offset cannot be negative: " + offset);
+        }
 
-                /* public key has been stored inside this.dh already */
-                tmp = this.dh.makeSharedSecret();
-                if (tmp == null) {
-                    throw new RuntimeException("Error when creating DH " +
-                            "shared secret");
-                }
+        try {
+            switch (this.type) {
+                case WC_DH:
 
-                /* DH shared secrets can vary in length depending on if they
-                 * are padded or not at the beginning with zero bytes to make
-                 * a total output size matching the prime length.
-                 *
-                 * Native wolfCrypt does not prepend zero bytes to DH shared
-                 * secrets, following RFC 5246 (8.1.2) which instructs to
-                 * strip leading zero bytes.
-                 *
-                 * Sun KeyAgreement DH implementations as of after Java 8
-                 * prepend zero bytes if total length is not equal to prime
-                 * length. This was changed with OpenJDK bug fix JDK-7146728.
-                 *
-                 * BouncyCastle also behaves the same way, prepending zero
-                 * bytes if total secret size is not prime length. This
-                 * follows RFC 2631 (2.1.2).
-                 *
-                 * To match Sun and BC behavior, we pad the secret to primeLen
-                 * by prepending zeros for both generateSecret() methods.
-                 */
-                byte[] paddedSecret = new byte[this.primeLen];
-                Arrays.fill(paddedSecret, (byte)0);
-                System.arraycopy(tmp, 0, paddedSecret,
-                    paddedSecret.length - tmp.length, tmp.length);
+                    /* public key has been stored inside this.dh already */
+                    tmp = this.dh.makeSharedSecret();
+                    if (tmp == null) {
+                        throw new RuntimeException("Error when creating DH " +
+                                "shared secret");
+                    }
 
-                if ((sharedSecret.length - offset) < paddedSecret.length) {
-                    zeroArray(tmp);
-                    zeroArray(paddedSecret);
-                    throw new ShortBufferException(
-                        "Output buffer too small when generating " +
-                        "DH shared secret");
-                }
+                    /* DH shared secrets can vary in length depending on if
+                     * they are padded or not at the beginning with zero bytes
+                     * to make a total output size matching the prime length.
+                     *
+                     * Native wolfCrypt does not prepend zero bytes to DH
+                     * shared secrets, following RFC 5246 (8.1.2) which
+                     * instructs to strip leading zero bytes.
+                     *
+                     * Sun KeyAgreement DH implementations as of after Java 8
+                     * prepend zero bytes if total length is not equal to
+                     * prime length. This was changed with OpenJDK bug fix
+                     * JDK-7146728.
+                     *
+                     * BouncyCastle also behaves the same way, prepending
+                     * zero bytes if total secret size is not prime length.
+                     * This follows RFC 2631 (2.1.2).
+                     *
+                     * To match Sun and BC behavior, we pad the secret to
+                     * primeLen by prepending zeros for both generateSecret()
+                     * methods.
+                     */
+                    paddedSecret = new byte[this.primeLen];
+                    Arrays.fill(paddedSecret, (byte)0);
+                    System.arraycopy(tmp, 0, paddedSecret,
+                        paddedSecret.length - tmp.length, tmp.length);
 
-                /* copy padded array back to output offset */
-                System.arraycopy(paddedSecret, 0, sharedSecret, offset,
-                    paddedSecret.length);
+                    if ((sharedSecret.length - offset) <
+                            paddedSecret.length) {
+                        throw new ShortBufferException(
+                            "Output buffer too small when generating " +
+                            "DH shared secret");
+                    }
 
-                returnLen = this.primeLen;
+                    /* copy padded array back to output offset */
+                    System.arraycopy(paddedSecret, 0, sharedSecret, offset,
+                        paddedSecret.length);
 
-                /* reset state, using same private info and alg params */
-                this.state = EngineState.WC_PRIVKEY_DONE;
+                    returnLen = this.primeLen;
 
-                zeroArray(paddedSecret);
+                    /* reset state, using same private info and alg params */
+                    this.state = EngineState.WC_PRIVKEY_DONE;
 
-                break;
+                    break;
 
-            case WC_ECDH:
+                case WC_ECDH:
 
-                tmp = this.ecPrivate.makeSharedSecret(this.ecPublic);
-                if (tmp == null) {
-                    throw new RuntimeException("Error when creating ECDH " +
-                            "shared secret");
-                }
+                    tmp = this.ecPrivate.makeSharedSecret(this.ecPublic);
+                    if (tmp == null) {
+                        throw new RuntimeException("Error when creating " +
+                                "ECDH shared secret");
+                    }
 
-                if ((sharedSecret.length - offset) < tmp.length) {
-                    zeroArray(tmp);
-                    throw new ShortBufferException(
-                        "Output buffer too small when generating " +
-                        "ECDH shared secret");
-                }
+                    if ((sharedSecret.length - offset) < tmp.length) {
+                        throw new ShortBufferException(
+                            "Output buffer too small when generating " +
+                            "ECDH shared secret");
+                    }
 
-                /* copy array back to output ofset */
-                System.arraycopy(tmp, 0, sharedSecret, offset, tmp.length);
+                    /* copy array back to output offset */
+                    System.arraycopy(tmp, 0, sharedSecret, offset,
+                        tmp.length);
 
-                returnLen = tmp.length;
+                    returnLen = tmp.length;
 
-                /* reset state, using same private info and alg params */
-                byte[] priv = this.ecPrivate.exportPrivate();
-                if (priv == null) {
-                    throw new RuntimeException("Error reseting native " +
-                            "wolfCrypt state during ECDH operation");
-                }
+                    /* reset state, using same private info and alg params */
+                    byte[] priv = this.ecPrivate.exportPrivate();
+                    if (priv == null) {
+                        throw new RuntimeException("Error reseting native " +
+                                "wolfCrypt state during ECDH operation");
+                    }
 
-                this.ecPublic.releaseNativeStruct();
-                this.ecPublic = new Ecc();
-                this.ecPrivate.releaseNativeStruct();
-                this.ecPrivate = new Ecc();
-                try {
-                    this.ecPrivate.importPrivateOnCurve(priv, null,
-                                                        this.curveName);
-                } finally {
-                    zeroArray(priv);
-                }
+                    this.ecPublic.releaseNativeStruct();
+                    this.ecPublic = new Ecc();
+                    this.ecPrivate.releaseNativeStruct();
+                    this.ecPrivate = new Ecc();
+                    try {
+                        this.ecPrivate.importPrivateOnCurve(priv, null,
+                                                            this.curveName);
+                    } finally {
+                        zeroArray(priv);
+                    }
 
-                this.state = EngineState.WC_PRIVKEY_DONE;
+                    this.state = EngineState.WC_PRIVKEY_DONE;
 
-                break;
-        };
+                    break;
+            };
+
+        } finally {
+            zeroArray(tmp);
+            zeroArray(paddedSecret);
+        }
 
         log("generated secret, len: " + returnLen);
-
-        zeroArray(tmp);
 
         return returnLen;
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
@@ -24,6 +24,8 @@ package com.wolfssl.provider.jce;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.Arrays;
+import java.util.Objects;
+import java.security.MessageDigest;
 import java.security.spec.InvalidKeySpecException;
 import javax.crypto.interfaces.PBEKey;
 
@@ -242,35 +244,52 @@ public class WolfCryptPBEKey implements PBEKey {
         }
     }
 
+    /* equals() and hashCode() do not throw after destroy(), but the hash
+     * changes when key bytes are cleared, remove from maps before destroy */
     @Override
     public synchronized int hashCode() {
         return Arrays.hashCode(encoded);
     }
 
     @Override
-    public synchronized boolean equals(Object obj) {
+    public boolean equals(Object obj) {
 
-        PBEKey pKey = null;
+        byte[] pKeyEncoded = null;
+        byte[] thisEncoded = null;
+        byte[] pKeySalt = null;
+        byte[] thisSalt = null;
+        char[] pKeyPass = null;
+        char[] thisPass = null;
+        PBEKey pKey;
 
-        synchronized (destroyedLock) {
-            if (obj == this) {
-                return true;
-            }
+        if (obj == this) {
+            return true;
+        }
 
-            if (!(obj instanceof PBEKey)) {
+        if (!(obj instanceof PBEKey)) {
+            return false;
+        }
+        pKey = (PBEKey)obj;
+
+        try {
+            pKeyEncoded = pKey.getEncoded();
+            pKeySalt = pKey.getSalt();
+            pKeyPass = pKey.getPassword();
+
+            thisEncoded = getEncoded();
+            thisSalt = getSalt();
+            thisPass = getPassword();
+
+            /* MessageDigest.isEqual() for constant-time comparison */
+            if (!MessageDigest.isEqual(pKeyEncoded, thisEncoded)) {
                 return false;
             }
-            pKey = (PBEKey)obj;
 
-            if (!Arrays.equals(pKey.getEncoded(), getEncoded())) {
+            if (!Arrays.equals(pKeySalt, thisSalt)) {
                 return false;
             }
 
-            if (!Arrays.equals(pKey.getSalt(), getSalt())) {
-                return false;
-            }
-
-            if (!Arrays.equals(pKey.getPassword(), getPassword())) {
+            if (!Arrays.equals(pKeyPass, thisPass)) {
                 return false;
             }
 
@@ -278,15 +297,32 @@ public class WolfCryptPBEKey implements PBEKey {
                 return false;
             }
 
-            if (!pKey.getAlgorithm().equals(getAlgorithm())) {
+            if (!Objects.equals(pKey.getAlgorithm(), getAlgorithm())) {
                 return false;
             }
 
-            if (!pKey.getFormat().equals(getFormat())) {
+            if (!Objects.equals(pKey.getFormat(), getFormat())) {
                 return false;
             }
 
             return true;
+
+        } catch (Exception e) {
+            /* Destroyed keys cannot be compared, treat as not equal */
+            return false;
+
+        } finally {
+            /* Only our own copies, the other key's accessors may return
+             * internal references and zeroizing those would destroy it */
+            if (thisEncoded != null) {
+                Arrays.fill(thisEncoded, (byte)0);
+            }
+            if (thisSalt != null) {
+                Arrays.fill(thisSalt, (byte)0);
+            }
+            if (thisPass != null) {
+                Arrays.fill(thisPass, (char)0);
+            }
         }
     }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKey.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKey.java
@@ -187,20 +187,19 @@ public class WolfCryptSecretKey implements SecretKey {
         return this.destroyed;
     }
 
+    /* equals() and hashCode() do not throw after destroy(), but the hash
+     * changes when key bytes are cleared, remove from maps before destroy */
     @Override
     public synchronized int hashCode() {
-        checkDestroyed();
         return Arrays.hashCode(encoded);
     }
 
     @Override
-    public synchronized boolean equals(Object obj) {
+    public boolean equals(Object obj) {
 
         byte[] sKeyEncoded = null;
         byte[] thisEncoded = null;
         SecretKey sKey;
-
-        checkDestroyed();
 
         if (obj == this) {
             return true;
@@ -235,13 +234,12 @@ public class WolfCryptSecretKey implements SecretKey {
             return true;
 
         } catch (Exception e) {
-            /* If encoding fails for either key, cannot be equal */
+            /* Destroyed keys cannot be compared, treat as not equal */
             return false;
 
         } finally {
-            if (sKeyEncoded != null) {
-                Arrays.fill(sKeyEncoded, (byte)0);
-            }
+            /* Only our own copy, the other key's getEncoded() may return
+             * an internal reference and zeroizing that would destroy it */
             if (thisEncoded != null) {
                 Arrays.fill(thisEncoded, (byte)0);
             }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptUtil.java
@@ -70,15 +70,6 @@ public class WolfCryptUtil {
     }
 
     /**
-     * Maximum size of the keystore buffer to mark. We try to set this
-     * high enough to handle any large keystore. Although there is no
-     * upper limit on the size of a keystore, looking at the JDK 23 cacerts
-     * KeyStore file, that is 190kB. We leave ample room for growth here
-     * with 512kB.
-     */
-    private static final int MAX_KEYSTORE_SIZE = 512 * 1024;
-
-    /**
      * Chunk size for reading the keystore. We use 4kB as a happy medium
      * between memory usage and performance.
      */
@@ -98,10 +89,10 @@ public class WolfCryptUtil {
      * format.
      *
      * This method detects the type of the input KeyStore (WKS, JKS, or PKCS12)
-     * and converts it to WKS format if needed. All certificates and keys from
-     * the source KeyStore are transferred to the destination KeyStore. If the
-     * input KeyStore is already of type WKS, the method will return the same
-     * InputStream.
+     * and converts it to WKS format. All certificates and keys from the source
+     * KeyStore are transferred to a newly created WKS KeyStore, including when
+     * the input is already WKS. The input stream is read to the end but not
+     * closed, and the returned stream is always a new InputStream.
      *
      * @param stream Input stream containing a WKS, JKS, or PKCS12 KeyStore
      * @param oldPassword Password used to decrypt KeyStore entries.
@@ -129,6 +120,7 @@ public class WolfCryptUtil {
         boolean wksFound = false;
         boolean jksFound = false;
         KeyStore sourceStore = null;
+        IOException passwordError = null;
 
         log("converting KeyStore InputStream to WKS format");
 
@@ -169,17 +161,15 @@ public class WolfCryptUtil {
             log("JKS to WKS mapping enabled: " + mapJksToWks);
             log("PKCS12 to WKS mapping enabled: " + mapPkcs12ToWks);
 
-            /* Since we will be doing KeyStore type detection by trying to
-             * read the KeyStore, we want to make sure we have the ability
-             * to mark() the stream. If we don't have the ability, we copy
-             * the stream into a ByteArrayOutputStream and then into a
-             * ByteArrayInputStream which is markable. */
-            if (!stream.markSupported()) {
+            /* Copy into a ByteArrayInputStream, which ignores the mark()
+             * read limit, so reset() works after type detection reads any
+             * amount. Other stream types drop the mark on large KeyStores. */
+            if (!(stream instanceof ByteArrayInputStream)) {
                 try {
                     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
                     int numRead;
                     byte[] data = new byte[KEYSTORE_CHUNK_SIZE];
-                    while ((numRead = stream.read(data, 0, data.length)) != -1) {
+                    while ((numRead = stream.read(data)) != -1) {
                         buffer.write(data, 0, numRead);
                     }
                     buffer.flush();
@@ -189,8 +179,8 @@ public class WolfCryptUtil {
                 }
             }
 
-            /* Mark the current position in the stream */
-            stream.mark(MAX_KEYSTORE_SIZE);
+            /* ByteArrayInputStream ignores the read limit */
+            stream.mark(Integer.MAX_VALUE);
 
             /* Try WKS */
             try {
@@ -228,9 +218,11 @@ public class WolfCryptUtil {
                     jksFound = true;
 
                     log("Input KeyStore is in JKS format");
-                } catch (IOException | NoSuchAlgorithmException |
-                        CertificateException e) {
-                    /* Not a JKS KeyStore, continue with other formats */
+                } catch (KeyStoreException | IOException |
+                        NoSuchAlgorithmException | CertificateException e) {
+                    /* Not a JKS KeyStore, or no JKS on this platform as on
+                     * Android, continue with other formats */
+                    passwordError = getPasswordError(e);
                 } finally {
                     stream.reset();
                 }
@@ -258,7 +250,20 @@ public class WolfCryptUtil {
 
                     log("Input KeyStore is in PKCS12 format");
                 } catch (KeyStoreException | NoSuchAlgorithmException |
-                         CertificateException ex) {
+                         CertificateException | IOException ex) {
+                    /* A valid KeyStore opened with the wrong password also
+                     * fails detection, report that over a format error */
+                    IOException pwError = getPasswordError(ex);
+                    if (pwError == null) {
+                        pwError = passwordError;
+                    }
+                    if (pwError != null) {
+                        /* Keep PKCS12 failure visible */
+                        if (pwError != ex) {
+                            pwError.addSuppressed(ex);
+                        }
+                        throw pwError;
+                    }
                     throw new IOException(
                         "Input KeyStore is neither WKS, JKS nor " +
                         "PKCS12 KeyStore format", ex);
@@ -323,6 +328,27 @@ public class WolfCryptUtil {
                  CertificateException e) {
             throw new IOException("Error during KeyStore conversion", e);
         }
+    }
+
+    /**
+     * Return the exception if it reports a wrong KeyStore password.
+     *
+     * KeyStore.load() signals a bad password with an IOException caused by
+     * UnrecoverableKeyException, otherwise indistinguishable from a format
+     * mismatch.
+     *
+     * @param e exception thrown by KeyStore.load()
+     *
+     * @return e if it reports a bad password, otherwise null
+     */
+    private static IOException getPasswordError(Exception e) {
+
+        if ((e instanceof IOException) &&
+            (e.getCause() instanceof UnrecoverableKeyException)) {
+            return (IOException)e;
+        }
+
+        return null;
     }
 
     /**

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptECKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptECKeyFactoryTest.java
@@ -39,6 +39,7 @@ import java.security.PublicKey;
 import java.security.Security;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
@@ -52,6 +53,7 @@ import org.junit.Test;
 
 import com.wolfssl.provider.jce.WolfCryptProvider;
 import com.wolfssl.provider.jce.WolfCryptECParameterSpec;
+import com.wolfssl.provider.jce.WolfCryptECPublicKey;
 import com.wolfssl.wolfcrypt.FeatureDetect;
 import com.wolfssl.wolfcrypt.Ecc;
 import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
@@ -353,6 +355,140 @@ public class WolfCryptECKeyFactoryTest {
         ECPublicKey convertedECKey = (ECPublicKey) convertedKey;
         assertEquals("Public key points should match",
              pubKey.getW(), convertedECKey.getW());
+    }
+
+    /**
+     * Test that generatePublic() rejects ECPublicKeySpec points that are
+     * not valid points on the named curve.
+     */
+    @Test
+    public void testECPublicKeySpecRejectsInvalidPoint() throws Exception {
+
+        if (!FeatureDetect.EccEnabled()) {
+            return;
+        }
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "wolfJCE");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        ECPublicKey pubKey = (ECPublicKey) kpg.generateKeyPair().getPublic();
+
+        ECParameterSpec params = pubKey.getParams();
+        BigInteger validX = pubKey.getW().getAffineX();
+        BigInteger validY = pubKey.getW().getAffineY();
+
+        KeyFactory kf = KeyFactory.getInstance("EC", "wolfJCE");
+
+        /* Unmodified point must still convert */
+        assertNotNull("Valid point should convert",
+            kf.generatePublic(new ECPublicKeySpec(
+                new ECPoint(validX, validY), params)));
+
+        /* Off-curve point sharing the X of a valid point */
+        try {
+            kf.generatePublic(new ECPublicKeySpec(
+                new ECPoint(validX, validY.add(BigInteger.ONE)), params));
+            fail("Off-curve point should be rejected");
+        } catch (InvalidKeySpecException e) {
+            /* expected */
+        }
+
+        /* Small off-curve point */
+        try {
+            kf.generatePublic(new ECPublicKeySpec(
+                new ECPoint(BigInteger.ONE, BigInteger.ONE), params));
+            fail("Off-curve point should be rejected");
+        } catch (InvalidKeySpecException e) {
+            /* expected */
+        }
+
+        /* All-zero point, off curve. ECPoint.POINT_INFINITY cannot be
+         * tested here, ECPublicKeySpec rejects it in its constructor. */
+        try {
+            kf.generatePublic(new ECPublicKeySpec(
+                new ECPoint(BigInteger.ZERO, BigInteger.ZERO), params));
+            fail("All-zero off-curve point should be rejected");
+        } catch (InvalidKeySpecException e) {
+            /* expected */
+        }
+    }
+
+    /**
+     * Test that the WolfCryptECPublicKey(ECPoint, ECParameterSpec)
+     * constructor rejects points not on the named curve.
+     */
+    @Test
+    public void testECPublicKeyConstructorRejectsInvalidPoint()
+        throws Exception {
+
+        if (!FeatureDetect.EccEnabled()) {
+            return;
+        }
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "wolfJCE");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        ECPublicKey pubKey = (ECPublicKey) kpg.generateKeyPair().getPublic();
+
+        ECParameterSpec params = pubKey.getParams();
+        BigInteger validX = pubKey.getW().getAffineX();
+        BigInteger validY = pubKey.getW().getAffineY();
+
+        /* Unmodified point must still be accepted, and round trip */
+        WolfCryptECPublicKey valid =
+            new WolfCryptECPublicKey(pubKey.getW(), params);
+        assertEquals("Round trip should preserve the point",
+            pubKey.getW(), valid.getW());
+        assertArrayEquals("Round trip should preserve the encoding",
+            pubKey.getEncoded(), valid.getEncoded());
+
+        try {
+            new WolfCryptECPublicKey(
+                new ECPoint(validX, validY.add(BigInteger.ONE)), params);
+            fail("Off-curve point should be rejected");
+        } catch (IllegalArgumentException e) {
+            /* expected */
+        }
+
+        try {
+            new WolfCryptECPublicKey(
+                new ECPoint(BigInteger.ONE, BigInteger.ONE), params);
+            fail("Off-curve point should be rejected");
+        } catch (IllegalArgumentException e) {
+            /* expected */
+        }
+
+        /* Negative coordinate. Raw import reinterprets bytes unsigned, so
+         * this would otherwise import as validX and produce a key whose
+         * getW() disagrees with getEncoded(). */
+        BigInteger negX = validX.subtract(BigInteger.ONE.shiftLeft(256));
+        try {
+            new WolfCryptECPublicKey(new ECPoint(negX, validY), params);
+            fail("Negative coordinate should be rejected");
+        } catch (IllegalArgumentException e) {
+            /* expected */
+        }
+
+        /* Coordinate too large for the curve */
+        try {
+            new WolfCryptECPublicKey(
+                new ECPoint(validX.shiftLeft(64), validY), params);
+            fail("Oversized coordinate should be rejected");
+        } catch (IllegalArgumentException e) {
+            /* expected */
+        }
+
+        /* KeyFactory must reject the same inputs as the constructor */
+        KeyFactory kf = KeyFactory.getInstance("EC", "wolfJCE");
+        for (ECPoint bad : new ECPoint[] {
+                new ECPoint(negX, validY),
+                new ECPoint(validX.shiftLeft(64), validY),
+                new ECPoint(validX, validY.add(BigInteger.ONE)) }) {
+            try {
+                kf.generatePublic(new ECPublicKeySpec(bad, params));
+                fail("KeyFactory should reject what the constructor rejects");
+            } catch (InvalidKeySpecException e) {
+                /* expected */
+            }
+        }
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptKeyAgreementTest.java
@@ -356,6 +356,55 @@ public class WolfCryptKeyAgreementTest {
         assertArrayEquals(secretA2, secretC);
     }
 
+    /**
+     * Test that generateSecret() rejects a negative output offset with
+     * ShortBufferException and stays usable afterwards.
+     */
+    @Test
+    public void testDHGenerateSecretNegativeOffset()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InvalidKeyException, InvalidAlgorithmParameterException,
+               ShortBufferException {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        byte[][] pg = Dh.getNamedDhParams(Dh.WC_FFDHE_2048);
+        BigInteger p = new BigInteger(1, pg[0]);
+        BigInteger g = new BigInteger(1, pg[1]);
+
+        KeyPairGenerator keyGen =
+            KeyPairGenerator.getInstance("DH", "wolfJCE");
+        keyGen.initialize(new DHParameterSpec(p, g));
+        KeyPair aPair = keyGen.generateKeyPair();
+        KeyPair bPair = keyGen.generateKeyPair();
+
+        KeyAgreement aKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
+        KeyAgreement bKeyAgree = KeyAgreement.getInstance("DH", "wolfJCE");
+        aKeyAgree.init(aPair.getPrivate());
+        bKeyAgree.init(bPair.getPrivate());
+        aKeyAgree.doPhase(bPair.getPublic(), true);
+        bKeyAgree.doPhase(aPair.getPublic(), true);
+
+        byte secretA[] = new byte[256];
+        byte secretB[] = new byte[256];
+
+        try {
+            aKeyAgree.generateSecret(secretA, -1);
+            fail("Negative offset should throw ShortBufferException");
+        } catch (ShortBufferException e) {
+            /* expected */
+        }
+
+        /* object must remain usable after rejected offset */
+        int secretASz = aKeyAgree.generateSecret(secretA, 0);
+        int secretBSz = bKeyAgree.generateSecret(secretB, 0);
+        assertEquals(secretASz, secretBSz);
+        assertArrayEquals(secretA, secretB);
+    }
+
     /* Minimal DHPublicKey holding a caller-chosen Y, for feeding malicious
      * peer public key values into engineDoPhase() during testing. */
     private static DHPublicKey makeDHPublicKey(final BigInteger y,
@@ -727,6 +776,47 @@ public class WolfCryptKeyAgreementTest {
 
         assertEquals(secretA2Sz, secretCSz);
         assertArrayEquals(secretA2, secretC);
+    }
+
+    /**
+     * Test that generateSecret() rejects a negative output offset with
+     * ShortBufferException and stays usable afterwards.
+     */
+    @Test
+    public void testECDHGenerateSecretNegativeOffset()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               InvalidKeyException, InvalidAlgorithmParameterException,
+               ShortBufferException {
+
+        KeyPairGenerator keyGen =
+            KeyPairGenerator.getInstance("EC", "wolfJCE");
+        keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+
+        KeyPair aPair = keyGen.generateKeyPair();
+        KeyPair bPair = keyGen.generateKeyPair();
+
+        KeyAgreement aKeyAgree = KeyAgreement.getInstance("ECDH", "wolfJCE");
+        KeyAgreement bKeyAgree = KeyAgreement.getInstance("ECDH", "wolfJCE");
+        aKeyAgree.init(aPair.getPrivate());
+        bKeyAgree.init(bPair.getPrivate());
+        aKeyAgree.doPhase(bPair.getPublic(), true);
+        bKeyAgree.doPhase(aPair.getPublic(), true);
+
+        byte secretA[] = new byte[256];
+        byte secretB[] = new byte[256];
+
+        try {
+            aKeyAgree.generateSecret(secretA, -1);
+            fail("Negative offset should throw ShortBufferException");
+        } catch (ShortBufferException e) {
+            /* expected */
+        }
+
+        /* object must remain usable after rejected offset */
+        int secretASz = aKeyAgree.generateSecret(secretA, 0);
+        int secretBSz = bKeyAgree.generateSecret(secretB, 0);
+        assertEquals(secretASz, secretBSz);
+        assertArrayEquals(secretA, secretB);
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
@@ -50,6 +50,7 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.IvParameterSpec;
+import javax.security.auth.DestroyFailedException;
 
 import com.wolfssl.wolfcrypt.Fips;
 import com.wolfssl.wolfcrypt.Aes;
@@ -1147,6 +1148,170 @@ public class WolfCryptSecretKeyFactoryTest {
                 fail("Threading error in generateSecret() threaded test");
             }
         }
+    }
+
+    /**
+     * Test PBEKey equals() and hashCode() behavior, including that
+     * destroyed keys compare as not equal instead of throwing.
+     */
+    @Test
+    public void testPBKDF2WithHmacSHA256_KeyEquals()
+        throws NoSuchAlgorithmException, InvalidKeySpecException,
+               NoSuchProviderException, DestroyFailedException {
+
+        char[] pass = "passwordpassword".toCharArray();
+        byte[] saltA = {
+            (byte)0x78, (byte)0x57, (byte)0x8E, (byte)0x5a,
+            (byte)0x5d, (byte)0x63, (byte)0xcb, (byte)0x06
+        };
+        byte[] saltB = {
+            (byte)0x78, (byte)0x57, (byte)0x8E, (byte)0x5a,
+            (byte)0x5d, (byte)0x63, (byte)0xcb, (byte)0x07
+        };
+        int iterations = 2048;
+        int kLen = 192;
+
+        if (!FeatureDetect.Pbkdf2Enabled() ||
+            !FeatureDetect.HmacSha256Enabled() ||
+            !algoSupported("PBKDF2WithHmacSHA256")) {
+            System.out.println(
+                "Skipped: SecretKeyFactory PBEKey equals test");
+            Assume.assumeTrue(false);
+        }
+
+        SecretKeyFactory sf =
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
+
+        SecretKey keyA = sf.generateSecret(
+            new PBEKeySpec(pass, saltA, iterations, kLen));
+        SecretKey keyB = sf.generateSecret(
+            new PBEKeySpec(pass, saltA, iterations, kLen));
+        SecretKey keyC = sf.generateSecret(
+            new PBEKeySpec(pass, saltB, iterations, kLen));
+
+        assertTrue(keyA.equals(keyA));
+        assertTrue(keyA.equals(keyB));
+        assertTrue(keyB.equals(keyA));
+        assertEquals(keyA.hashCode(), keyB.hashCode());
+
+        assertFalse(keyA.equals(keyC));
+        assertFalse(keyC.equals(keyA));
+        assertFalse(keyA.equals(null));
+        assertFalse(keyA.equals("not a key"));
+
+        keyB.destroy();
+        assertFalse(keyA.equals(keyB));
+        assertFalse(keyB.equals(keyA));
+    }
+
+    /**
+     * Test that PBEKey equals() does not deadlock when two threads
+     * compare the same pair of keys in opposite order.
+     */
+    @Test
+    public void testPBKDF2WithHmacSHA256_ThreadedKeyEquals()
+        throws NoSuchAlgorithmException, InvalidKeySpecException,
+               NoSuchProviderException, InterruptedException {
+
+        char[] pass = "passwordpassword".toCharArray();
+        byte[] salt = {
+            (byte)0x78, (byte)0x57, (byte)0x8E, (byte)0x5a,
+            (byte)0x5d, (byte)0x63, (byte)0xcb, (byte)0x06
+        };
+        int iterations = 2048;
+        int kLen = 192;
+
+        if (!FeatureDetect.Pbkdf2Enabled() ||
+            !FeatureDetect.HmacSha256Enabled() ||
+            !algoSupported("PBKDF2WithHmacSHA256")) {
+            System.out.println(
+                "Skipped: SecretKeyFactory PBEKey equals threaded test");
+            Assume.assumeTrue(false);
+        }
+
+        SecretKeyFactory sf =
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
+
+        final SecretKey keyA = sf.generateSecret(
+            new PBEKeySpec(pass, salt, iterations, kLen));
+        final SecretKey keyB = sf.generateSecret(
+            new PBEKeySpec(pass, salt, iterations, kLen));
+
+        assertNoDeadlockOnCrossThreadEquals(keyA, keyB, "PBEKey");
+    }
+
+    /**
+     * Compare two equal keys from two threads in opposite order, so both
+     * are inside equals() on both keys at once and the opposite lock
+     * ordering can deadlock.
+     */
+    private void assertNoDeadlockOnCrossThreadEquals(final SecretKey keyA,
+        final SecretKey keyB, final String label)
+        throws InterruptedException {
+
+        final LinkedBlockingQueue<Integer> results =
+            new LinkedBlockingQueue<>();
+        final CountDownLatch startGate = new CountDownLatch(1);
+
+        Thread threadA = new Thread(new Runnable() {
+            @Override public void run() {
+                results.add(compareRepeatedly(startGate, keyA, keyB));
+            }
+        });
+        Thread threadB = new Thread(new Runnable() {
+            @Override public void run() {
+                results.add(compareRepeatedly(startGate, keyB, keyA));
+            }
+        });
+
+        /* Daemon threads so the JVM can exit if equals() deadlocks */
+        threadA.setDaemon(true);
+        threadB.setDaemon(true);
+        threadA.start();
+        threadB.start();
+        startGate.countDown();
+        threadA.join(30000);
+        threadB.join(30000);
+
+        if (threadA.isAlive() || threadB.isAlive()) {
+            fail("Deadlock in " + label +
+                ".equals() cross-thread comparison");
+        }
+
+        /* Both threads must have reported, a thread that died on an unchecked
+         * throwable never reaches results.add() */
+        assertEquals("Both threads should report a result for " + label,
+            2, results.size());
+
+        Iterator<Integer> listIterator = results.iterator();
+        while (listIterator.hasNext()) {
+            Integer cur = listIterator.next();
+            if (cur == 1) {
+                fail(label + ".equals() returned false for equal keys");
+            }
+        }
+    }
+
+    /**
+     * Wait on the start gate then compare repeatedly, returning 0 if every
+     * comparison matched and 1 otherwise.
+     */
+    private static int compareRepeatedly(CountDownLatch startGate,
+        SecretKey first, SecretKey second) {
+
+        try {
+            startGate.await();
+        } catch (InterruptedException e) {
+            return 1;
+        }
+
+        for (int i = 0; i < 10000; i++) {
+            if (!first.equals(second)) {
+                return 1;
+            }
+        }
+
+        return 0;
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
@@ -1642,5 +1642,75 @@ public class WolfCryptSecretKeyFactoryTest {
         /* Verify round-trip */
         assertTrue(Arrays.equals(plaintext, decrypted));
     }
+
+    /**
+     * Test SecretKey equals() and hashCode() behavior, including that
+     * destroyed keys compare as not equal instead of throwing.
+     */
+    @Test
+    public void testAESKeyEquals()
+        throws NoSuchAlgorithmException, InvalidKeySpecException,
+               NoSuchProviderException, DestroyFailedException {
+
+        if (!algoSupported("AES")) {
+            return;
+        }
+
+        byte[] keyBytesA = new byte[Aes.KEY_SIZE_128];
+        Arrays.fill(keyBytesA, (byte)0x2A);
+        byte[] keyBytesB = new byte[Aes.KEY_SIZE_128];
+        Arrays.fill(keyBytesB, (byte)0x2B);
+
+        SecretKeyFactory skf =
+            SecretKeyFactory.getInstance("AES", provider);
+
+        SecretKey keyA = skf.generateSecret(
+            new SecretKeySpec(keyBytesA, "AES"));
+        SecretKey keyB = skf.generateSecret(
+            new SecretKeySpec(keyBytesA, "AES"));
+        SecretKey keyC = skf.generateSecret(
+            new SecretKeySpec(keyBytesB, "AES"));
+
+        assertTrue(keyA.equals(keyA));
+        assertTrue(keyA.equals(keyB));
+        assertTrue(keyB.equals(keyA));
+        assertEquals(keyA.hashCode(), keyB.hashCode());
+
+        assertFalse(keyA.equals(keyC));
+        assertFalse(keyC.equals(keyA));
+        assertFalse(keyA.equals(null));
+        assertFalse(keyA.equals("not a key"));
+
+        keyB.destroy();
+        assertFalse(keyA.equals(keyB));
+        assertFalse(keyB.equals(keyA));
+    }
+
+    /**
+     * Test that SecretKey equals() does not deadlock when two threads
+     * compare the same pair of keys in opposite order.
+     */
+    @Test
+    public void testAESThreadedKeyEquals()
+        throws NoSuchAlgorithmException, InvalidKeySpecException,
+               NoSuchProviderException, InterruptedException {
+
+        if (!algoSupported("AES")) {
+            return;
+        }
+
+        byte[] keyBytes = new byte[Aes.KEY_SIZE_128];
+        Arrays.fill(keyBytes, (byte)0x2A);
+
+        SecretKeyFactory skf =
+            SecretKeyFactory.getInstance("AES", provider);
+
+        final SecretKey keyA = skf.generateSecret(
+            new SecretKeySpec(keyBytes, "AES"));
+        final SecretKey keyB = skf.generateSecret(
+            new SecretKeySpec(keyBytes, "AES"));
+
+        assertNoDeadlockOnCrossThreadEquals(keyA, keyB, "SecretKey");
+    }
 }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyTest.java
@@ -270,6 +270,7 @@ public class WolfCryptSecretKeyTest {
         Arrays.fill(keyBytes, (byte)0x42);
 
         WolfCryptSecretKey key = new WolfCryptSecretKey("AES", keyBytes);
+        WolfCryptSecretKey liveKey = new WolfCryptSecretKey("AES", keyBytes);
 
         assertFalse(key.isDestroyed());
 
@@ -277,7 +278,6 @@ public class WolfCryptSecretKeyTest {
 
         assertTrue(key.isDestroyed());
 
-        /* All operations should throw IllegalStateException after destroy */
         try {
             key.getAlgorithm();
             fail("getAlgorithm() should throw IllegalStateException " +
@@ -302,20 +302,11 @@ public class WolfCryptSecretKeyTest {
             /* expected */
         }
 
-        try {
-            key.hashCode();
-            fail("hashCode() should throw IllegalStateException " +
-                 "after destroy");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
-
-        try {
-            key.equals(key);
-            fail("equals() should throw IllegalStateException after destroy");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
+        /* equals() and hashCode() do not throw after destroy */
+        key.hashCode();
+        assertTrue(key.equals(key));
+        assertFalse(key.equals(liveKey));
+        assertFalse(liveKey.equals(key));
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
@@ -31,17 +31,22 @@ import org.junit.runner.Description;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.File;
 import java.math.BigInteger;
 import java.security.Security;
 import java.util.Arrays;
 import java.util.Locale;
+import java.security.Key;
 import java.security.Provider;
 import java.security.KeyStore;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.security.NoSuchAlgorithmException;
@@ -74,6 +79,16 @@ public class WolfCryptUtilTest {
     private static String origMapJksToWks = null;
     private static String origMapPkcs12ToWks = null;
     private static String origIterationCount = null;
+
+    /* Minimum size for the large KeyStore fixtures, asserted so these
+     * tests keep covering conversion of multi hundred kB KeyStores */
+    private static final int LARGE_KEYSTORE_MIN_SIZE = 512 * 1024;
+
+    /* Chain length and entry count for buildLargeKeyStore(). Chain stays
+     * well under the WKS default max of 100 so a lower
+     * wolfjce.wks.maxCertChainLength does not fail these tests early. */
+    private static final int TEST_CHAIN_LENGTH = 50;
+    private static final int TEST_ENTRY_COUNT = 10;
 
     @Rule(order = Integer.MIN_VALUE)
     public TestRule testWatcher = TimedTestWatcher.create();
@@ -137,6 +152,31 @@ public class WolfCryptUtilTest {
     }
 
     /**
+     * Helper method to load a KeyStore file into a byte array
+     * @param path Path to the KeyStore file
+     * @return byte array containing the KeyStore data
+     * @throws Exception if file cannot be read
+     */
+    private static synchronized byte[] loadKeyStoreBytes(String path)
+        throws Exception {
+
+        int bytesRead;
+        byte[] buffer = new byte[1024];
+        FileInputStream fis = new FileInputStream(path);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        try {
+            while ((bytesRead = fis.read(buffer)) != -1) {
+                baos.write(buffer, 0, bytesRead);
+            }
+        } finally {
+            fis.close();
+        }
+
+        return baos.toByteArray();
+    }
+
+    /**
      * Helper method to load a KeyStore file into a ByteArrayInputStream
      * @param path Path to the KeyStore file
      * @return ByteArrayInputStream containing the KeyStore data
@@ -145,17 +185,49 @@ public class WolfCryptUtilTest {
     private static synchronized ByteArrayInputStream loadKeyStoreFile(
         String path) throws Exception {
 
-        FileInputStream fis = new FileInputStream(path);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        return new ByteArrayInputStream(loadKeyStoreBytes(path));
+    }
 
-        byte[] buffer = new byte[1024];
-        int bytesRead;
-        while ((bytesRead = fis.read(buffer)) != -1) {
-            baos.write(buffer, 0, bytesRead);
+    /**
+     * Helper method to build a large KeyStore from repeated server.jks
+     * entries, at least LARGE_KEYSTORE_MIN_SIZE bytes when stored.
+     *
+     * @param type KeyStore type to create ("JKS" or "WKS")
+     * @return byte array holding the stored KeyStore
+     * @throws Exception on error building KeyStore
+     */
+    private static byte[] buildLargeKeyStore(String type) throws Exception {
+
+        KeyStore src = KeyStore.getInstance("JKS");
+        FileInputStream fis = new FileInputStream(TEST_JKS_PATH);
+        try {
+            src.load(fis, PASSWORD);
+        } finally {
+            fis.close();
         }
-        fis.close();
 
-        return new ByteArrayInputStream(baos.toByteArray());
+        Key key = src.getKey(TEST_ALIAS, PASSWORD);
+        Certificate[] chain = src.getCertificateChain(TEST_ALIAS);
+
+        Certificate[] bigChain = new Certificate[TEST_CHAIN_LENGTH];
+        for (int i = 0; i < bigChain.length; i++) {
+            bigChain[i] = chain[i % chain.length];
+        }
+
+        KeyStore big;
+        if (type.equals("WKS")) {
+            big = KeyStore.getInstance("WKS", WKS_PROVIDER);
+        } else {
+            big = KeyStore.getInstance(type);
+        }
+        big.load(null, PASSWORD);
+        for (int i = 0; i < TEST_ENTRY_COUNT; i++) {
+            big.setKeyEntry(TEST_ALIAS + i, key, PASSWORD, bigChain);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        big.store(baos, PASSWORD);
+        return baos.toByteArray();
     }
 
     /**
@@ -503,6 +575,138 @@ public class WolfCryptUtilTest {
         /* Verify the KeyStore was converted and contains entries */
         assertTrue("WKS KeyStore should contain entries",
                   wksStore.size() > 0);
+    }
+
+    /**
+     * Test converting a JKS KeyStore larger than 512kB supplied through
+     * a mark-limited BufferedInputStream.
+     */
+    @Test
+    public void testConvertLargeJksToWksFromBufferedStream()
+        throws Exception {
+        assumeTestFileExists(TEST_JKS_PATH);
+
+        byte[] jksBytes = buildLargeKeyStore("JKS");
+        assertTrue("Test KeyStore should be large",
+            jksBytes.length > LARGE_KEYSTORE_MIN_SIZE);
+
+        InputStream wksStream = WolfCryptUtil.convertKeyStoreToWKS(
+            new BufferedInputStream(new ByteArrayInputStream(jksBytes)),
+            PASSWORD, PASSWORD, true);
+
+        KeyStore wksStore = KeyStore.getInstance("WKS", WKS_PROVIDER);
+        wksStore.load(wksStream, PASSWORD);
+
+        assertEquals("All entries should be converted",
+            TEST_ENTRY_COUNT, wksStore.size());
+        assertNotNull("Private key should exist",
+            wksStore.getKey(TEST_ALIAS + "0", PASSWORD));
+        assertEquals("Certificate chain length should be preserved",
+            TEST_CHAIN_LENGTH,
+            wksStore.getCertificateChain(TEST_ALIAS + "0").length);
+    }
+
+    /**
+     * Test converting a WKS KeyStore larger than 512kB supplied through
+     * a mark-limited BufferedInputStream.
+     */
+    @Test
+    public void testConvertLargeWksToWksFromBufferedStream()
+        throws Exception {
+        assumeTestFileExists(TEST_JKS_PATH);
+
+        byte[] wksBytes = buildLargeKeyStore("WKS");
+        assertTrue("Test KeyStore should be large",
+            wksBytes.length > LARGE_KEYSTORE_MIN_SIZE);
+
+        InputStream wksStream = WolfCryptUtil.convertKeyStoreToWKS(
+            new BufferedInputStream(new ByteArrayInputStream(wksBytes)),
+            PASSWORD, PASSWORD, true);
+
+        KeyStore wksStore = KeyStore.getInstance("WKS", WKS_PROVIDER);
+        wksStore.load(wksStream, PASSWORD);
+
+        assertEquals("All entries should be converted",
+            TEST_ENTRY_COUNT, wksStore.size());
+    }
+
+    /**
+     * Test that a valid KeyStore opened with the wrong password reports
+     * the password problem rather than a format detection failure.
+     */
+    @Test
+    public void testConvertWrongPasswordReportsPasswordError()
+        throws Exception {
+
+        char[] wrongPassword = "wrongPasswordNotTheRealOne".toCharArray();
+
+        String[] paths = { TEST_P12_PATH, TEST_JKS_PATH };
+
+        for (String path : paths) {
+            /* Skip just this path, not the whole method */
+            if (!new File(path).exists()) {
+                continue;
+            }
+
+            try {
+                WolfCryptUtil.convertKeyStoreToWKS(loadKeyStoreFile(path),
+                    wrongPassword, PASSWORD, true);
+                fail("Conversion should fail with wrong password: " + path);
+
+            } catch (IOException e) {
+                assertFalse("Wrong password for " + path + " should not be " +
+                    "reported as a format error: " + e.getMessage(),
+                    e.getMessage().contains("neither WKS, JKS nor PKCS12"));
+
+                assertTrue("Expected UnrecoverableKeyException cause for " +
+                    path + ", got: " + e.getCause(),
+                    e.getCause() instanceof UnrecoverableKeyException);
+            }
+        }
+    }
+
+    /**
+     * Test converting a PKCS12 KeyStore supplied through a mark-limited
+     * BufferedInputStream, covering the third detection branch.
+     */
+    @Test
+    public void testConvertP12FromBufferedStream() throws Exception {
+        assumeTestFileExists(TEST_P12_PATH);
+
+        byte[] p12Bytes = loadKeyStoreBytes(TEST_P12_PATH);
+
+        InputStream wksStream = WolfCryptUtil.convertKeyStoreToWKS(
+            new BufferedInputStream(new ByteArrayInputStream(p12Bytes)),
+            PASSWORD, PASSWORD, true);
+
+        KeyStore wksStore = KeyStore.getInstance("WKS", WKS_PROVIDER);
+        wksStore.load(wksStream, PASSWORD);
+
+        assertTrue("RSA key entry should exist",
+            wksStore.isKeyEntry("client"));
+        assertNotNull("RSA private key should exist",
+            wksStore.getKey("client", PASSWORD));
+    }
+
+    /**
+     * Test that input in no supported KeyStore format fails with a
+     * descriptive exception.
+     */
+    @Test
+    public void testConvertInvalidKeyStoreFormat() throws Exception {
+
+        byte[] garbage = new byte[1024];
+        Arrays.fill(garbage, (byte)0xAB);
+
+        try {
+            WolfCryptUtil.convertKeyStoreToWKS(
+                new ByteArrayInputStream(garbage), PASSWORD, PASSWORD, true);
+            fail("Conversion should fail for invalid KeyStore data");
+        } catch (IOException e) {
+            assertTrue("Exception should indicate unsupported format: " +
+                e.getMessage(),
+                e.getMessage().contains("neither WKS, JKS nor PKCS12"));
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR includes four Fenrir fixes and one related change:

  - **F-5890**: `WolfCryptPBEKey.equals()` no longer holds this key's monitors while calling the other key's synchronized accessors, so each accessor call locks a single key at a time. Secret buffers are zeroized in a `finally` covering every exit path.

  - **WolfCryptSecretKey.equals()**: the same change applied to the sibling class, which had the identical structure. In both classes `equals()` and `hashCode()` now return normally after `destroy()`, so a destroyed key remains usable as a Map or Set member. Accessors still throw.

  - **F-5891**: `convertKeyStoreToWKS()` copies the input into a `ByteArrayInputStream` before KeyStore type detection, so `reset()` succeeds regardless of how much a detection attempt reads. The previous 512kB mark read limit left the mark invalid for larger KeyStores supplied through a mark-limited stream. A valid KeyStore opened with the wrong password now reports the password error instead of a format error.

  - **F-5907**: `engineGenerateSecret(byte[], int)` rejects negative offsets with `ShortBufferException` before any state change, and moves shared secret zeroization into a `finally` so every exit path clears it.

  - **F-5908**: EC public keys built from raw `{x, y}` coordinates are validated with `checkKey()` after import, in both `WolfCryptECKeyFactory.generatePublicFromECSpec()` and the `WolfCryptECPublicKey(ECPoint, ECParameterSpec)` constructor. Raw import only validates the point when native wolfSSL is built with `WOLFSSL_VALIDATE_ECC_IMPORT`