### PR TITLE
Fenrir fixes for JNI feature gates and FIPS wrappers

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Ecc.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Ecc.h
@@ -59,6 +59,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1check_1key
 
 /*
  * Class:     com_wolfssl_wolfcrypt_Ecc
+ * Method:    wc_ecc_set_rng
+ * Signature: (Lcom/wolfssl/wolfcrypt/Rng;)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1set_1rng
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_Ecc
  * Method:    wc_ecc_shared_secret
  * Signature: (Lcom/wolfssl/wolfcrypt/Ecc;Lcom/wolfssl/wolfcrypt/Rng;)[B
  */

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -253,6 +253,45 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1check_1key(
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1set_1rng
+    (JNIEnv* env, jobject this, jobject rng_object)
+{
+/* wc_ecc_set_rng() is not available in FIPS v2 or selftest bundles */
+#if defined(HAVE_ECC) && (!defined(HAVE_FIPS) || \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
+    !defined(HAVE_SELFTEST)
+    int ret = 0;
+    ecc_key* ecc = NULL;
+    RNG* rng = NULL;
+
+    ecc = (ecc_key*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    rng = (RNG*) getNativeStruct(env, rng_object);
+    if ((*env)->ExceptionOccurred(env)) {
+        return;
+    }
+
+    if (ecc == NULL || rng == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = wc_ecc_set_rng(ecc, rng);
+    }
+
+    if (ret != 0) {
+        throwWolfCryptExceptionFromError(env, ret);
+    }
+
+    LogStr("wc_ecc_set_rng(ecc=%p, rng=%p) = %d\n", ecc, rng, ret);
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1import_1private
   (JNIEnv* env, jobject this, jbyteArray priv_object,
    jbyteArray pub_object, jstring curveName)

--- a/jni/jni_ed25519.c
+++ b/jni/jni_ed25519.c
@@ -553,7 +553,7 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_wolfcrypt_Ed25519_wc_1ed25519_1verif
   (JNIEnv* env, jobject this, jbyteArray sig_in, jbyteArray msg_in)
 {
     int result = -1;
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_SIGN)
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY)
     int ret = 0;
     word32 msglen, siglen;
     ed25519_key* ed25519 = NULL;

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -2160,7 +2160,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaSSL_1Sign_1fips__L
         return BAD_FUNC_ARG;
     }
 
-    rng = (RNG*) getNativeStruct(env, rsa_object);
+    rng = (RNG*) getNativeStruct(env, rng_object);
     if ((*env)->ExceptionOccurred(env)) {
         /* prevent additional JNI calls with pending exception */
         return BAD_FUNC_ARG;
@@ -2217,7 +2217,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaSSL_1Sign_1fips___
         return BAD_FUNC_ARG;
     }
 
-    rng = (RNG*) getNativeStruct(env, rsa_object);
+    rng = (RNG*) getNativeStruct(env, rng_object);
     if ((*env)->ExceptionOccurred(env)) {
         /* prevent additional JNI calls with pending exception */
         return BAD_FUNC_ARG;

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -2402,6 +2402,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPrivateKeyDecode_1
 #if defined(HAVE_FIPS) && !defined(NO_RSA)
 
     jlong tmpIdx;
+    word32 tmpIdx32;
     byte* input = NULL;
     RsaKey* key = NULL;
 
@@ -2419,15 +2420,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPrivateKeyDecode_1
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpIdx32 = (word32)tmpIdx;
 
     #if (HAVE_FIPS_VERSION >= 2)
-        ret = 0; wc_RsaPrivateKeyDecode(input, (word32*) &tmpIdx, key,
-                                        (word32)inSz);
+        ret = wc_RsaPrivateKeyDecode(input, &tmpIdx32, key, (word32)inSz);
     #else
-        ret = 0; RsaPrivateKeyDecode_fips(input, (word32*) &tmpIdx, key,
-                                          (word32)inSz);
+        ret = RsaPrivateKeyDecode_fips(input, &tmpIdx32, key, (word32)inSz);
     #endif
 
+    tmpIdx = (jlong)tmpIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpIdx);
 
     LogStr("RsaPrivateKeyDecode_fips(input, inOutIdx, key=%p, inSz) = %d\n",
@@ -2449,6 +2450,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPrivateKeyDecode_1
 #if defined(HAVE_FIPS) && !defined(NO_RSA)
 
     jlong tmpIdx;
+    word32 tmpIdx32;
     byte* input = NULL;
     RsaKey* key = NULL;
 
@@ -2465,18 +2467,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPrivateKeyDecode_1
         releaseByteArray(env, input_object, input, 1);
         return BAD_FUNC_ARG;
     }
+    tmpIdx32 = (word32)tmpIdx;
 
     #if (HAVE_FIPS_VERSION >= 2)
         ret = (!input || !key)
             ? BAD_FUNC_ARG
-            : wc_RsaPrivateKeyDecode(input, (word32*) &tmpIdx, key, (word32)inSz);
+            : wc_RsaPrivateKeyDecode(input, &tmpIdx32, key, (word32)inSz);
     #else
         ret = (!input || !key)
             ? BAD_FUNC_ARG
-            : RsaPrivateKeyDecode_fips(input, (word32*) &tmpIdx, key,
-                                       (word32)inSz);
+            : RsaPrivateKeyDecode_fips(input, &tmpIdx32, key, (word32)inSz);
     #endif
 
+    tmpIdx = (jlong)tmpIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpIdx);
 
     LogStr("RsaPrivateKeyDecode_fips(input, inOutIdx, key=%p, inSz) = %d\n",
@@ -2500,6 +2503,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPublicKeyDecode_1f
 #if defined(HAVE_FIPS) && !defined(NO_RSA)
 
     jlong tmpIdx;
+    word32 tmpIdx32;
     byte* input = NULL;
     RsaKey* key = NULL;
 
@@ -2516,15 +2520,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPublicKeyDecode_1f
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpIdx32 = (word32)tmpIdx;
 
     #if (HAVE_FIPS_VERSION >= 2)
-        ret = wc_RsaPublicKeyDecode(input, (word32*) &tmpIdx, key,
-                                    (word32)inSz);
+        ret = wc_RsaPublicKeyDecode(input, &tmpIdx32, key, (word32)inSz);
     #else
-        ret = RsaPublicKeyDecode_fips(input, (word32*) &tmpIdx, key,
-                                      (word32)inSz);
+        ret = RsaPublicKeyDecode_fips(input, &tmpIdx32, key, (word32)inSz);
     #endif
 
+    tmpIdx = (jlong)tmpIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpIdx);
 
     LogStr("RsaPublicKeyDecode_fips(input, inOutIdx, key=%p, inSz) = %d\n", key,
@@ -2546,6 +2550,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPublicKeyDecode_1f
 #if defined(HAVE_FIPS) && !defined(NO_RSA)
 
     jlong tmpIdx;
+    word32 tmpIdx32;
     byte* input = NULL;
     RsaKey* key = NULL;
 
@@ -2561,18 +2566,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1RsaPublicKeyDecode_1f
         releaseByteArray(env, input_object, input, 1);
         return BAD_FUNC_ARG;
     }
