### PR TITLE
fix: map invalid EC/DH key errors to JCE types

### DIFF
--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
@@ -303,9 +303,19 @@ public class WolfCryptECKeyFactory extends KeyFactorySpi {
                     "ECParameterSpec cannot be null");
             }
 
-            /* Validate ECParameterSpec is supported by wolfCrypt,
-             * throws WolfCryptException if invalid */
-            WolfCryptECParameterSpec.validateParameters(keySpec.getParams());
+            /* Validate ECParameterSpec is supported by wolfCrypt.
+             * validateParameters throws IllegalArgumentException (unchecked)
+             * when the curve is not recognized; wrap it as
+             * InvalidKeySpecException so callers see a
+             * GeneralSecurityException. */
+            try {
+                WolfCryptECParameterSpec.validateParameters(
+                    keySpec.getParams());
+            } catch (IllegalArgumentException e) {
+                throw new InvalidKeySpecException(
+                    "Unsupported curve parameters: " +
+                    e.getMessage(), e);
+            }
 
             /* Get curve name from ECParameterSpec */
             try {
@@ -560,9 +570,19 @@ public class WolfCryptECKeyFactory extends KeyFactorySpi {
                     "ECParameterSpec cannot be null");
             }
 
-            /* Validate ECParameterSpec is supported by wolfCrypt,
-             * throws WolfCryptException if invalid */
-            WolfCryptECParameterSpec.validateParameters(keySpec.getParams());
+            /* Validate ECParameterSpec is supported by wolfCrypt.
+             * validateParameters throws IllegalArgumentException (unchecked)
+             * when the curve is not recognized; wrap it as
+             * InvalidKeySpecException so callers see a
+             * GeneralSecurityException. */
+            try {
+                WolfCryptECParameterSpec.validateParameters(
+                    keySpec.getParams());
+            } catch (IllegalArgumentException e) {
+                throw new InvalidKeySpecException(
+                    "Unsupported curve parameters: " +
+                    e.getMessage(), e);
+            }
 
             /* Get curve name from ECParameterSpec */
             try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -71,6 +71,8 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
     private Ecc ecPrivate = null;
 
     private int primeLen  = 0;
+    private byte[] dhParamP = null;
+    private byte[] dhParamG = null;
     private int curveSize = 0;
     private String curveName = null;
 
@@ -128,10 +130,29 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
                         "Key must be of type DHPublicKey");
                 }
 
-                pubKey = ((DHPublicKey)key).getY().toByteArray();
+                DHPublicKey dhPubKey = (DHPublicKey)key;
+
+                pubKey = dhPubKey.getY().toByteArray();
                 if (pubKey == null) {
                     throw new InvalidKeyException(
                         "Failed to get DH public key from Key object");
+                }
+
+                if (this.dhParamP == null || this.dhParamG == null) {
+                    throw new InvalidKeyException(
+                        "DH private key not initialized with parameters");
+                }
+
+                BigInteger privP = new BigInteger(this.dhParamP);
+                BigInteger privG = new BigInteger(this.dhParamG);
+                BigInteger pubPBig = dhPubKey.getParams().getP();
+                BigInteger pubGBig = dhPubKey.getParams().getG();
+
+                if (!privP.equals(pubPBig) || !privG.equals(pubGBig)) {
+                    throw new InvalidKeyException(
+                        "DH public key parameters do not match " +
+                        "private key parameters, cannot generate " +
+                        "shared secret");
                 }
 
                 /* Validate peer public key (SP 800-56A) before use */
@@ -162,10 +183,35 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
                  * the curve before use. */
                 try {
                     this.ecPublic.publicKeyDecode(pubKey);
+                } catch (WolfCryptException e) {
+                    throw new InvalidKeyException(
+                        "EC public key could not be decoded", e);
+                }
+
+                try {
                     this.ecPublic.checkKey();
                 } catch (WolfCryptException e) {
                     throw new InvalidKeyException(
-                        "ECC public key failed validation", e);
+                        "EC public key point is not on the curve", e);
+                }
+
+                /* Verify the public key curve matches the private key curve.
+                 * A curve mismatch (e.g. secp224r1 public against secp256r1
+                 * private) is caught here so the caller sees
+                 * InvalidKeyException
+                 * rather than a WolfCryptException from makeSharedSecret. */
+                try {
+                    int pubCurveId  = this.ecPublic.getCurveId();
+                    int privCurveId = this.ecPrivate.getCurveId();
+                    if (pubCurveId != privCurveId) {
+                        throw new InvalidKeyException(
+                            "EC public key curve does not match private key " +
+                            "curve (public curveId=" + pubCurveId +
+                            ", private curveId=" + privCurveId + ")");
+                    }
+                } catch (WolfCryptException e) {
+                    throw new InvalidKeyException(
+                        "Failed to validate EC key curve compatibility", e);
                 }
 
                 break;
