### PR TITLE
Fixes for CertPathChecker ordering and build/example script path hardening

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -720,8 +720,8 @@
         <taskdef
             resource="edu/umd/cs/findbugs/anttask/tasks.properties">
             <classpath>
-                <fileset dir="${env.SPOTBUGS_HOME}/lib"
-                         includes="*.jar"/>
+                <pathelement
+                    location="${env.SPOTBUGS_HOME}/lib/spotbugs-ant.jar"/>
             </classpath>
         </taskdef>
     </target>

--- a/examples/certs/systemcerts/system-cacerts-to-wks.sh
+++ b/examples/certs/systemcerts/system-cacerts-to-wks.sh
@@ -23,20 +23,30 @@
 # WKS type.
 #
 
-# Export library paths for Linux and Mac to find shared JNI library
-export LD_LIBRARY_PATH=../../../lib:$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=../../../lib:$DYLD_LIBRARY_PATH
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
 
-OUTDIR=`pwd`
+# Export library paths for Linux and Mac to find shared JNI library
+export LD_LIBRARY_PATH="$SCRIPT_DIR/../../../lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="$SCRIPT_DIR/../../../lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+
+# Converted KeyStores are written next to this script
+OUTDIR="$SCRIPT_DIR"
 
 # First argument can be passed in to represent path to
-# wolfcrypt-jni.jar provider JAR. If not given, use default.
+# wolfcrypt-jni.jar provider JAR, must be a single JAR file
+# path. If not given, use default.
 if [ -z "$1" ]; then
     # default wolfcrypt-jni.jar path
-    PROVIDER_PATH="../../../lib/wolfcrypt-jni.jar"
+    PROVIDER_PATH="$SCRIPT_DIR/../../../lib/wolfcrypt-jni.jar"
 else
     # use custom provider path
     PROVIDER_PATH=$1
+fi
+
+if [ ! -f "$PROVIDER_PATH" ]; then
+    echo "Provider JAR not found: $PROVIDER_PATH"
+    exit 1
 fi
 
 # ARGS: <input-keystore-name> <output-keystore-name> <in-password> <out-password> <java home>
@@ -97,8 +107,8 @@ echo "    $OS $ARCH"
 echo "Java Home = $javaHome"
 echo ""
 
-if [ ! -d $OUTDIR ]; then
-    mkdir $OUTDIR
+if [ ! -d "$OUTDIR" ]; then
+    mkdir "$OUTDIR"
 fi
 
 if [ -f "$javaHome/$CACERTS_JDK9" ]; then
@@ -107,8 +117,8 @@ if [ -f "$javaHome/$CACERTS_JDK9" ]; then
     echo "    TO:   $OUTDIR/cacerts.wks"
     echo "    IN PASS (default): changeit"
     echo "    OUT PASS: changeitchangeit"
-    if [ -f $OUTDIR/cacerts.wks ]; then
-        rm $OUTDIR/cacerts.wks
+    if [ -f "$OUTDIR/cacerts.wks" ]; then
+        rm "$OUTDIR/cacerts.wks"
     fi
     jks_to_wks "$javaHome/$CACERTS_JDK9" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
 fi
@@ -119,8 +129,8 @@ if [ -f "$javaHome/$CACERTS_JDK8" ]; then
     echo "    TO:   $OUTDIR/cacerts.wks"
     echo "    IN PASS (default): changeit"
     echo "    OUT PASS: changeitchangeit"
-    if [ -f $OUTDIR/cacerts.wks ]; then
-        rm $OUTDIR/cacerts.wks
+    if [ -f "$OUTDIR/cacerts.wks" ]; then
+        rm "$OUTDIR/cacerts.wks"
     fi
     jks_to_wks "$javaHome/$CACERTS_JDK8" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
 fi
@@ -131,8 +141,8 @@ if [ -f "$javaHome/$JSSECERTS_JDK9" ]; then
     echo "    TO:   $OUTDIR/jssecacerts.wks"
     echo "    IN PASS (default): changeit"
     echo "    OUT PASS: changeitchangeit"
-    if [ -f $OUTDIR/jssecacerts.wks ]; then
-        rm $OUTDIR/jssecacerts.wks
+    if [ -f "$OUTDIR/jssecacerts.wks" ]; then
+        rm "$OUTDIR/jssecacerts.wks"
     fi
     jks_to_wks "$javaHome/$JSSECACERTS_JDK9" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
 fi