+    tmpIdx32 = (word32)tmpIdx;
+
     #if (HAVE_FIPS_VERSION >= 2)
         ret = (!input)
             ? BAD_FUNC_ARG
-            : wc_RsaPublicKeyDecode(input, (word32*) &tmpIdx, key,
-                                    (word32)inSz);
+            : wc_RsaPublicKeyDecode(input, &tmpIdx32, key, (word32)inSz);
     #else
         ret = (!input)
             ? BAD_FUNC_ARG
-            : RsaPublicKeyDecode_fips(input, (word32*) &tmpIdx, key,
-                                      (word32)inSz);
+            : RsaPublicKeyDecode_fips(input, &tmpIdx32, key, (word32)inSz);
     #endif
 
+    tmpIdx = (jlong)tmpIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpIdx);
 
     LogStr("RsaPublicKeyDecode_fips(input, inOutIdx, key=%p, inSz) = %d\n", key,
@@ -3723,6 +3729,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhGenerateKeyPair__Lc
     byte* priv = NULL;
     byte* pub  = NULL;
     jlong tmpPrivSz, tmpPubSz;
+    word32 tmpPrivSz32, tmpPubSz32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -3750,8 +3757,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhGenerateKeyPair__Lc
         return BAD_FUNC_ARG;
     }
 
-    ret = wc_DhGenerateKeyPair(key, rng, priv, (word32*) &tmpPrivSz,
-                                         pub,  (word32*) &tmpPubSz);
+    tmpPrivSz32 = (word32)tmpPrivSz;
+    tmpPubSz32  = (word32)tmpPubSz;
+
+    ret = wc_DhGenerateKeyPair(key, rng, priv, &tmpPrivSz32, pub, &tmpPubSz32);
+
+    tmpPrivSz = (jlong)tmpPrivSz32;
+    tmpPubSz  = (jlong)tmpPubSz32;
 
     (*env)->SetLongArrayRegion(env, privSz, 0, 1, &tmpPrivSz);
     if ((*env)->ExceptionOccurred(env)) {
@@ -3787,6 +3799,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhGenerateKeyPair__Lc
     byte* priv = NULL;
     byte* pub  = NULL;
     jlong tmpPrivSz, tmpPubSz;
+    word32 tmpPrivSz32, tmpPubSz32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -3808,13 +3821,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhGenerateKeyPair__Lc
         return BAD_FUNC_ARG;
     }
 
+    tmpPrivSz32 = (word32)tmpPrivSz;
+    tmpPubSz32  = (word32)tmpPubSz;
+
     priv = getByteArray(env, priv_buffer);
     pub  = getByteArray(env, pub_buffer);
 
     ret = (!priv || !pub)
         ? BAD_FUNC_ARG
