### PR TITLE
Buffer sizing, native resource cleanup, and lifecycle fixes

### DIFF
--- a/jni/jni_aescmac.c
+++ b/jni/jni_aescmac.c
@@ -37,6 +37,11 @@
 /* #define WOLFCRYPT_JNI_DEBUG_ON */
 #include <wolfcrypt_jni_debug.h>
 
+#if (LIBWOLFSSL_VERSION_HEX >= 0x05006006) && (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 6)))
+    #define WC_JNI_CMAC_HAVE_FREE
+#endif
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_AesCmac_mallocNativeStruct_1internal(
     JNIEnv* env, jobject this)
 {
@@ -94,10 +99,19 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCmac_native_1free(
     LogStr("free Cmac %p\n", cmac);
 
     if (cmac) {
-        /* Only clear the CMAC struct - do NOT free the memory here.
-         * The base class NativeStruct.xfree() will handle the actual
-         * memory deallocation to avoid double-free. */
+        /* Release and zeroize CMAC context contents, not freeing the
+         * memory since base class NativeStruct.xfree() will handle that
+         * deallocation. */
+#ifdef WC_JNI_CMAC_HAVE_FREE
+        if (cmac->type == WC_CMAC_AES) {
+            wc_CmacFree(cmac);
+        }
+        else {
+            XMEMSET(cmac, 0, sizeof(Cmac));
+        }
+#else
         XMEMSET(cmac, 0, sizeof(Cmac));
+#endif
     }
 #else
     throwNotCompiledInException(env);
@@ -126,6 +140,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCmac_wc_1CmacSetKey(
     if (!cmac || !key) {
         ret = BAD_FUNC_ARG;
     } else {
+#ifdef WC_JNI_CMAC_HAVE_FREE
+        /* Free any active context first, reset() and repeated setKey() calls
+         * reinitialize the same struct */
+        if (cmac->type == WC_CMAC_AES) {
+            wc_CmacFree(cmac);
+        }
+#endif
         /* Initialize CMAC with the provided key */
         ret = wc_InitCmac(cmac, key, keySz, WC_CMAC_AES, NULL);
     }

--- a/jni/jni_curve25519.c
+++ b/jni/jni_curve25519.c
@@ -171,11 +171,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1imp
     pub    = getByteArray(env, pub_object);
     pubSz  = getByteArrayLength(env, pub_object);
 
-    /* pub may be null if only importing private key */
     if (!curve25519 || !priv) {
         ret = BAD_FUNC_ARG;
     } else {
-        /* detect, and later skip, leading zero byte */
+        /* Import raw fixed width private and public key bytes unchanged */
         ret = wc_curve25519_import_private_raw(priv, privSz, pub,
                                                pubSz, curve25519);
     }
@@ -211,11 +210,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1imp
     priv   = getByteArrayIsCopy(env, priv_object, &privIsCopy);
     privSz = getByteArrayLength(env, priv_object);
 
-    /* pub may be null if only importing private key */
     if (!curve25519 || !priv) {
         ret = BAD_FUNC_ARG;
     } else {
-        /* detect, and later skip, leading zero byte */
+        /* Import raw fixed width private key bytes unchanged */
         ret = wc_curve25519_import_private(priv, privSz, curve25519);
     }
 
@@ -251,7 +249,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Curve25519_wc_1curve25519_1imp
     if (!curve25519 || !pub) {
         ret = BAD_FUNC_ARG;
     } else {
-        /* detect, and later skip, leading zero byte */
+        /* Import raw fixed width public key bytes unchanged */
         ret = wc_curve25519_import_public(pub, pubSz, curve25519);
     }
 

--- a/jni/jni_ed25519.c
+++ b/jni/jni_ed25519.c
@@ -202,7 +202,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ed25519_wc_1ed25519_1import_1p
     if (!ed25519 || !priv) {
         ret = BAD_FUNC_ARG;
     } else {
-        /* detect, and later skip, leading zero byte */
+        /* Select private only import when no public key is supplied,
+         * raw fixed width key bytes are passed unchanged */
         if (!pub)
             ret = wc_ed25519_import_private_only(priv, privSz, ed25519);
         else
@@ -278,7 +279,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ed25519_wc_1ed25519_1import_1p
     if (!ed25519 || !priv) {
         ret = BAD_FUNC_ARG;
     } else {
-        /* detect, and later skip, leading zero byte */
+        /* Import raw fixed width private key bytes unchanged */
         ret = wc_ed25519_import_private_only(priv, privSz, ed25519);
     }
 

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -108,10 +108,11 @@ void NativeErrorCallback(const int ok, const int err, const char * const hash)
 #ifdef HAVE_FIPS
     JNIEnv* env;
     jobject localCb = NULL;
-    jclass class;
-    jmethodID method;
+    jclass class = NULL;
+    jmethodID method = NULL;
     jint ret;
-    jstring hashStr;
+    jstring hashStr = NULL;
+    int needsDetach = 0;
 
     if (g_vm == NULL) {
         return;
@@ -128,6 +129,7 @@ void NativeErrorCallback(const int ok, const int err, const char * const hash)
             printf("Failed to attach JNIEnv to thread\n");
             return;
         }
+        needsDetach = 1;
     }
     else if (ret != JNI_OK) {
         printf("Unable to get JNIEnv from JavaVM\n");
@@ -138,63 +140,43 @@ void NativeErrorCallback(const int ok, const int err, const char * const hash)
      * so a concurrent wolfCrypt_1SetCb_1fips() cannot free the global
      * reference while we use it. The rest of this function uses only the
      * local reference and never touches g_errCb again. */
-    if (!g_fipsCbMutexInit || wc_LockMutex(&g_fipsCbMutex) != 0) {
-        return;
-    }
-    if (g_errCb != NULL &&
-        (*env)->GetObjectRefType(env, g_errCb) == JNIGlobalRefType) {
-        localCb = (*env)->NewLocalRef(env, g_errCb);
-    }
-    wc_UnLockMutex(&g_fipsCbMutex);
-
-    /* Return silently if no valid callback was registered */
-    if (localCb == NULL) {
-        if ((*env)->ExceptionOccurred(env)) {
-            (*env)->ExceptionDescribe(env);
-            (*env)->ExceptionClear(env);
+    if (g_fipsCbMutexInit && wc_LockMutex(&g_fipsCbMutex) == 0) {
+        if (g_errCb != NULL &&
+            (*env)->GetObjectRefType(env, g_errCb) == JNIGlobalRefType) {
+            localCb = (*env)->NewLocalRef(env, g_errCb);
         }
-        return;
+        wc_UnLockMutex(&g_fipsCbMutex);
     }
 
-    class = (*env)->GetObjectClass(env, localCb);
-    if (!class) {
-        if ((*env)->ExceptionOccurred(env)) {
-            (*env)->ExceptionDescribe(env);
-            (*env)->ExceptionClear(env);
-        }
-        (*env)->DeleteLocalRef(env, localCb);
-        return;
+    if (localCb != NULL) {
+        class = (*env)->GetObjectClass(env, localCb);
     }
-
-    method = (*env)->GetMethodID(env, class, "errorCallback",
-        "(IILjava/lang/String;)V");
-    if (!method) {
-        if ((*env)->ExceptionOccurred(env)) {
-            (*env)->ExceptionDescribe(env);
-            (*env)->ExceptionClear(env);
-        }
-        (*env)->DeleteLocalRef(env, localCb);
-        return;
+    if (class != NULL) {
+        method = (*env)->GetMethodID(env, class, "errorCallback",
+            "(IILjava/lang/String;)V");
     }
-
-    hashStr = (*env)->NewStringUTF(env, hash);
-    if (!hashStr) {
-        if ((*env)->ExceptionOccurred(env)) {
-            (*env)->ExceptionDescribe(env);
-            (*env)->ExceptionClear(env);
-        }
-        (*env)->DeleteLocalRef(env, localCb);
-        return;
+    if (method != NULL) {
+        hashStr = (*env)->NewStringUTF(env, hash);
     }
-
-    (*env)->CallVoidMethod(env, localCb, method, ok, err, hashStr);
-
-    (*env)->DeleteLocalRef(env, hashStr);
-    (*env)->DeleteLocalRef(env, localCb);
+    if (hashStr != NULL) {
+        (*env)->CallVoidMethod(env, localCb, method, ok, err, hashStr);
+        (*env)->DeleteLocalRef(env, hashStr);
+    }
 
     if ((*env)->ExceptionOccurred(env)) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
+    }
+
+    if (class != NULL) {
+        (*env)->DeleteLocalRef(env, class);
+    }
+    if (localCb != NULL) {
+        (*env)->DeleteLocalRef(env, localCb);
+    }
+
+    if (needsDetach) {
+        (*g_vm)->DetachCurrentThread(g_vm);
     }
 #endif
 }

--- a/jni/jni_fips.c
+++ b/jni/jni_fips.c
@@ -1231,10 +1231,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmDecrypt_1fips__
     LogStr(
         "AesGcmDecrypt_fips(aes=%p, out, in, iv, authTag, authIn) = %d\n",
         aes, ret);
-    LogStr("in[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, in);
-    LogHex(in, 0, AES_BLOCK_SIZE);
-    LogStr("out[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, out);
-    LogHex(out, 0, AES_BLOCK_SIZE);
+    LogStr("in[%u]: [%p]\n", (word32)size, in);
+    LogHex(in, 0, size);
+    LogStr("out[%u]: [%p]\n", (word32)size, out);
+    LogHex(out, 0, size);
     LogStr("iv[%u]: [%p]\n", (word32)ivSz, iv);
     LogHex(iv, 0, ivSz);
     LogStr("authTag[%u]: [%p]\n", (word32)authTagSz, authTag);
@@ -1293,10 +1293,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Fips_wc_1AesGcmDecrypt_1fips__
     LogStr(
         "AesGcmDecrypt_fips(aes=%p, out, in, iv, authTag, authIn) = %d\n",
         aes, ret);
-    LogStr("in[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, in);
-    LogHex(in, 0, AES_BLOCK_SIZE);
-    LogStr("out[%u]: [%p]\n", (word32)AES_BLOCK_SIZE, out);
-    LogHex(out, 0, AES_BLOCK_SIZE);
+    LogStr("in[%u]: [%p]\n", (word32)size, in);
+    LogHex(in, 0, size);
+    LogStr("out[%u]: [%p]\n", (word32)size, out);
+    LogHex(out, 0, size);
     LogStr("iv[%u]: [%p]\n", (word32)ivSz, iv);
     LogHex(iv, 0, ivSz);
     LogStr("authTag[%u]: [%p]\n", (word32)authTagSz, authTag);

--- a/jni/jni_native_struct.c
+++ b/jni/jni_native_struct.c
@@ -61,12 +61,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
     /* Initialize WolfSSLCertManager global mutex for thread-safe callback
      * handling. Done here so it is before any CertManager ops happen. */
     if (wolfSSL_CertManager_init() != 0) {
+        g_vm = NULL;
         return JNI_ERR;
     }
 
     /* Initialize FIPS callback mutex for thread-safe error callback handling.
      * No-op in non-FIPS builds. */
     if (wolfCrypt_JNI_FipsCb_init() != 0) {
+        wolfSSL_CertManager_cleanup();
+        g_vm = NULL;
         return JNI_ERR;
     }
 

--- a/jni/jni_rsa.c
+++ b/jni/jni_rsa.c
@@ -2017,6 +2017,14 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaExportCrtKey(
         q == NULL || dP == NULL || dQ == NULL || u == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    /* Supplied buffer sizes must not exceed actual array lengths */
+    else if (nSz < 0 || nSz > (jlong)(*env)->GetArrayLength(env, n_object) ||
+        eSz < 0 || eSz > (jlong)(*env)->GetArrayLength(env, e_object) ||
+        dSz < 0 || dSz > (jlong)(*env)->GetArrayLength(env, d_object) ||
+        pSz < 0 || pSz > (jlong)(*env)->GetArrayLength(env, p_object) ||
+        qSz < 0 || qSz > (jlong)(*env)->GetArrayLength(env, q_object)) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Export e, n, d, p, q using wc_RsaExportKey() */
         nSz32 = (word32)nSz;

--- a/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/BlockCipher.java
@@ -184,9 +184,22 @@ public abstract class BlockCipher extends NativeStruct {
         checkStateAndInitialize();
         throwIfKeyNotLoaded();
 
-        byte[] output = new byte[input.length];
+        if (input == null || offset < 0 || length < 0 ||
+            ((long)offset + (long)length) > input.length) {
+            throw new WolfCryptException(WolfCryptError.BAD_FUNC_ARG.getCode());
+        }
 
-        native_update(opmode, input, offset, length, output, 0);
+        int outputLength;
+        byte[] output = new byte[length];
+
+        outputLength = native_update(opmode, input, offset, length, output, 0);
+
+        if (outputLength != length) {
+            /* resize array to match actual output length */
+            byte[] tmp = new byte[outputLength];
+            System.arraycopy(output, 0, tmp, 0, outputLength);
+            output = tmp;
+        }
 
         return output;
     }

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesCmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesCmacTest.java
@@ -249,6 +249,27 @@ public class AesCmacTest {
     }
 
     @Test
+    public void aesCmacResetAndRekeyMidStreamShouldWork() {
+        byte[] keyBytes = Util.h2b("2b7e151628aed2a6abf7158809cf4f3c");
+        byte[] dataBytes = Util.h2b("6bc1bee22e409f96e93d7e117393172a");
+        byte[] expectedBytes = Util.h2b("070a16b46b4d4144f79bdd9dd04a287c");
+
+        /* reset() mid stream must reinitialize the active context */
+        AesCmac cmac = new AesCmac();
+        cmac.setKey(keyBytes);
+        cmac.update(new byte[8]);
+        cmac.reset();
+        cmac.update(dataBytes);
+        assertArrayEquals(expectedBytes, cmac.doFinal());
+
+        /* setKey() again without doFinal() must also reinitialize */
+        cmac.setKey(keyBytes);
+        cmac.update(new byte[4]);
+        cmac.setKey(keyBytes);
+        assertArrayEquals(expectedBytes, cmac.doFinal(dataBytes));
+    }
+
+    @Test
     public void aesCmacAlgorithmInfoShouldWork() {
         try {
             String key = "2b7e151628aed2a6abf7158809cf4f3c";

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesEcbTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesEcbTest.java
@@ -127,6 +127,38 @@ public class AesEcbTest {
     }
 
     @Test
+    public void updateWithInvalidLengthShouldThrow() {
+
+        AesEcb enc = new AesEcb();
+        enc.setKey(KEY_128, AesEcb.ENCRYPT_MODE);
+
+        byte[] in = new byte[AesEcb.BLOCK_SIZE];
+
+        try {
+            enc.update(null, 0, AesEcb.BLOCK_SIZE);
+            fail("null input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, 0, -1);
+            fail("negative length should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, AesEcb.BLOCK_SIZE, AesEcb.BLOCK_SIZE);
+            fail("offset plus length beyond input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        enc.releaseNativeStruct();
+    }
+
+    @Test
     public void checkUpdateParams() throws ShortBufferException {
         byte[] input = new byte[AesEcb.BLOCK_SIZE];
         byte[] output = new byte[AesEcb.BLOCK_SIZE];

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesTest.java
@@ -423,6 +423,32 @@ public class AesTest {
     }
 
     @Test
+    public void updateWithPartialLengthShouldSizeOutputToLength() {
+
+        byte[] key = Util.h2b("2b7e151628aed2a6abf7158809cf4f3c");
+        byte[] iv = Util.h2b("000102030405060708090A0B0C0D0E0F");
+        byte[] input = Util.h2b("6bc1bee22e409f96e93d7e117393172a" +
+                                "ae2d8a571e03ac9c9eb76fac45af8e51");
+        byte[] expected = Util.h2b("7649abac8119b246cee98e9b12e9197d");
+
+        /* process only the first block, output must be sized to length */
+        Aes enc = new Aes();
+        enc.setKey(key, iv, Aes.ENCRYPT_MODE);
+        byte[] cipher = enc.update(input, 0, Aes.BLOCK_SIZE);
+        assertEquals(Aes.BLOCK_SIZE, cipher.length);
+        assertArrayEquals(expected, cipher);
+
+        Aes dec = new Aes();
+        dec.setKey(key, iv, Aes.DECRYPT_MODE);
+        byte[] plain = dec.update(cipher, 0, Aes.BLOCK_SIZE);
+        assertEquals(Aes.BLOCK_SIZE, plain.length);
+        assertArrayEquals(Arrays.copyOf(input, Aes.BLOCK_SIZE), plain);
+
+        enc.releaseNativeStruct();
+        dec.releaseNativeStruct();
+    }
+
+    @Test
     public void reuseObject() {
 
         byte[] key = Util.h2b("2b7e151628aed2a6abf7158809cf4f3c");
@@ -455,6 +481,41 @@ public class AesTest {
         /* free again */
         enc.releaseNativeStruct();
         dec.releaseNativeStruct();
+    }
+
+    @Test
+    public void updateWithInvalidLengthShouldThrow() {
+
+        byte[] key = Util.h2b("2b7e151628aed2a6abf7158809cf4f3c");
+        byte[] iv = Util.h2b("000102030405060708090A0B0C0D0E0F");
+
+        Aes enc = new Aes();
+        enc.setKey(key, iv, Aes.ENCRYPT_MODE);
+
+        byte[] in = new byte[Aes.BLOCK_SIZE];
+
+        try {
+            enc.update(null, 0, Aes.BLOCK_SIZE);
+            fail("null input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, 0, -1);
+            fail("negative length should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, Aes.BLOCK_SIZE, Aes.BLOCK_SIZE);
+            fail("offset plus length beyond input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        enc.releaseNativeStruct();
     }
 
     @Test

--- a/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/Des3Test.java
@@ -255,6 +255,42 @@ public class Des3Test {
     }
 
     @Test
+    public void updateWithInvalidLengthShouldThrow() {
+
+        byte[] key = Util.h2b("e61a38548694f1fd8cef251c518" +
+                              "cc70bb613751c1ce52aa8");
+        byte[] iv = Util.h2b("48a8ceb8551fd4ad");
+
+        Des3 enc = new Des3();
+        enc.setKey(key, iv, Des3.ENCRYPT_MODE);
+
+        byte[] in = new byte[Des3.BLOCK_SIZE];
+
+        try {
+            enc.update(null, 0, Des3.BLOCK_SIZE);
+            fail("null input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, 0, -1);
+            fail("negative length should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        try {
+            enc.update(in, Des3.BLOCK_SIZE, Des3.BLOCK_SIZE);
+            fail("offset plus length beyond input should throw");
+        } catch (WolfCryptException e) {
+            /* expected */
+        }
+
+        enc.releaseNativeStruct();
+    }
+
+    @Test
     public void reuseObject() {
 
         byte[] key = Util.h2b("e61a38548694f1fd8cef251c518" +

--- a/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/RsaTest.java
@@ -747,6 +747,27 @@ public class RsaTest {
         assertTrue(dQSz[0] >= 127 && dQSz[0] <= 129);
         assertTrue(uSz[0] >= 127 && uSz[0] <= 129);
 
+        /* Capacity larger than the actual array must be rejected */
+        byte[] shortN = new byte[1];
+        nSz[0] = 256;
+        try {
+            key.exportRawPrivateKey(shortN, nSz, e, eSz, d, dSz, p, pSz,
+                q, qSz, dP, dPSz, dQ, dQSz, u, uSz);
+            fail("exportRawPrivateKey should reject oversized nSz");
+        } catch (WolfCryptException ex) {
+            /* expected */
+        }
+
+        /* Negative capacity must be rejected */
+        nSz[0] = -1;
+        try {
+            key.exportRawPrivateKey(n, nSz, e, eSz, d, dSz, p, pSz,
+                q, qSz, dP, dPSz, dQ, dQSz, u, uSz);
+            fail("exportRawPrivateKey should reject negative nSz");
+        } catch (WolfCryptException ex) {
+            /* expected */
+        }
+
         key.releaseNativeStruct();
     }
 


### PR DESCRIPTION
This PR includes 11 Fenrir fixes:

  - **F-9991**: Size `BlockCipher.update()` output from requested length instead of the full input array
  - **F-9992**: Validate caller-supplied buffer sizes against actual array lengths in the RsaExportCrtKey before native export
  - **F-9993**: Free active CMAC context with `wc_CmacFree()` on release and before reinitializing in setKey/reset
  - **F-9994**: Log the requested operation size instead of a fixed AES_BLOCK_SIZE in FIPS GCM decrypt wrapper
  - **F-9995**: Detach natively attached threads and release all local references in the FIPS error callback
  - **F-9996**: Clean up the CertManager mutex and stored JavaVM pointer when JNI_OnLoad fails partway through init
  - **F-9986 / F-9987 / F-9988**: Correct copied import comments in the Curve25519 wrappers
  - **F-9989 / F-9990**: Correct the same copied import comments in the Ed25519 wrappers