### PR TITLE
Prep for 1.11 release

### DIFF
--- a/.github/workflows/windows-vs.yml
+++ b/.github/workflows/windows-vs.yml
@@ -299,7 +299,7 @@ jobs:
           $content = Get-Content $userSettingsPath -Raw
           Write-Output "Original file size: $($content.Length) characters"
 
-          $newDefines = "#define WOLFSSL_KEY_GEN`n#define HAVE_CRL`n#define OPENSSL_ALL`n#define WOLFSSL_SHA224`n#define HAVE_FFDHE_2048`n#define HAVE_FFDHE_3072`n#define HAVE_FFDHE_4096`n#define HAVE_FFDHE_Q`n#define WOLFSSL_VALIDATE_FFC_IMPORT`n#define WOLFSSL_PUBLIC_MP`n`n"
+          $newDefines = "#define WOLFSSL_KEY_GEN`n#define HAVE_CRL`n#define OPENSSL_ALL`n#define ERROR_QUEUE_PER_THREAD`n#define HAVE_THREAD_LS`n#define WOLFSSL_SHA224`n#define HAVE_FFDHE_2048`n#define HAVE_FFDHE_3072`n#define HAVE_FFDHE_4096`n#define HAVE_FFDHE_Q`n#define WOLFSSL_VALIDATE_FFC_IMPORT`n#define WOLFSSL_PUBLIC_MP`n`n"
 
           # Try multiple possible insertion points
           $insertPoints = @(

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,95 @@
+### wolfCrypt JNI Release 1.11.0 (08/10/2026)
+
+Release 1.11.0 of wolfCrypt JNI and JCE changes the open source license from
+GPLv2 to GPLv3 to match native wolfSSL, and has bug fixes and new features
+including:
+
+**New JCE Functionality:**
+- Add ML-DSA (FIPS 204) Signature, KeyPairGenerator, and KeyFactory support (PR 228)
+- Add ML-KEM (FIPS 203) KeyPairGenerator KeyFactory, and KEM support (PR 232)
+- Add SLH-DSA (FIPS 205) Signature, KeyPairGenerator, and KeyFactory support (PR 235)
+- Add LMS/HSS Signature and KeyFactory support, verify only (PR 233)
+- Add XMSS/XMSS^MT Signature and KeyFactory support, verify only (PR 234)
+- Add PQC key and cert storage to WKS KeyStore (PR 228, 232, 233, 234, 235)
+- Add filtered `SUN`, `SunEC`, and `SunRsaSign` providers for hardened FIPS JREs (PR 226)
+- Add OID alias `1.2.840.10045.2.1` for EC KeyFactory (PR 230)
+
+**New JNI Functionality:**
+- Add ML-DSA (FIPS 204) support via new `MlDsa` class (PR 228)
+- Add ML-KEM (FIPS 203) support via new `MlKem` class (PR 232)
+- Add SLH-DSA (FIPS 205) support via new `SlhDsa` class (PR 235)
+- Add LMS/HSS verify support via new `Lms` class (PR 233)
+- Add XMSS/XMSS^MT verify support via new `Xmss` class (PR 234)
+
+**New Property Support:**
+- Add `wolfjce.wks.maxEntrySize` property to bound WKS KeyStore load allocations (PR 238)
+- Add `wolfssl.filtered.useOriginalNames` property to register filtered providers under original names (PR 246)
+- Add `wolfssl.filtered.*.additionalServices` properties to grant individual filtered services (PR 246)
+- Support `jdk.mlkem.pkcs8.encoding` property when encoding ML-KEM private keys (PR 232)
+
+**JNI and JCE Changes:**
+- Fix AES-GCM encryption failing with an external IV on FIPS v5.1 and later builds (PR 242)
+- Fix PBKDF2 and Ed25519/ML-DSA/ML-KEM/SLH-DSA key export failures on FIPS builds (PR 242)
+- Throw `BadPaddingException` on RSA PKCS#1 v1.5 and OAEP decrypt failures (PR 216)
+- Throw `IllegalBlockSizeException` when RSA decrypt input length does not match the modulus size (PR 216)
+- Use constant-time PKCS#7 unpadding with a uniform `BadPaddingException` (PR 237)
+- Reject AES-GCM and AES-GMAC key and IV reuse for encryption (PR 237, 240)
+- Fix caller-supplied `PSSParameterSpec` being lost during RSASSA-PSS Signature init (PR 248)
+- Fix RSA-PSS verify ignoring the caller-provided salt length (PR 236)
+- Accept legacy RSA OID `1.3.14.3.2.15` in RSA KeyFactory X.509 public key decode (PR 231)
+- Pin internal `KeyFactory` lookups to wolfJCE so generated keys keep CRT parameters (PR 215)
+- Accept `RSAPrivateKey` without `RSAPrivateCrtKey` when its PKCS#8 encoding has CRT components (PR 215)
+- Validate peer DH and ECC public keys in `KeyAgreement.doPhase()` (PR 237)
+- Reject out-of-range DH public keys at KeyFactory and X.509 import (PR 237, 245)
+- Validate EC public keys imported from raw `{x, y}` coordinates (PR 249)
+- Throw `ShortBufferException` for a negative offset in `KeyAgreement.generateSecret()` (PR 249)
+- Reject unsupported DH parameter generation sizes at `AlgorithmParameterGenerator.init()` (PR 229)
+- Reject an invalid `DHParameterSpec` at `KeyPairGenerator.initialize()` rather than at key generation (PR 248)
+- Fix potential deadlock comparing two `WolfCryptPBEKey` or `WolfCryptSecretKey` objects (PR 249)
+- Allow `equals()` and `hashCode()` after `destroy()` so destroyed keys stay usable in a Map or Set (PR 249)
+- Fix usage-scoped `jdk.certpath.disabledAlgorithms` entries acting as blanket disables (PR 240)
+- Match qualified `jdk.certpath.disabledAlgorithms` entries by algorithm name (PR 237)
+- Enforce BasicConstraints `pathLenConstraint` in the Java fallback CertPathBuilder (PR 245)
+- Enforce PKIX `maxPathLength` as a per-iteration depth budget in CertPathBuilder (PR 247)
+- Fix FIPS signature provider comparison in `WolfCryptPKIXCertPathValidator` (PR 238)
+- Fix use-after-free race in the `WolfSSLCertManager` native verify callback (PR 237)
+- Fix race on concurrent FIPS error callback access (PR 237)
+- Fix release and free race in `Curve25519`, `Ed25519`, and other `NativeStruct` subclasses (PR 237, 248)
+- Fix `convertKeyStoreToWKS()` failing on KeyStores larger than 512kB (PR 249)
+- Report password errors instead of format errors when converting a KeyStore with the wrong password (PR 249)
+- Bound allocations and enforce the exact HMAC length when loading a WKS KeyStore (PR 238)
+- Commit WKS KeyStore entries only after the HMAC integrity check passes (PR 238)
+- Throw `UnrecoverableKeyException` instead of `WolfCryptException` from `WolfSSLKeyStore` (PR 212)
+- Bound DER field lengths when parsing DH private and public keys (PR 248)
+- Reject oversized and out-of-range DER lengths in `WolfCryptASN1Util` (PR 245, 247)
+- Bound maximum PEM input size in the PEM to DER conversion functions (PR 248)
+- Fix native `authTag` buffer leak in the AES-GCM and AES-CCM encrypt wrappers (PR 236)
+- Validate caller-provided buffer sizes in the `Rsa`, `Asn`, and `WolfSSLCertManager` JNI wrappers (PR 236)
+- Fix null file and directory argument handling in `CertManagerLoadCA()` (PR 236)
+- Zeroize password, key, and secret buffers across the JNI and JCE layers (PR 212, 245, 247, 248, 249)
+- Fix JNI wrappers ignoring the caller-supplied output offset when writing results (PR 212)
+- Throw exceptions instead of returning error values on JNI wrapper failures (PR 212)
+
+**Example Changes:**
+- Add `MlDsaExample` ML-DSA sign and verify example (PR 228)
+- Add `MlKemExample` ML-KEM encapsulation and decapsulation example (PR 232)
+- Add `XmssExample` XMSS signature verification example (PR 234)
+- Add `SlhDsaExample` SLH-DSA sign and verify example (PR 235)
+- Add ML-DSA certs and WKS KeyStores to `examples/certs` (PR 228)
+- Update Android example project CMakeLists.txt file exclusion list (PR 226, 238, 241)
+- Update Android example project Gradle wrapper scripts (PR 236)
+
+**Testing Changes:**
+- Add GitHub Actions workflows covering LMS, XMSS, and SLH-DSA native build options (PR 233, 234, 235)
+- Add GitHub Actions workflow for filtered providers across JDK 8 through 25 (PR 226)
+- Add known-answer and NIST KAT tests for PQC algorithm support (PR 228, 232, 233, 234, 235)
+- Add wolfJCE and SunJCE interop tests for ML-DSA and ML-KEM (PR 228, 232)
+- GitHub workflow performance and stability improvements (PR 227, 244, 245, 249)
+
+The wolfCrypt JNI/JCE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfcryptjni/. For build
+instructions and more details, please check the manual.
+
 ### wolfCrypt JNI Release 1.10.0 (04/15/2026)
 
 Release 1.10.0 of wolfCrypt JNI and JCE has bug fixes and new features including:

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -138,6 +138,8 @@ section titled `/* Configuration */`:
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
 #define OPENSSL_ALL
+#define ERROR_QUEUE_PER_THREAD
+#define HAVE_THREAD_LS
 #define WOLFSSL_SHA224
 #define HAVE_FFDHE_2048
 #define HAVE_FFDHE_3072
@@ -216,6 +218,7 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define WOLFSSL_KEY_GEN
 #define HAVE_CRL
 #define OPENSSL_ALL
+#define ERROR_QUEUE_PER_THREAD
 #define HAVE_FFDHE_2048
 ```
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ on the current release):
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfcrypt-jni</artifactId>
-            <version>1.10.0-SNAPSHOT</version>
+            <version>1.11.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfCrypt JNI" />
-    <property name="implementation.version" value="1.10" />
+    <property name="implementation.version" value="1.11" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/main/java/" />

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfcrypt-jni</artifactId>
-	<version>1.10.0-SNAPSHOT</version>
+	<version>1.11.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfcrypt-jni</name>
     <url>https://www.wolfssl.com</url>

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -91,7 +91,7 @@ public final class WolfCryptProvider extends Provider {
      */
     @SuppressWarnings("deprecation")
     public WolfCryptProvider() {
-        super("wolfJCE", 1.10, "wolfCrypt JCE Provider");
+        super("wolfJCE", 1.11, "wolfCrypt JCE Provider");
 
         /* Refresh debug flags in case system properties were set after
          * WolfCryptDebug class was first loaded (e.g., via JAVA_OPTS) */

--- a/src/test/java/com/wolfssl/security/providers/test/FilteredProviderFunctionalTest.java
+++ b/src/test/java/com/wolfssl/security/providers/test/FilteredProviderFunctionalTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import java.security.Provider;
 import java.security.Security;
@@ -480,8 +481,20 @@ public class FilteredProviderFunctionalTest {
             Security.setProperty(ADD_PROP,
                 "MessageDigest, .MD5, MessageDigest., , ,,");
 
+            /* Warnings are expected here: capture them to keep the suite
+             * log quiet, assert them so they cannot go missing */
+            AtomicReference<Set<String>> observed = new AtomicReference<>();
+            String warnings = captureStderr(
+                () -> observed.set(serviceKeys(new FilteredSun())));
+
             assertEquals("malformed entries changed the service set",
-                baseline, serviceKeys(new FilteredSun()));
+                baseline, observed.get());
+
+            for (String bad : new String[] {
+                    "'MessageDigest'", "'.MD5'", "'MessageDigest.'" }) {
+                assertTrue("no warning for malformed entry " + bad +
+                    ", stderr was: " + warnings, warnings.contains(bad));
+            }
 
         } finally {
             restoreAdditionalServices(prev);

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesCcmTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesCcmTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.Assume;
@@ -780,7 +781,8 @@ public class AesCcmTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         if (exceptions.size() > 0) {
@@ -843,7 +845,8 @@ public class AesCcmTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         if (exceptions.size() > 0) {
@@ -906,7 +909,8 @@ public class AesCcmTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         if (exceptions.size() > 0) {
@@ -1266,7 +1270,8 @@ public class AesCcmTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         if (exceptions.size() > 0) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesCmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesCmacTest.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.wolfssl.wolfcrypt.Aes;
@@ -315,7 +316,8 @@ public class AesCmacTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         Iterator<Object> i = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesGcmTest.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.Assume;
@@ -934,7 +935,9 @@ public class AesGcmTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<Integer> listIterator = results.iterator();
@@ -1005,7 +1008,9 @@ public class AesGcmTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<Integer> listIterator = results.iterator();
@@ -1075,7 +1080,9 @@ public class AesGcmTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<Integer> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesGmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesGmacTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -565,7 +566,8 @@ public class AesGmacTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         service.shutdown();
 
         for (Exception e : exception) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 import java.nio.ByteBuffer;
@@ -689,7 +690,9 @@ public class AesTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<Integer> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.nio.ByteBuffer;
 
@@ -362,7 +363,9 @@ public class Des3Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<Integer> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import java.security.KeyPairGenerator;
@@ -450,21 +451,17 @@ public class EccTest {
                         alice2.releaseNativeStruct();
                         aliceX963.releaseNativeStruct();
                         bob.releaseNativeStruct();
+                        results.add(failed);
                         latch.countDown();
-                    }
-
-                    if (failed == 1) {
-                        results.add(1);
-                    }
-                    else {
-                        results.add(0);
                     }
                 }
             });
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Look for any failures that happened */
         Iterator<Integer> listIterator = results.iterator();
@@ -572,21 +569,17 @@ public class EccTest {
                             bob.releaseNativeStruct();
                             bob = null;
                         }
+                        results.add(failed);
                         latch.countDown();
-                    }
-
-                    if (failed == 1) {
-                        results.add(1);
-                    }
-                    else {
-                        results.add(0);
                     }
                 }
             });
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Look for any failures that happened */
         Iterator<Integer> listIterator = results.iterator();
@@ -792,7 +785,9 @@ public class EccTest {
         }
 
         /* Wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Verify all results are consistent */
         String[] firstResult = results.poll();
@@ -834,7 +829,9 @@ public class EccTest {
         }
 
         /* Wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Verify all results are consistent */
         String[] firstResult = results.poll();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.wolfssl.wolfcrypt.Fips;
@@ -535,21 +536,17 @@ public class HmacTest {
                         failed = 1;
 
                     } finally {
+                        results.add(failed);
                         latch.countDown();
-                    }
-
-                    if (failed == 1) {
-                        results.add(1);
-                    }
-                    else {
-                        results.add(0);
                     }
                 }
             });
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Look for any failures that happened */
         Iterator<Integer> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Md5Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -255,7 +256,9 @@ public class Md5Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RngTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RngTest.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.wolfssl.wolfcrypt.Rng;
@@ -206,7 +207,9 @@ public class RngTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         Iterator<byte[]> listIterator = results.iterator();
         byte[] current = listIterator.next();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.security.MessageDigest;
 
@@ -927,21 +928,17 @@ public class RsaTest {
                         }
                         priv.releaseNativeStruct();
                         pub.releaseNativeStruct();
+                        results.add(failed);
                         latch.countDown();
-                    }
-
-                    if (failed == 1) {
-                        results.add(1);
-                    }
-                    else {
-                        results.add(0);
                     }
                 }
             });
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* Look for any failures that happened */
         Iterator<Integer> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha224Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha224Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -224,7 +225,9 @@ public class Sha224Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha256Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -239,7 +240,9 @@ public class Sha256Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha384Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -251,7 +252,9 @@ public class Sha384Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha3Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha3Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.Test;
@@ -281,7 +282,9 @@ public class Sha3Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Sha512Test.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -255,7 +256,9 @@ public class Sha512Test {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ShaTest.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.crypto.ShortBufferException;
 
@@ -237,7 +238,9 @@ public class ShaTest {
         }
 
         /* wait for all threads to complete */
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
+        service.shutdown();
 
         /* compare all digests, all should be the same across threads */
         Iterator<byte[]> listIterator = results.iterator();

--- a/src/test/java/com/wolfssl/wolfcrypt/test/WolfCryptTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/WolfCryptTest.java
@@ -36,6 +36,7 @@ import java.security.KeyPairGenerator;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1017,7 +1018,8 @@ public class WolfCryptTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         executor.shutdown();
 
         assertEquals("No thread failures should occur", 0, failures.get());
@@ -1062,7 +1064,8 @@ public class WolfCryptTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         executor.shutdown();
 
         assertEquals("No thread failures should occur", 0, failures.get());
@@ -1177,7 +1180,8 @@ public class WolfCryptTest {
             });
         }
 
-        latch.await();
+        assertTrue("timed out waiting for threads to finish",
+            latch.await(120, TimeUnit.SECONDS));
         executor.shutdown();
 
         assertEquals("No thread failures should occur", 0, failures.get());


### PR DESCRIPTION
This PR preps for the 1.11 release of wolfCrypt JNI/JCE:

- Updates ChangeLog.md
- Bump version to 1.11 in `build.xml`, `pom.xml`, `WolfCryptProvider.java`, `README.md`
- Adds `ERROR_QUEUE_PER_THREAD` and `HAVE_THREAD_LS` to Windows `user_settings.h`