@@ -326,7 +372,13 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
 
                 case WC_ECDH:
 
-                    tmp = this.ecPrivate.makeSharedSecret(this.ecPublic);
+                    try {
+                        tmp = this.ecPrivate.makeSharedSecret(this.ecPublic);
+                    } catch (WolfCryptException e) {
+                        throw new IllegalStateException(
+                            "Native ECDH shared secret generation failed: " +
+                            e.getMessage(), e);
+                    }
                     if (tmp == null) {
                         throw new RuntimeException("Error when creating " +
                                 "ECDH shared secret");
@@ -477,6 +529,9 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
 
                 this.dh.setParams(paramP, paramG);
 
+                this.dhParamP = paramP;
+                this.dhParamG = paramG;
+
                 primeLen = paramP.length;
 
                 /* prime may have leading zero */
@@ -504,6 +559,9 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
         }
 
         this.dh.setParams(paramP, paramG);
+
+        this.dhParamP = paramP;
+        this.dhParamG = paramG;
 
         primeLen = paramP.length;
 


### PR DESCRIPTION
Invalid EC and DH key inputs threw exception types a caller cannot catch as `GeneralSecurityException`.

`WolfCryptException` extends `RuntimeException`, so code wrapping `doPhase()` or `generatePublic()` in `catch (GeneralSecurityException)` never sees it, which is what #220 reports.

## Changes

`WolfCryptECKeyFactory.engineGeneratePublic` and `engineGeneratePrivate`: `WolfCryptECParameterSpec.validateParameters` throws an unchecked `IllegalArgumentException` when the curve is not recognized. It is now wrapped as `InvalidKeySpecException`.

`WolfCryptKeyAgreement.engineDoPhase`, EC path: decode failure and an off-curve point are now reported separately, both as `InvalidKeyException`, and a public/private curve mismatch is caught before `makeSharedSecret` instead of surfacing from inside it.

`WolfCryptKeyAgreement.engineDoPhase`, DH path: a peer key whose `(p, g)` do not match the private key's is rejected with `InvalidKeyException`. The private key's parameters are recorded at init time for that comparison.

## One hunk does not satisfy #220, and cannot at that call site

The wrap around `ecPrivate.makeSharedSecret` converts `WolfCryptException` into `IllegalStateException`. Both are unchecked, so this does not make the failure catchable as `GeneralSecurityException`.

It cannot be made so there: `engineGenerateSecret(byte[], int)` has a JCA-mandated throws clause of `IllegalStateException, ShortBufferException`, and `ShortBufferException` would misdescribe a native crypto failure. The hunk is included as a portability improvement, since `IllegalStateException` is a JDK type a caller can name without importing wolfSSL classes, but it does not close that part of the issue. Happy to drop it if you would rather this PR stay strictly to what #220 asks for.

The other changes do satisfy the issue: `InvalidKeyException` and `InvalidKeySpecException` are both `GeneralSecurityException` subtypes.

## Verification

`ant test`: 1630 run, 0 failures, 0 errors, 293 skipped, identical to pristine master. Since this PR changes exception types on invalid-key paths, the useful result is that no existing test depended on the old types.

The KeyFactory change was measured directly against a master-built jar:

| | master 7d8188f | this branch |
|---|---|---|
| `generatePublic()` with an unsupported curve | `IllegalArgumentException`, unchecked | `InvalidKeySpecException` |

The Wycheproof runner itself was not run here, so the specific test list in #220 is not claimed as measured. Marked as addressing rather than closing #220 for that reason, plus the open question above.

Split out of #239, which retains the AES-GCM streaming feature and the RSA/OAEP work. The ECDH re-init fix from that PR is in a separate PR against issue #221.
