### PR TITLE
fix: allow ECDH KeyAgreement init() reuse

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -603,6 +603,17 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
                 "ECC curve is null, please check algorithm parameters");
         }
 
+        /* Release and recreate native structs to support re-initialization.
+         * JCE requires KeyAgreement.init() to be callable multiple times. */
+        if (this.ecPrivate != null) {
+            this.ecPrivate.releaseNativeStruct();
+        }
+        this.ecPrivate = new Ecc();
+        if (this.ecPublic != null) {
+            this.ecPublic.releaseNativeStruct();
+        }
+        this.ecPublic = new Ecc();
+
         privKeyBytes = ecKey.getS().toByteArray();
 
         try {


### PR DESCRIPTION
`KeyAgreement.init()` could not be called twice on the same ECDH instance.

`wolfCryptInit()` allocates `ecPrivate`/`ecPublic` once per KeyAgreement instance, and `Ecc.importPrivateOnCurve` is guarded by `throwIfKeyExists()`, so a second `engineInit()` threw:

```
java.lang.IllegalStateException: Object already has a key
```

The `javax.crypto.KeyAgreement` javadoc requires `init()` to reset the object to its post-construction state, so it must be callable at any time. `wcInitECDHParams` now releases and recreates both native Ecc structs before importing the private key.

The DH path needs no equivalent change: `Dh.setPrivateKey` overwrites rather than rejecting.

## Verification

`ant test`: 1630 run, 0 failures, 0 errors, 293 skipped.

Pristine master returns byte-identical totals, so the existing suite does not cover this defect and passing it is not evidence of a fix. The behavior change was measured directly instead, running the same probe class against a master-built jar and this branch's jar:

| | master 7d8188f | this branch |
|---|---|---|
| `init()` called twice on one instance | `IllegalStateException: Object already has a key` | both rounds succeed, identical 32-byte secret |

Fixes #221.

## One behavioral note

If `importPrivateOnCurve` throws after the new release-and-recreate step, the instance is left holding fresh but unimported Ecc structs rather than the previously working ones. That is the only consequence beyond the fix itself.

Split out of #239, which retains the AES-GCM streaming feature and the RSA/OAEP work. The invalid-key exception mapping from that PR is in a separate PR against issue #220.