@@ -143,8 +153,8 @@ if [ -f "$javaHome/$JSSECERTS_JDK8" ]; then
     echo "    TO:   $OUTDIR/jssecacerts.wks"
     echo "    IN PASS (default): changeit"
     echo "    OUT PASS: changeitchangeit"
-    if [ -f $OUTDIR/jssecacerts.wks ]; then
-        rm $OUTDIR/jssecacerts.wks
+    if [ -f "$OUTDIR/jssecacerts.wks" ]; then
+        rm "$OUTDIR/jssecacerts.wks"
     fi
     jks_to_wks "$javaHome/$JSSECACERTS_JDK8" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
 fi

--- a/examples/provider/CertPathBuilderExample.sh
+++ b/examples/provider/CertPathBuilderExample.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ CertPathBuilderExample $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" CertPathBuilderExample "$@"

--- a/examples/provider/CryptoBenchmark.sh
+++ b/examples/provider/CryptoBenchmark.sh
@@ -37,7 +37,7 @@ verify_sha256() {
 # Function to download Bouncy Castle JARs with pinned version
 download_bc_jars() {
   local bc_version="$BC_VERSION"
-  local lib_dir="../../../lib"
+  local lib_dir="$LIB_DIR"
   local bc_url="https://repo1.maven.org/maven2/org/bouncycastle"
 
   echo -n "Downloading Bouncy Castle JARs (version $bc_version)... "
@@ -81,25 +81,29 @@ download_bc_jars() {
 
 # Function to cleanup BC JARs
 cleanup_bc_jars() {
-  local lib_dir="../../../lib"
+  local lib_dir="$LIB_DIR"
   echo -n "Removing Bouncy Castle JARs... "
   rm -f "$lib_dir/bcprov-jdk18on-"*".jar" "$lib_dir/bctls-jdk18on-"*".jar" && echo "done" || echo "failed"
 }
 
-cd ./examples/build/provider || {
-  echo "Error: Cannot change to ./examples/build/provider"
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || {
+  echo "Error: Cannot change to $SCRIPT_DIR/../build/provider"
   exit 1
 }
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib:/usr/local/lib
-CLASSPATH="../../../lib/wolfcrypt-jni.jar:."
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+CLASSPATH="$LIB_DIR/wolfcrypt-jni.jar:."
 
 # Check for existing Bouncy Castle JARs (any version)
-if ls "../../../lib/bcprov-jdk18on-"*".jar" "../../../lib/bctls-jdk18on-"*".jar" 2>/dev/null; then
-  latest_bc_jar=$(ls -t "../../../lib/bcprov-jdk18on-"*".jar" | head -n 1)
+if ls "$LIB_DIR/bcprov-jdk18on-"*".jar" "$LIB_DIR/bctls-jdk18on-"*".jar" 2>/dev/null; then
+  latest_bc_jar=$(ls -t "$LIB_DIR/bcprov-jdk18on-"*".jar" | head -n 1)
   bc_version=$(basename "$latest_bc_jar" | sed -e 's/bcprov-jdk18on-//' -e 's/.jar$//')
   echo "Running crypto benchmark with Bouncy Castle (version $bc_version)"
-  CLASSPATH="$CLASSPATH:$latest_bc_jar:../../../lib/bctls-jdk18on-$bc_version.jar"
+  CLASSPATH="$CLASSPATH:$latest_bc_jar:$LIB_DIR/bctls-jdk18on-$bc_version.jar"
 else
   echo "Bouncy Castle JARs not found in lib directory"
   read -p "Would you like to download Bouncy Castle JARs? (y/n) " -n 1 -r
@@ -107,7 +111,7 @@ else
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     if download_bc_jars; then
       echo "Running crypto benchmark with Bouncy Castle (version $BC_VERSION)"
-      CLASSPATH="$CLASSPATH:../../../lib/bcprov-jdk18on-$BC_VERSION.jar:../../../lib/bctls-jdk18on-$BC_VERSION.jar"
+      CLASSPATH="$CLASSPATH:$LIB_DIR/bcprov-jdk18on-$BC_VERSION.jar:$LIB_DIR/bctls-jdk18on-$BC_VERSION.jar"
     else
       echo "Running crypto benchmark without Bouncy Castle due to download failure"
     fi
@@ -125,7 +129,7 @@ java -Xint \
      -XX:+UseG1GC \
      -XX:MaxGCPauseMillis=100 \
      -classpath "$CLASSPATH" \
-     -Dsun.boot.library.path=../../../lib/ \
+     -Dsun.boot.library.path="$LIB_DIR/" \
      CryptoBenchmark "$@"
 
 if [ "$BC_DOWNLOADED" = true ]; then

--- a/examples/provider/KeyStoreBenchmark.sh
+++ b/examples/provider/KeyStoreBenchmark.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ KeyStoreBenchmark $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" KeyStoreBenchmark "$@"

--- a/examples/provider/MlDsaExample.sh
+++ b/examples/provider/MlDsaExample.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ MlDsaExample $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
 
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" MlDsaExample "$@"

--- a/examples/provider/MlKemExample.sh
+++ b/examples/provider/MlKemExample.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ MlKemExample "$@"
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" MlKemExample "$@"

--- a/examples/provider/ProviderTest.sh
+++ b/examples/provider/ProviderTest.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ -Dwolfjce.debug=true ProviderTest $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
 
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" -Dwolfjce.debug=true ProviderTest "$@"

--- a/examples/provider/SlhDsaExample.sh
+++ b/examples/provider/SlhDsaExample.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ SlhDsaExample "$@"
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
 
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" SlhDsaExample "$@"

--- a/examples/provider/WolfSSLKeyStoreExample.sh
+++ b/examples/provider/WolfSSLKeyStoreExample.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ -Dwolfjce.debug=true WolfSSLKeyStoreExample $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
 
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" -Dwolfjce.debug=true WolfSSLKeyStoreExample "$@"

--- a/examples/provider/WolfSSLKeyStoreGetKeyBenchmark.sh
+++ b/examples/provider/WolfSSLKeyStoreGetKeyBenchmark.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ WolfSSLKeyStoreGetKeyBenchmark $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" WolfSSLKeyStoreGetKeyBenchmark "$@"

--- a/examples/provider/XmssExample.sh
+++ b/examples/provider/XmssExample.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./examples/build/provider
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../../lib/:/usr/local/lib
-java -classpath ../../../lib/wolfcrypt-jni.jar:./ -Dsun.boot.library.path=../../../lib/ XmssExample $@
+# Paths anchored to this script location, runs from any directory
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+LIB_DIR="$SCRIPT_DIR/../../lib"
+
+cd "$SCRIPT_DIR/../build/provider" || exit 1
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIB_DIR:/usr/local/lib"
+java -classpath "$LIB_DIR/wolfcrypt-jni.jar:./" -Dsun.boot.library.path="$LIB_DIR/" XmssExample "$@"

--- a/makefile.linux
+++ b/makefile.linux
@@ -77,13 +77,13 @@ lib/wolfcrypt-jni.jar:
 	ant build-jni-release
 
 install: all lib/wolfcrypt-jni.jar
-	$(INSTALL) -d $(INSTALL_DIR)/$(LIBDIR)
-	$(INSTALL) lib/libwolfcryptjni.so $(INSTALL_DIR)/$(LIBDIR)
-	$(INSTALL) lib/wolfcrypt-jni.jar $(INSTALL_DIR)/$(LIBDIR)
+	$(INSTALL) -d "$(INSTALL_DIR)/$(LIBDIR)"
+	$(INSTALL) lib/libwolfcryptjni.so "$(INSTALL_DIR)/$(LIBDIR)"
+	$(INSTALL) lib/wolfcrypt-jni.jar "$(INSTALL_DIR)/$(LIBDIR)"
 
 uninstall:
-	rm -f $(INSTALL_DIR)/$(LIBDIR)/libwolfcryptjni.so
-	rm -f $(INSTALL_DIR)/$(LIBDIR)/wolfcrypt-jni.jar
+	rm -f "$(INSTALL_DIR)/$(LIBDIR)/libwolfcryptjni.so"
+	rm -f "$(INSTALL_DIR)/$(LIBDIR)/wolfcrypt-jni.jar"
 
 .PHONY: clean
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPKIXCertPathValidator.java
@@ -547,8 +547,8 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
                 revChecker.setTrustAnchors(params.getTrustAnchors());
             }
 
-            /* Initialize the checker. wolfSSL validates in reverse order
-             * (leaf to root), so forward is false */
+            /* Initialize the checker for reverse order cert presentation,
+             * so forward is false */
             checker.init(false);
         }
 
@@ -1167,6 +1167,12 @@ public class WolfCryptPKIXCertPathValidator extends CertPathValidatorSpi {
             /* Sanity checks on certs from PKIXParameters constraints */
             for (i = 0; i < certs.size(); i++) {
                 sanitizeX509Certificate(certs.get(i), i, certPath, pkixParams);
+            }
+
+            /* Call registered CertPathCheckers from the cert closest
+             * to the trust anchor toward the target, matching
+             * init(false) reverse presentation order */
+            for (i = certs.size() - 1; i >= 0; i--) {
                 callCertPathCheckers(certs.get(i), pathCheckers);
             }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathValidatorTest.java
@@ -57,6 +57,7 @@ import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorResult;
 import java.security.cert.PKIXParameters;
+import java.security.cert.PKIXCertPathChecker;
 import java.security.cert.PKIXCertPathValidatorResult;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
@@ -593,6 +594,100 @@ public class WolfCryptPKIXCertPathValidatorTest {
         CertPathValidatorResult result = cpv.validate(path, params);
 
         checkPKIXCertPathValidatorResult(result, caCert, certPubKey);
+    }
+
+    /* Records init() direction and the order certs reach check().
+     * PKIXParameters clones registered checkers, clone() explicitly
+     * shares these references so results stay visible on the original. */
+    private static class RecordingCertPathChecker extends PKIXCertPathChecker {
+        List<X509Certificate> seen = new ArrayList<>();
+        boolean[] initForward = new boolean[] { true };
+
+        @Override
+        public Object clone() {
+            RecordingCertPathChecker copy = new RecordingCertPathChecker();
+            copy.seen = this.seen;
+            copy.initForward = this.initForward;
+            return copy;
+        }
+
+        @Override
+        public void init(boolean forward) {
+            this.initForward[0] = forward;
+            this.seen.clear();
+        }
+
+        @Override
+        public boolean isForwardCheckingSupported() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getSupportedExtensions() {
+            return null;
+        }
+
+        @Override
+        public void check(Certificate cert, Collection<String> unresolved) {
+            seen.add((X509Certificate)cert);
+        }
+    }
+
+    /**
+     * Registered CertPathCheckers are initialized with init(false), so
+     * certs must be presented in reverse order, trust anchor side first.
+     */
+    @Test
+    public void testCertPathCheckerReverseOrder() throws Exception {
+
+        KeyStore store = null;
+        CertificateFactory certFactory = null;
+        InputStream fis = null;
+        Certificate cert = null;
+        List<Certificate> certList = new ArrayList<>();
+
+        store = createKeyStoreFromFile(jksCaServerRSA2048, keyStorePass);
+        if (store == null || store.size() != 1) {
+            throw new Exception("Error creating KeyStore");
+        }
+
+        /* Build cert chain, going from peer to last intermediate */
+        certFactory = CertificateFactory.getInstance("X.509");
+
+        fis = new FileInputStream(intRsaServerCertDer);
+        cert = certFactory.generateCertificate(fis);
+        certList.add(cert);
+        fis.close();
+
+        fis = new FileInputStream(intRsaInt2CertDer);
+        cert = certFactory.generateCertificate(fis);
+        certList.add(cert);
+        fis.close();
+
+        fis = new FileInputStream(intRsaInt1CertDer);
+        cert = certFactory.generateCertificate(fis);
+        certList.add(cert);
+        fis.close();
+
+        PKIXParameters params = new PKIXParameters(store);
+        params.setRevocationEnabled(false);
+
+        RecordingCertPathChecker recorder = new RecordingCertPathChecker();
+        params.addCertPathChecker(recorder);
+
+        CertPath path = certFactory.generateCertPath(certList);
+        CertPathValidator cpv =
+            CertPathValidator.getInstance("PKIX", provider);
+        cpv.validate(path, params);
+
+        assertFalse("checker must be initialized with forward false",
+            recorder.initForward[0]);
+        assertEquals("checker must see every cert in the path",
+            certList.size(), recorder.seen.size());
+        for (int j = 0; j < certList.size(); j++) {
+            assertEquals("checker cert order must be reverse of CertPath",
+                certList.get(certList.size() - 1 - j), recorder.seen.get(j));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR includes 5 Fenrir fixes:

  - **F-9998**: Present certs to registered `PKIXCertPathChecker`s from trust anchor toward target, matching the reverse order declared by `init(false)`
  - **F-6617**: Load only `spotbugs-ant.jar` in the spotbugs taskdef classpath instead of globbing every JAR in `$SPOTBUGS_HOME/lib`
  - **F-8217**: Anchor provider example launcher paths to the script location and fail closed on `cd` errors
  - **F-10003**: Quote install and uninstall paths in makefile.linux so spaced `DESTDIR`/`PREFIX` values cannot split or misdirect install commands
  - **F-10005**: Anchor the default provider JAR path in the system cacerts WKS conversion script, fail closed when the JAR is missing, and write outputs to the documented script directory