-        : wc_DhGenerateKeyPair(key, rng, priv, (word32*) &tmpPrivSz,
-                                         pub,  (word32*) &tmpPubSz);
+        : wc_DhGenerateKeyPair(key, rng, priv, &tmpPrivSz32, pub, &tmpPubSz32);
+
+    tmpPrivSz = (jlong)tmpPrivSz32;
+    tmpPubSz  = (jlong)tmpPubSz32;
 
     (*env)->SetLongArrayRegion(env, privSz, 0, 1, &tmpPrivSz);
     if ((*env)->ExceptionOccurred(env)) {
@@ -3854,6 +3872,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhAgree__Lcom_wolfssl
     byte* priv = NULL;
     byte* pub = NULL;
     jlong tmpAgreeSz;
+    word32 tmpAgreeSz32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -3871,10 +3890,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhAgree__Lcom_wolfssl
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpAgreeSz32 = (word32)tmpAgreeSz;
 
-    ret = wc_DhAgree(key, agree, (word32*) &tmpAgreeSz, priv, (word32)privSz,
+    ret = wc_DhAgree(key, agree, &tmpAgreeSz32, priv, (word32)privSz,
                      pub, (word32)pubSz);
 
+    tmpAgreeSz = (jlong)tmpAgreeSz32;
     (*env)->SetLongArrayRegion(env, agreeSz, 0, 1, &tmpAgreeSz);
 
     LogStr("DhAgree(key=%p, agree, agreeSz, priv, privSz, pub, pubSz) = %d\n",
@@ -3905,6 +3926,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhAgree__Lcom_wolfssl
     byte* priv  = NULL;
     byte* pub   = NULL;
     jlong tmpAgreeSz;
+    word32 tmpAgreeSz32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -3915,6 +3937,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhAgree__Lcom_wolfssl
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpAgreeSz32 = (word32)tmpAgreeSz;
 
     agree = getByteArray(env, agree_buffer);
     priv  = getByteArray(env, priv_buffer);
@@ -3922,9 +3945,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhAgree__Lcom_wolfssl
 
     ret = (!key || !agree || !priv || !pub)
         ? BAD_FUNC_ARG
-        : wc_DhAgree(key, agree, (word32*) &tmpAgreeSz, priv, (word32)privSz,
+        : wc_DhAgree(key, agree, &tmpAgreeSz32, priv, (word32)privSz,
                      pub, (word32)pubSz);
 
+    tmpAgreeSz = (jlong)tmpAgreeSz32;
     (*env)->SetLongArrayRegion(env, agreeSz, 0, 1, &tmpAgreeSz);
 
     LogStr("DhAgree(key=%p, agree, agreeSz, priv, privSz, pub, pubSz) = %d\n",
@@ -3956,6 +3980,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhKeyDecode__Ljava_ni
     DhKey* key  = NULL;
     byte* input = NULL;
     jlong tmpInOutIdx;
+    word32 tmpInOutIdx32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -3970,9 +3995,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhKeyDecode__Ljava_ni
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpInOutIdx32 = (word32)tmpInOutIdx;
 
-    ret = wc_DhKeyDecode(input, (word32*) &tmpInOutIdx, key, (word32)inSz);
+    ret = wc_DhKeyDecode(input, &tmpInOutIdx32, key, (word32)inSz);
 
+    tmpInOutIdx = (jlong)tmpInOutIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpInOutIdx);
 
     LogStr("DhKeyDecode(input, &inOutIdx, key=%p, inSz) = %d\n", key, ret);
@@ -3995,6 +4022,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhKeyDecode___3B_3JLc
     DhKey* key  = NULL;
     byte* input = NULL;
     jlong tmpInOutIdx;
+    word32 tmpInOutIdx32;
 
     key = (DhKey*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -4005,12 +4033,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhKeyDecode___3B_3JLc
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpInOutIdx32 = (word32)tmpInOutIdx;
 
     input = getByteArray(env, input_buffer);
     ret = (!input)
         ? BAD_FUNC_ARG
-        : wc_DhKeyDecode(input, (word32*) &tmpInOutIdx, key, (word32)inSz);
+        : wc_DhKeyDecode(input, &tmpInOutIdx32, key, (word32)inSz);
 
+    tmpInOutIdx = (jlong)tmpInOutIdx32;
     (*env)->SetLongArrayRegion(env, inOutIdx, 0, 1, &tmpInOutIdx);
 
     LogStr("DhKeyDecode(input, &inOutIdx, key=%p, inSz) = %d\n", key, ret);
@@ -4111,6 +4141,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhParamsLoad__Ljava_n
     byte* p = getDirectBufferAddress(env, p_buffer);
     byte* g = getDirectBufferAddress(env, g_buffer);
     jlong tmpPInOutSz, tmpGInOutSz;
+    word32 tmpPInOutSz32, tmpGInOutSz32;
 
     if (!input || !p || !g)
         return BAD_FUNC_ARG;
@@ -4125,8 +4156,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhParamsLoad__Ljava_n
         return BAD_FUNC_ARG;
     }
 
-    ret = wc_DhParamsLoad(input, (word32)inSz, p, (word32*) &tmpPInOutSz,
-                                            g, (word32*) &tmpGInOutSz);
+    tmpPInOutSz32 = (word32)tmpPInOutSz;
+    tmpGInOutSz32 = (word32)tmpGInOutSz;
+
+    ret = wc_DhParamsLoad(input, (word32)inSz, p, &tmpPInOutSz32,
+        g, &tmpGInOutSz32);
+
+    tmpPInOutSz = (jlong)tmpPInOutSz32;
+    tmpGInOutSz = (jlong)tmpGInOutSz32;
 
     (*env)->SetLongArrayRegion(env, pInOutSz, 0, 1, &tmpPInOutSz);
     if ((*env)->ExceptionOccurred(env)) {
@@ -4161,6 +4198,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhParamsLoad___3BJ_3B
     byte* p = NULL;
     byte* g = NULL;
     jlong tmpPInOutSz, tmpGInOutSz;
+    word32 tmpPInOutSz32, tmpGInOutSz32;
 
     (*env)->GetLongArrayRegion(env, pInOutSz, 0, 1, &tmpPInOutSz);
     if ((*env)->ExceptionOccurred(env)) {
@@ -4172,20 +4210,26 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhParamsLoad___3BJ_3B
         return BAD_FUNC_ARG;
     }
 
+    tmpPInOutSz32 = (word32)tmpPInOutSz;
+    tmpGInOutSz32 = (word32)tmpGInOutSz;
+
     input = getByteArray(env, input_buffer);
     p = getByteArray(env, p_buffer);
     g = getByteArray(env, g_buffer);
 
     ret = (!input || !p || !g)
         ? BAD_FUNC_ARG
-        : wc_DhParamsLoad(input, (word32)inSz, p, (word32*) &tmpPInOutSz,
-                                               g, (word32*) &tmpGInOutSz);
+        : wc_DhParamsLoad(input, (word32)inSz, p, &tmpPInOutSz32,
+            g, &tmpGInOutSz32);
+
+    tmpPInOutSz = (jlong)tmpPInOutSz32;
+    tmpGInOutSz = (jlong)tmpGInOutSz32;
 
     (*env)->SetLongArrayRegion(env, pInOutSz, 0, 1, &tmpPInOutSz);
     if ((*env)->ExceptionOccurred(env)) {
         releaseByteArray(env, input_buffer, input, 1);
-        releaseByteArray(env, p_buffer, p, 1);
-        releaseByteArray(env, g_buffer, g, 1);
+        releaseByteArray(env, p_buffer, p, ret < 0);
+        releaseByteArray(env, g_buffer, g, ret < 0);
         return BAD_FUNC_ARG;
     }
 
@@ -4200,8 +4244,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1DhParamsLoad___3BJ_3B
     LogHex(g, 0, tmpGInOutSz);
 
     releaseByteArray(env, input_buffer, input, 1);
-    releaseByteArray(env, p_buffer, p, 1);
-    releaseByteArray(env, g_buffer, g, 1);
+    releaseByteArray(env, p_buffer, p, ret < 0);
+    releaseByteArray(env, g_buffer, g, ret < 0);
 
 #endif
 
@@ -4290,6 +4334,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1shared_1secret__
     ecc_key* pub  = NULL;
     byte* out = NULL;
     jlong tmpOutLen;
+    word32 tmpOutLen32;
 
     priv = (ecc_key*) getNativeStruct(env, priv_object);
     if ((!priv) || ((*env)->ExceptionOccurred(env))) {
@@ -4309,9 +4354,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1shared_1secret__
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpOutLen32 = (word32)tmpOutLen;
 
-    ret = wc_ecc_shared_secret(priv, pub, out, (word32*) &tmpOutLen);
+    ret = wc_ecc_shared_secret(priv, pub, out, &tmpOutLen32);
 
+    tmpOutLen = (jlong)tmpOutLen32;
     (*env)->SetLongArrayRegion(env, outlen, 0, 1, &tmpOutLen);
 
     LogStr("ecc_shared_secret(priv=%p, pub=%p, out, outLen) = %d\n", priv, pub,
@@ -4336,6 +4383,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1shared_1secret__
     ecc_key* pub  = NULL;
     byte* out = NULL;
     jlong tmpOutLen;
+    word32 tmpOutLen32;
 
     priv = (ecc_key*) getNativeStruct(env, priv_object);
     if ((!priv) || ((*env)->ExceptionOccurred(env))) {
@@ -4359,9 +4407,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1shared_1secret__
             releaseByteArray(env, out_buffer, out, 1);
             return BAD_FUNC_ARG;
         }
+        tmpOutLen32 = (word32)tmpOutLen;
 
-        ret = wc_ecc_shared_secret(priv, pub, out, (word32*) &tmpOutLen);
+        ret = wc_ecc_shared_secret(priv, pub, out, &tmpOutLen32);
 
+        tmpOutLen = (jlong)tmpOutLen32;
         (*env)->SetLongArrayRegion(env, outlen, 0, 1, &tmpOutLen);
 
         LogStr("out[%u]: [%p]\n", (word32)tmpOutLen, out);
@@ -4449,6 +4499,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1export_1x963__Lc
     ecc_key* key = NULL;
     byte* out = NULL;
     jlong tmpOutLen;
+    word32 tmpOutLen32;
 
     key = (ecc_key*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -4463,9 +4514,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1export_1x963__Lc
     if ((*env)->ExceptionOccurred(env)) {
         return BAD_FUNC_ARG;
     }
+    tmpOutLen32 = (word32)tmpOutLen;
 
-    ret = wc_ecc_export_x963(key, out, (word32*) &tmpOutLen);
+    ret = wc_ecc_export_x963(key, out, &tmpOutLen32);
 
+    tmpOutLen = (jlong)tmpOutLen32;
     (*env)->SetLongArrayRegion(env, outLen, 0, 1, &tmpOutLen);
 
     LogStr("wc_ecc_export_x963(key=%p, out, outLen) = %d\n", key, ret);
@@ -4488,6 +4541,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1export_1x963__Lc
     ecc_key* key = NULL;
     byte* out = NULL;
     jlong tmpOutLen;
+    word32 tmpOutLen32;
 
     key = (ecc_key*) getNativeStruct(env, key_object);
     if ((!key) || ((*env)->ExceptionOccurred(env))) {
@@ -4506,9 +4560,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1ecc_1export_1x963__Lc
             releaseByteArray(env, out_buffer, out, 1);
             return BAD_FUNC_ARG;
         }
+        tmpOutLen32 = (word32)tmpOutLen;
 
-        ret = wc_ecc_export_x963(key, out, (word32*) &tmpOutLen);
+        ret = wc_ecc_export_x963(key, out, &tmpOutLen32);
 
+        tmpOutLen = (jlong)tmpOutLen32;
         (*env)->SetLongArrayRegion(env, outLen, 0, 1, &tmpOutLen);
 
         LogStr("out[%u]: [%p]\n", (word32)tmpOutLen, out);

--- a/jni/jni_rsa.c
+++ b/jni/jni_rsa.c
@@ -1467,6 +1467,7 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1Sign(
     JNIEnv* env, jobject this, jbyteArray data_object, jlong hashType,
     jint mgf, jint saltLen, jobject rng_object)
 {
+    jbyteArray result = NULL;
 #if !defined(NO_RSA) && defined(WC_RSA_PSS)
     int ret = 0;
     int encSz = 0;
@@ -1476,7 +1477,6 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1Sign(
     byte*   signature = NULL;
     word32  dataSz = 0;
     word32  signatureSz = 0;
-    jbyteArray result = NULL;
 
     /* get RsaKey pointer from Java object */
     key = (RsaKey*) getNativeStruct(env, this);
@@ -1572,6 +1572,7 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1Verify(
     JNIEnv* env, jobject this, jbyteArray signature_object,
     jbyteArray data_object, jlong hashType, jint mgf, jint saltLen)
 {
+    jboolean result = JNI_FALSE;
 #if !defined(NO_RSA) && defined(WC_RSA_PSS)
     int ret = 0;
     RsaKey* key = NULL;
@@ -1582,7 +1583,6 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1Verify(
     word32  dataSz = 0;
     word32  outputSz = 0;
     int encSz = 0;
-    jboolean result = JNI_FALSE;
 
     /* get RsaKey pointer from Java object */
     key = (RsaKey*) getNativeStruct(env, this);
@@ -1670,6 +1670,7 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1VerifyCheck(
     jbyteArray data_object, jbyteArray digest_object, jlong hashType,
     jint mgf, jint saltLen)
 {
+    jboolean result = JNI_FALSE;
 #if !defined(NO_RSA) && defined(WC_RSA_PSS)
     int ret = 0;
     RsaKey* key = NULL;
@@ -1679,7 +1680,6 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1VerifyCheck(
     word32  signatureSz = 0;
     word32  dataSz = 0;
     word32  digestSz = 0;
-    jboolean result = JNI_FALSE;
 
     /* get RsaKey pointer from Java object */
     key = (RsaKey*) getNativeStruct(env, this);
@@ -1780,6 +1780,7 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1CheckPadding(
     JNIEnv* env, jobject this, jbyteArray signature_object,
     jbyteArray digest_object, jint hashType, jint mgf, jint saltLen)
 {
+    jboolean result = JNI_FALSE;
 #if !defined(NO_RSA) && defined(WC_RSA_PSS)
     int ret = 0;
     int encSz = 0;
@@ -1790,7 +1791,6 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaPSS_1CheckPadding(
     word32  signatureSz = 0;
     word32  digestSz = 0;
     word32  pssDataSz = 0;
-    jboolean result = JNI_FALSE;
 
     /* get RsaKey pointer from Java object */
     key = (RsaKey*) getNativeStruct(env, this);

--- a/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Ecc.java
@@ -120,6 +120,7 @@ public class Ecc extends NativeStruct {
     private native void wc_ecc_make_key(Rng rng, int size);
     private native void wc_ecc_make_key_ex(Rng rng, int size, String curveName);
     private native void wc_ecc_check_key();
+    private native void wc_ecc_set_rng(Rng rng);
     private native byte[] wc_ecc_shared_secret(Ecc pubKey, Rng rng);
     private native void wc_ecc_import_private(byte[] privKey, byte[] x963Key,
                                               String curveName);
@@ -290,6 +291,33 @@ public class Ecc extends NativeStruct {
 
         synchronized (pointerLock) {
             wc_ecc_check_key();
+        }
+    }
+
+    /**
+     * Associate Rng with this Ecc key.
+     *
+     * @param rng initialized Rng object
+     *
+     * @throws WolfCryptException if native operation fails
+     * @throws IllegalStateException if object has been released
+     */
+    public synchronized void setRng(Rng rng)
+        throws WolfCryptException, IllegalStateException {
+
+        checkStateAndInitialize();
+
+        synchronized (pointerLock) {
+            wc_ecc_set_rng(rng);
+        }
+
+        synchronized (rngLock) {
+            if (this.weOwnRng && this.rng != null && this.rng != rng) {
+                this.rng.free();
+                this.rng.releaseNativeStruct();
+            }
+            this.rng = rng;
+            this.weOwnRng = false;
         }
     }
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
@@ -106,6 +107,74 @@ public class EccTest {
         alice2.importPrivate(alice.exportPrivate(), alice.exportX963());
 
         assertArrayEquals(sharedSecretA, alice2.makeSharedSecret(bob));
+    }
+
+    private static boolean isAndroid() {
+        return System.getProperty("java.runtime.name").contains("Android");
+    }
+
+    @Test
+    public void setRngShouldRetainRngReference() {
+        /* skip on Android, debuggable build GC behavior is unreliable */
+        if (isAndroid()) {
+            return;
+        }
+
+        Ecc ecc = new Ecc();
+        Rng callerRng = new Rng();
+        callerRng.init();
+
+        try {
+            ecc.setRng(callerRng);
+        } catch (WolfCryptException e) {
+            /* skip on FIPS v2 and selftest bundles */
+            if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {
+                Assume.assumeNoException(e);
+            }
+            throw e;
+        }
+
+        /* Drop our only strong reference, the Ecc object must keep the Rng
+         * reachable while native holds a pointer to it */
+        WeakReference<Rng> ref = new WeakReference<Rng>(callerRng);
+        callerRng = null;
+        System.gc();
+
+        assertNotNull("Ecc must retain a strong reference to the Rng " +
+            "set via setRng()", ref.get());
+
+        /* Recover the strong reference for cleanup */
+        callerRng = ref.get();
+        ecc.releaseNativeStruct();
+        if (callerRng != null) {
+            callerRng.free();
+            callerRng.releaseNativeStruct();
+        }
+    }
+
+    @Test
+    public void sharedSecretShouldMatchUsingSetRng() {
+        Ecc alice = new Ecc();
+        Ecc bob = new Ecc();
+
+        synchronized (rngLock) {
+            try {
+                alice.setRng(rng);
+                bob.setRng(rng);
+            } catch (WolfCryptException e) {
+                /* skip on FIPS v2 and selftest bundles */
+                if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {
+                    Assume.assumeNoException(e);
+                }
+                throw e;
+            }
+
+            alice.makeKey(rng, 32);
+            bob.makeKey(rng, 32);
+        }
+
+        assertArrayEquals(alice.makeSharedSecret(bob),
+            bob.makeSharedSecret(alice));
     }
 
     @Test

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/DhFipsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/DhFipsTest.java
@@ -1,0 +1,289 @@
+/* DhFipsTest.java
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.wolfcrypt.test.fips;
+
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+import org.junit.runner.Description;
+
+import com.wolfssl.wolfcrypt.Dh;
+import com.wolfssl.wolfcrypt.FeatureDetect;
+import com.wolfssl.wolfcrypt.Rng;
+import com.wolfssl.wolfcrypt.WolfCrypt;
+import com.wolfssl.wolfcrypt.Fips;
+
+import com.wolfssl.wolfcrypt.test.Util;
+import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
+
+public class DhFipsTest extends FipsTest {
+
+    /* 2048-bit DH prime p, generator g is 2 */
+    private static final String DH_P_2048_HEX =
+        "8E7EC04F98E157D62585624B5283FFD8D33B5EC35F0812FE79227319974A3517" +
+        "6F858116030A97494618413BB82E87BBCFF26A24DF32CAEEF40BE3FBBC18C709" +
+        "A167423BEE8C84539B0FADEBD305039AA800C3AA4A4E3C6B775FAD8E11E30FF9" +
+        "B1E1CA138C9DC9947751A5EE935AC54BB4B045D0CE6BA1AB4D40701D62F4990E" +
+        "A1CB9783CC3769171C8FFDC1AE7A10EC1C82AF9240B67CC667A00F70F2FE9B3B" +
+        "4BDABE25EB42FBEC5533E53A4BA5B60B32B7CBF326D42F620757A11C554B91DF" +
+        "C67B54403807E1A228B858B8D2614BF9D0E08B840F5CA95BA0ADDD641F2481B9" +
+        "0A7C47583D2F14E9C3A5C80440E74B7AA41BBD71025B9F754F424BF382BB5817";
+
+    /* DER group parameters for the prime above, SEQUENCE of
+     * INTEGER p and INTEGER g */
+    private static final String DH_PARAMS_DER_HEX =
+        "30820108" + "0282010100" + DH_P_2048_HEX + "020102";
+
+    @Rule(order = Integer.MIN_VALUE)
+    public TestRule testWatcher = TimedTestWatcher.create();
+
+    /* Rule to skip tests when native wolfSSL is built without DH */
+    @Rule(order = Integer.MIN_VALUE + 1)
+    public TestRule dhAvailable = new TestRule() {
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    Assume.assumeTrue("DH not compiled in native wolfSSL",
+                        FeatureDetect.DhEnabled());
+                    base.evaluate();
+                }
+            };
+        }
+    };
+
+    @BeforeClass
+    public static void setupClass() {
+        System.out.println("JNI FIPS DH Tests");
+
+        if (Fips.enabled) {
+            Fips.setPrivateKeyReadEnable(1, Fips.WC_KEYTYPE_ALL);
+        }
+    }
+
+    @Test
+    public void GenerateKeyPairAndAgreeUsingByteArray() {
+        byte[] p = Util.h2b(DH_P_2048_HEX);
+        byte[] g = Util.h2b("02");
+        Dh alice = new Dh();
+        Dh bob = new Dh();
+        Rng rng = new Rng();
+
+        byte[] alicePriv = new byte[256];
+        byte[] alicePub = new byte[256];
+        byte[] bobPriv = new byte[256];
+        byte[] bobPub = new byte[256];
+        long[] alicePrivSz = { alicePriv.length };
+        long[] alicePubSz = { alicePub.length };
+        long[] bobPrivSz = { bobPriv.length };
+        long[] bobPubSz = { bobPub.length };
+
+        byte[] aliceSecret = new byte[256];
+        byte[] bobSecret = new byte[256];
+        long[] aliceSecretSz = { aliceSecret.length };
+        long[] bobSecretSz = { bobSecret.length };
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+
+        Fips.InitDhKey(alice);
+        Fips.InitDhKey(bob);
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.DhSetKey(alice, p, p.length, g, g.length));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.DhSetKey(bob, p, p.length, g, g.length));
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhGenerateKeyPair(alice, rng,
+            alicePriv, alicePrivSz, alicePub, alicePubSz));
+        assertTrue(alicePrivSz[0] > 0 && alicePrivSz[0] <= alicePriv.length);
+        assertTrue(alicePubSz[0] > 0 && alicePubSz[0] <= alicePub.length);
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhGenerateKeyPair(bob, rng,
+            bobPriv, bobPrivSz, bobPub, bobPubSz));
+        assertTrue(bobPrivSz[0] > 0 && bobPrivSz[0] <= bobPriv.length);
+        assertTrue(bobPubSz[0] > 0 && bobPubSz[0] <= bobPub.length);
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhAgree(alice, aliceSecret,
+            aliceSecretSz, alicePriv, alicePrivSz[0], bobPub, bobPubSz[0]));
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhAgree(bob, bobSecret,
+            bobSecretSz, bobPriv, bobPrivSz[0], alicePub, alicePubSz[0]));
+
+        assertTrue(aliceSecretSz[0] > 0);
+        assertEquals(aliceSecretSz[0], bobSecretSz[0]);
+        assertArrayEquals(
+            Arrays.copyOf(aliceSecret, (int)aliceSecretSz[0]),
+            Arrays.copyOf(bobSecret, (int)bobSecretSz[0]));
+
+        Fips.FreeDhKey(alice);
+        Fips.FreeDhKey(bob);
+        Fips.FreeRng_fips(rng);
+    }
+
+    @Test
+    public void GenerateKeyPairAndAgreeUsingByteBuffer() {
+        byte[] p = Util.h2b(DH_P_2048_HEX);
+        byte[] g = Util.h2b("02");
+        Dh alice = new Dh();
+        Dh bob = new Dh();
+        Rng rng = new Rng();
+
+        ByteBuffer alicePriv = ByteBuffer.allocateDirect(256);
+        ByteBuffer alicePub = ByteBuffer.allocateDirect(256);
+        ByteBuffer bobPriv = ByteBuffer.allocateDirect(256);
+        ByteBuffer bobPub = ByteBuffer.allocateDirect(256);
+        long[] alicePrivSz = { alicePriv.capacity() };
+        long[] alicePubSz = { alicePub.capacity() };
+        long[] bobPrivSz = { bobPriv.capacity() };
+        long[] bobPubSz = { bobPub.capacity() };
+
+        ByteBuffer aliceSecret = ByteBuffer.allocateDirect(256);
+        ByteBuffer bobSecret = ByteBuffer.allocateDirect(256);
+        long[] aliceSecretSz = { aliceSecret.capacity() };
+        long[] bobSecretSz = { bobSecret.capacity() };
+
+        byte[] aliceSecretBytes = null;
+        byte[] bobSecretBytes = null;
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+
+        Fips.InitDhKey(alice);
+        Fips.InitDhKey(bob);
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.DhSetKey(alice, p, p.length, g, g.length));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.DhSetKey(bob, p, p.length, g, g.length));
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhGenerateKeyPair(alice, rng,
+            alicePriv, alicePrivSz, alicePub, alicePubSz));
+        assertTrue(alicePrivSz[0] > 0 &&
+            alicePrivSz[0] <= alicePriv.capacity());
+        assertTrue(alicePubSz[0] > 0 && alicePubSz[0] <= alicePub.capacity());
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhGenerateKeyPair(bob, rng,
+            bobPriv, bobPrivSz, bobPub, bobPubSz));
+        assertTrue(bobPrivSz[0] > 0 && bobPrivSz[0] <= bobPriv.capacity());
+        assertTrue(bobPubSz[0] > 0 && bobPubSz[0] <= bobPub.capacity());
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhAgree(alice, aliceSecret,
+            aliceSecretSz, alicePriv, alicePrivSz[0], bobPub, bobPubSz[0]));
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhAgree(bob, bobSecret,
+            bobSecretSz, bobPriv, bobPrivSz[0], alicePub, alicePubSz[0]));
+
+        assertTrue(aliceSecretSz[0] > 0);
+        assertEquals(aliceSecretSz[0], bobSecretSz[0]);
+
+        aliceSecretBytes = new byte[(int)aliceSecretSz[0]];
+        bobSecretBytes = new byte[(int)bobSecretSz[0]];
+        aliceSecret.get(aliceSecretBytes);
+        bobSecret.get(bobSecretBytes);
+        assertArrayEquals(aliceSecretBytes, bobSecretBytes);
+
+        Fips.FreeDhKey(alice);
+        Fips.FreeDhKey(bob);
+        Fips.FreeRng_fips(rng);
+    }
+
+    @Test
+    public void ParamsLoadUsingByteArray() {
+        byte[] params = Util.h2b(DH_PARAMS_DER_HEX);
+        byte[] p = new byte[256];
+        byte[] g = new byte[4];
+        long[] pSz = { p.length };
+        long[] gSz = { g.length };
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.DhParamsLoad(params, params.length, p, pSz, g, gSz));
+
+        assertEquals(256, pSz[0]);
+        assertEquals(1, gSz[0]);
+        assertArrayEquals(Util.h2b(DH_P_2048_HEX), p);
+        assertEquals(0x02, g[0]);
+    }
+
+    @Test
+    public void ParamsLoadUsingByteBuffer() {
+        ByteBuffer params = ByteBuffer.allocateDirect(512);
+        ByteBuffer p = ByteBuffer.allocateDirect(256);
+        ByteBuffer g = ByteBuffer.allocateDirect(4);
+        long[] pSz = { p.capacity() };
+        long[] gSz = { g.capacity() };
+
+        byte[] pBytes = new byte[256];
+
+        params.put(Util.h2b(DH_PARAMS_DER_HEX));
+        params.limit(params.position());
+        params.rewind();
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.DhParamsLoad(params,
+            params.remaining(), p, pSz, g, gSz));
+
+        assertEquals(256, pSz[0]);
+        assertEquals(1, gSz[0]);
+
+        p.get(pBytes);
+        assertArrayEquals(Util.h2b(DH_P_2048_HEX), pBytes);
+        assertEquals(0x02, g.get(0));
+    }
+
+    @Test
+    public void KeyDecodeBadInputUsingByteArray() {
+        Dh key = new Dh();
+        long[] idx = { 0 };
+
+        /* not a DER sequence */
+        byte[] badKey = Util.h2b("0102030405060708");
+
+        Fips.InitDhKey(key);
+
+        assertTrue(Fips.DhKeyDecode(badKey, idx, key, badKey.length) < 0);
+
+        Fips.FreeDhKey(key);
+    }
+
+    @Test
+    public void KeyDecodeBadInputUsingByteBuffer() {
+        Dh key = new Dh();
+        long[] idx = { 0 };
+        ByteBuffer badKey = ByteBuffer.allocateDirect(8);
+
+        /* not a DER sequence */
+        badKey.put(Util.h2b("0102030405060708"));
+        badKey.rewind();
+
+        Fips.InitDhKey(key);
+
+        assertTrue(Fips.DhKeyDecode(badKey, idx, key,
+            badKey.remaining()) < 0);
+
+        Fips.FreeDhKey(key);
+    }
+}

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/EccFipsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/EccFipsTest.java
@@ -1,0 +1,266 @@
+/* EccFipsTest.java
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.wolfcrypt.test.fips;
+
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+import org.junit.runner.Description;
+
+import com.wolfssl.wolfcrypt.Ecc;
+import com.wolfssl.wolfcrypt.FeatureDetect;
+import com.wolfssl.wolfcrypt.Rng;
+import com.wolfssl.wolfcrypt.WolfCrypt;
+import com.wolfssl.wolfcrypt.WolfCryptError;
+import com.wolfssl.wolfcrypt.WolfCryptException;
+import com.wolfssl.wolfcrypt.Fips;
+
+import com.wolfssl.wolfcrypt.test.TimedTestWatcher;
+
+public class EccFipsTest extends FipsTest {
+
+    /* P-256 key size in bytes */
+    private static final int ECC_KEY_SIZE = 32;
+
+    /* uncompressed x963 export size for P-256, 1 + 32 + 32 */
+    private static final int ECC_X963_SIZE = 65;
+
+    @Rule(order = Integer.MIN_VALUE)
+    public TestRule testWatcher = TimedTestWatcher.create();
+
+    /* Rule to skip tests when native wolfSSL is built without ECC */
+    @Rule(order = Integer.MIN_VALUE + 1)
+    public TestRule eccAvailable = new TestRule() {
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    Assume.assumeTrue("ECC not compiled in native wolfSSL",
+                        FeatureDetect.EccEnabled());
+                    base.evaluate();
+                }
+            };
+        }
+    };
+
+    @BeforeClass
+    public static void setupClass() {
+        System.out.println("JNI FIPS ECC Tests");
+
+        if (Fips.enabled) {
+            Fips.setPrivateKeyReadEnable(1, Fips.WC_KEYTYPE_ALL);
+        }
+    }
+
+    /* setRng is not compiled in for FIPS v2 or selftest bundles, where
+     * ECC operations do not use an associated RNG */
+    private static void setKeyRng(Ecc key, Rng rng) {
+        try {
+            key.setRng(rng);
+        } catch (WolfCryptException e) {
+            if (e.getError() != WolfCryptError.NOT_COMPILED_IN) {
+                throw e;
+            }
+        }
+    }
+
+    @Test
+    public void SharedSecretShouldMatchUsingByteArray() {
+        Ecc alice = new Ecc();
+        Ecc bob = new Ecc();
+        Rng rng = new Rng();
+
+        byte[] aliceSecret = new byte[64];
+        byte[] bobSecret = new byte[64];
+        long[] aliceSecretSz = { aliceSecret.length };
+        long[] bobSecretSz = { bobSecret.length };
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(alice));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(bob));
+
+        setKeyRng(alice, rng);
+        setKeyRng(bob, rng);
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, alice));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, bob));
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_shared_secret(alice, bob, aliceSecret, aliceSecretSz));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_shared_secret(bob, alice, bobSecret, bobSecretSz));
+
+        assertEquals(ECC_KEY_SIZE, aliceSecretSz[0]);
+        assertEquals(ECC_KEY_SIZE, bobSecretSz[0]);
+        assertArrayEquals(Arrays.copyOf(aliceSecret, (int)aliceSecretSz[0]),
+            Arrays.copyOf(bobSecret, (int)bobSecretSz[0]));
+
+        Fips.ecc_free(alice);
+        Fips.ecc_free(bob);
+        Fips.FreeRng_fips(rng);
+    }
+
+    @Test
+    public void SharedSecretShouldMatchUsingByteBuffer() {
+        Ecc alice = new Ecc();
+        Ecc bob = new Ecc();
+        Rng rng = new Rng();
+
+        ByteBuffer aliceSecret = ByteBuffer.allocateDirect(64);
+        ByteBuffer bobSecret = ByteBuffer.allocateDirect(64);
+        long[] aliceSecretSz = { aliceSecret.capacity() };
+        long[] bobSecretSz = { bobSecret.capacity() };
+
+        byte[] aliceSecretBytes = null;
+        byte[] bobSecretBytes = null;
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(alice));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(bob));
+
+        setKeyRng(alice, rng);
+        setKeyRng(bob, rng);
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, alice));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, bob));
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_shared_secret(alice, bob, aliceSecret, aliceSecretSz));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_shared_secret(bob, alice, bobSecret, bobSecretSz));
+
+        assertEquals(ECC_KEY_SIZE, aliceSecretSz[0]);
+        assertEquals(ECC_KEY_SIZE, bobSecretSz[0]);
+
+        aliceSecretBytes = new byte[(int)aliceSecretSz[0]];
+        bobSecretBytes = new byte[(int)bobSecretSz[0]];
+        aliceSecret.get(aliceSecretBytes);
+        bobSecret.get(bobSecretBytes);
+        assertArrayEquals(aliceSecretBytes, bobSecretBytes);
+
+        Fips.ecc_free(alice);
+        Fips.ecc_free(bob);
+        Fips.FreeRng_fips(rng);
+    }
+
+    @Test
+    public void ExportImportX963UsingByteArray() {
+        Ecc alice = new Ecc();
+        Ecc bob = new Ecc();
+        Ecc alicePub = new Ecc();
+        Rng rng = new Rng();
+
+        byte[] exported = new byte[128];
+        long[] exportedSz = { exported.length };
+
+        byte[] secretFromKey = new byte[64];
+        byte[] secretFromImport = new byte[64];
+        long[] secretFromKeySz = { secretFromKey.length };
+        long[] secretFromImportSz = { secretFromImport.length };
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(alice));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(bob));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(alicePub));
+
+        setKeyRng(bob, rng);
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, alice));
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, bob));
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_export_x963(alice, exported, exportedSz));
+        assertEquals(ECC_X963_SIZE, exportedSz[0]);
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_import_x963(
+            Arrays.copyOf(exported, (int)exportedSz[0]), exportedSz[0],
+            alicePub));
+
+        /* secret from the imported public key must match the one from
+         * the original key */
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_shared_secret(bob, alice,
+            secretFromKey, secretFromKeySz));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_shared_secret(bob, alicePub,
+            secretFromImport, secretFromImportSz));
+
+        assertEquals(secretFromKeySz[0], secretFromImportSz[0]);
+        assertArrayEquals(Arrays.copyOf(secretFromKey, (int)secretFromKeySz[0]),
+            Arrays.copyOf(secretFromImport, (int)secretFromImportSz[0]));
+
+        Fips.ecc_free(alice);
+        Fips.ecc_free(bob);
+        Fips.ecc_free(alicePub);
+        Fips.FreeRng_fips(rng);
+    }
+
+    @Test
+    public void ExportX963UsingByteBuffer() {
+        Ecc alice = new Ecc();
+        Rng rng = new Rng();
+
+        ByteBuffer exportedBuf = ByteBuffer.allocateDirect(128);
+        long[] exportedBufSz = { exportedBuf.capacity() };
+
+        byte[] exportedArr = new byte[128];
+        long[] exportedArrSz = { exportedArr.length };
+
+        byte[] exportedBufBytes = null;
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRng_fips(rng));
+        assertEquals(WolfCrypt.SUCCESS, Fips.ecc_init(alice));
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_make_key(rng, ECC_KEY_SIZE, alice));
+
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_export_x963(alice, exportedBuf, exportedBufSz));
+        assertEquals(ECC_X963_SIZE, exportedBufSz[0]);
+
+        /* both overloads must export the same bytes */
+        assertEquals(WolfCrypt.SUCCESS,
+            Fips.ecc_export_x963(alice, exportedArr, exportedArrSz));
+        assertEquals(exportedArrSz[0], exportedBufSz[0]);
+
+        exportedBufBytes = new byte[(int)exportedBufSz[0]];
+        exportedBuf.get(exportedBufBytes);
+        assertArrayEquals(Arrays.copyOf(exportedArr, (int)exportedArrSz[0]),
+            exportedBufBytes);
+
+        Fips.ecc_free(alice);
+        Fips.FreeRng_fips(rng);
+    }
+}

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/RsaFipsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/RsaFipsTest.java
@@ -371,6 +371,74 @@ public class RsaFipsTest extends FipsTest {
     }
 
     @Test
+    public void PrivateKeyDecodeBadInputUsingByteBuffer() {
+        Rsa rsa = new Rsa();
+        long[] idx = { 0 };
+        ByteBuffer badKey = ByteBuffer.allocateDirect(8);
+
+        /* not a DER sequence */
+        badKey.put(Util.h2b("0102030405060708"));
+        badKey.rewind();
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRsaKey_fips(rsa, null));
+
+        assertTrue(Fips.RsaPrivateKeyDecode_fips(badKey, idx, rsa,
+                badKey.remaining()) < 0);
+
+        Fips.FreeRsaKey_fips(rsa);
+    }
+
+    @Test
+    public void PrivateKeyDecodeBadInputUsingByteArray() {
+        Rsa rsa = new Rsa();
+        long[] idx = { 0 };
+
+        /* not a DER sequence */
+        byte[] badKey = Util.h2b("0102030405060708");
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRsaKey_fips(rsa, null));
+
+        assertTrue(Fips.RsaPrivateKeyDecode_fips(badKey, idx, rsa,
+            badKey.length) < 0);
+
+        Fips.FreeRsaKey_fips(rsa);
+    }
+
+    @Test
+    public void PublicKeyDecodeBadInputUsingByteBuffer() {
+        Rsa rsa = new Rsa();
+        long[] idx = { 0 };
+        ByteBuffer badKey = ByteBuffer.allocateDirect(8);
+
+        /* not a DER sequence */
+        badKey.put(Util.h2b("0102030405060708"));
+        badKey.rewind();
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRsaKey_fips(rsa, null));
+
+        assertTrue(Fips.RsaPublicKeyDecode_fips(badKey, idx, rsa,
+            badKey.remaining()) < 0);
+
+        Fips.FreeRsaKey_fips(rsa);
+    }
+
+    @Test
+    public void PublicKeyDecodeBadInputUsingByteArray() {
+        Rsa rsa = new Rsa();
+        long[] idx = { 0 };
+
+        /* not a DER sequence */
+        byte[] badKey = Util.h2b("0102030405060708");
+
+        assertEquals(WolfCrypt.SUCCESS, Fips.InitRsaKey_fips(rsa, null));
+
+        assertTrue(Fips.RsaPublicKeyDecode_fips(badKey, idx, rsa,
+            badKey.length) < 0);
+
+        Fips.FreeRsaKey_fips(rsa);
+    }
+
+    @Test
     public void PrivateKeyDecodeUsingByteArray() {
         byte[] privKey = Util
                 .h2b("308204a40201000282010100c303d12bfe39a432453b53c8842b2a7c"

--- a/src/test/java/com/wolfssl/wolfcrypt/test/fips/WolfCryptFipsTestSuite.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/fips/WolfCryptFipsTestSuite.java
@@ -29,7 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ FipsStatusTest.class, AesFipsTest.class, Des3FipsTest.class,
         ShaFipsTest.class, Sha256FipsTest.class, Sha384FipsTest.class,
         Sha512FipsTest.class, HmacFipsTest.class, RngFipsTest.class,
-        RsaFipsTest.class })
+        RsaFipsTest.class, DhFipsTest.class, EccFipsTest.class })
 public class WolfCryptFipsTestSuite {
 
 }


### PR DESCRIPTION
This PR includes seven Fenrir fixes:

  - **F-8200**: Gate the Ed25519 verify JNI wrapper on `HAVE_ED25519_VERIFY` instead of `HAVE_ED25519_SIGN`, so verify-only and sign-only native builds compile and behave correctly.

  - **F-8201**: Use `word32` locals for the size and index in/out arguments in the FIPS RSA, DH, and ECC wrappers instead of casting `jlong` addresses to `word32*`, making the values correct regardless of platform byte order. Adds new `DhFipsTest` and `EccFipsTest` round-trip coverage for the affected wrappers.

  - **F-8202 / F-8211**: Return the native error code from the ByteBuffer variant of `wc_RsaPrivateKeyDecode_fips` instead of always returning success. Adds bad-input decode tests for all four RSA decode overloads.

  - **F-8203 / F-8210**: Resolve the RNG argument in the FIPS `RsaSSL_Sign` wrappers from the caller's `Rng` object. It was previously fetched from the `Rsa` object.

  - **F-8194**: Declare the RSA-PSS wrapper return variables before the `WC_RSA_PSS` guard, matching the rest of jni_rsa.c, so builds without PSS compile.