### PR TITLE
Fixes for JNI error paths, key material zeroization, and JCE hardening

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_AesCts.h
+++ b/jni/include/com_wolfssl_wolfcrypt_AesCts.h
@@ -31,6 +31,14 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_AesCts_mallocNativeStruct_1in
 
 /*
  * Class:     com_wolfssl_wolfcrypt_AesCts
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1free
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_wolfssl_wolfcrypt_AesCts
  * Method:    native_set_key_internal
  * Signature: ([B[BI)V
  */

--- a/jni/jni_aescts.c
+++ b/jni/jni_aescts.c
@@ -26,7 +26,9 @@
 #elif !defined(__ANDROID__)
     #include <wolfssl/options.h>
 #endif
+#include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/openssl/aes.h>
 #include <wolfssl/openssl/modes.h>
 
@@ -72,6 +74,35 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_AesCts_mallocNativeStruct_1in
     throwNotCompiledInException(env);
 
     return (jlong)0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1free
+  (JNIEnv* env, jobject this)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_AES) && defined(HAVE_CTS) && \
+    !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API)
+    AesCtsCtx* ctx = NULL;
+
+    ctx = (AesCtsCtx*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free AesCts %p\n", ctx);
+
+    if (ctx != NULL) {
+        /* NativeStruct.xfree() handles the memory deallocation */
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(ctx, sizeof(AesCtsCtx));
+    #else
+        XMEMSET(ctx, 0, sizeof(AesCtsCtx));
+    #endif
+    }
+#else
+    throwNotCompiledInException(env);
 #endif
 }
 

--- a/jni/jni_chacha.c
+++ b/jni/jni_chacha.c
@@ -161,16 +161,14 @@ Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1process(
         ret = BAD_FUNC_ARG;
     }
 
-    if (ret == 0) {
+    if (ret == 0 && inputSz > 0) {
         output = (byte*)XMALLOC(inputSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (output == NULL) {
             releaseByteArray(env, input_obj, input, JNI_ABORT);
-            throwOutOfMemoryException(env, "Failed to allocate key buffer");
+            throwOutOfMemoryException(env, "Failed to allocate output buffer");
             return result;
         }
-    }
 
-    if (ret == 0) {
         XMEMSET(output, 0, inputSz);
 
         ret = wc_Chacha_Process(chacha, output, input, inputSz);
@@ -179,12 +177,13 @@ Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1process(
     if (ret == 0) {
         result = (*env)->NewByteArray(env, inputSz);
 
-        if (result) {
-            (*env)->SetByteArrayRegion(env, result, 0, inputSz,
-                                       (const jbyte*) output);
-        } else {
+        if (result == NULL) {
             throwWolfCryptException(env,
                 "Failed to allocate memory for Chacha_process");
+        }
+        else if (inputSz > 0) {
+            (*env)->SetByteArrayRegion(env, result, 0, inputSz,
+                                       (const jbyte*) output);
         }
     } else {
         throwWolfCryptExceptionFromError(env, ret);

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -1756,19 +1756,18 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1get_1all_
 #ifdef HAVE_ECC
     jstring* curveNames = NULL;
     int curveCount = 0;
-    int i;
-    int j;
-    int maxIdx = 0;
+    int i, j, maxIdx = 0, foundCurve = 0;
 
-    /* First pass: find maximum valid curve index by testing consecutive
-     * indices until we find an invalid one */
+    /* First pass: find maximum valid curve index, single curve builds hold
+     * their only curve at index 0 so track found separately */
     for (i = 0; i < ECC_CURVE_MAX; i++) {
         if (wc_ecc_is_valid_idx(i)) {
             maxIdx = i;
+            foundCurve = 1;
         }
     }
 
-    if (maxIdx == 0) {
+    if (foundCurve == 0) {
         throwWolfCryptExceptionFromError(env, ECC_CURVE_OID_E);
         return NULL;
     }

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -1470,11 +1470,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1import_1private_1
     }
 
     if (ret == 0) {
-        /* Initialize ECC key structure */
-        ret = wc_ecc_init(ecc);
-    }
-
-    if (ret == 0) {
         ret = wc_ecc_import_private_key_ex(privKey, privKeySz, NULL, 0,
             ecc, curveId);
     }
@@ -1543,10 +1538,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1import_1public_1r
     if (xSz != expectedSz || ySz != expectedSz) {
         LogStr("ECC x or y size does not match expected size for curve\n");
         ret = BAD_FUNC_ARG;
-    }
-
-    if (ret == 0) {
-        ret = wc_ecc_init(ecc);
     }
 
     if (ret == 0) {

--- a/jni/jni_ecc.c
+++ b/jni/jni_ecc.c
@@ -962,14 +962,11 @@ Java_com_wolfssl_wolfcrypt_Ecc_wc_1ecc_1sign_1hash(
             (*env)->SetByteArrayRegion(env, result, 0, signatureSz,
                                        (const jbyte*)signature);
         } else {
-            releaseByteArray(env, hash_object, hash, JNI_ABORT);
             throwWolfCryptException(env, "Failed to allocate signature");
-            return NULL;
         }
-    } else {
-        releaseByteArray(env, hash_object, hash, JNI_ABORT);
+    } else if (!(*env)->ExceptionOccurred(env)) {
+        /* BUFFER_E sanity check above already threw its own message */
         throwWolfCryptExceptionFromError(env, ret);
-        return NULL;
     }
 
     LogStr("wc_ecc_sign_hash(input, inSz, output, &outSz, rng, ecc) = %d\n",

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -2218,37 +2218,41 @@ public class WolfCryptCipher extends CipherSpi {
             throw new InvalidKeyException("Failed to unwrap key");
         }
 
-        switch (wrappedKeyType) {
-            case Cipher.SECRET_KEY:
-                return new SecretKeySpec(unwrappedKey, wrappedKeyAlgo);
+        try {
+            switch (wrappedKeyType) {
+                case Cipher.SECRET_KEY:
+                    return new SecretKeySpec(unwrappedKey, wrappedKeyAlgo);
 
-            case Cipher.PUBLIC_KEY:
-                try {
-                    KeyFactory kf = KeyFactory.getInstance(wrappedKeyAlgo);
-                    return kf.generatePublic(
-                        new X509EncodedKeySpec(unwrappedKey));
+                case Cipher.PUBLIC_KEY:
+                    try {
+                        KeyFactory kf = KeyFactory.getInstance(wrappedKeyAlgo);
+                        return kf.generatePublic(
+                            new X509EncodedKeySpec(unwrappedKey));
 
-                } catch (InvalidKeySpecException e) {
-                    throw new InvalidKeyException(
-                        "Failed to reconstruct public key: " +
-                        e.getMessage(), e);
-                }
+                    } catch (InvalidKeySpecException e) {
+                        throw new InvalidKeyException(
+                            "Failed to reconstruct public key: " +
+                            e.getMessage(), e);
+                    }
 
-            case Cipher.PRIVATE_KEY:
-                try {
-                    KeyFactory kf = KeyFactory.getInstance(wrappedKeyAlgo);
-                    return kf.generatePrivate(
-                        new PKCS8EncodedKeySpec(unwrappedKey));
+                case Cipher.PRIVATE_KEY:
+                    try {
+                        KeyFactory kf = KeyFactory.getInstance(wrappedKeyAlgo);
+                        return kf.generatePrivate(
+                            new PKCS8EncodedKeySpec(unwrappedKey));
 
-                } catch (InvalidKeySpecException e) {
-                    throw new InvalidKeyException(
-                        "Failed to reconstruct private key: " +
-                        e.getMessage(), e);
-                }
+                    } catch (InvalidKeySpecException e) {
+                        throw new InvalidKeyException(
+                            "Failed to reconstruct private key: " +
+                            e.getMessage(), e);
+                    }
 
-            default:
-                throw new InvalidKeyException("Invalid wrappedKeyType: " +
-                    wrappedKeyType);
+                default:
+                    throw new InvalidKeyException("Invalid wrappedKeyType: " +
+                        wrappedKeyType);
+            }
+        } finally {
+            zeroArray(unwrappedKey);
         }
     }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDebug.java
@@ -120,6 +120,10 @@ class WolfCryptDebug {
             if (message == null) {
                 message = "";
             }
+            else {
+                /* Escape CR and LF */
+                message = message.replace("\r", "\\r").replace("\n", "\\n");
+            }
 
             return String.format("%s [%s %s: TID %d: %s] %s\n",
                     TimeFormatter.format(

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyAgreement.java
@@ -227,10 +227,12 @@ public class WolfCryptKeyAgreement extends KeyAgreementSpi {
              * running on a Java version later than Java 8.
              */
             if (this.type == KeyAgreeType.WC_DH) {
+                zeroArray(tmp);
                 tmp = new byte[this.primeLen];
                 Arrays.fill(tmp, (byte)0);
                 System.arraycopy(secret, 0, tmp,
                     tmp.length - secret.length, secret.length);
+                zeroArray(secret);
                 secret = tmp.clone();
             }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMac.java
@@ -211,6 +211,9 @@ public class WolfCryptMac extends MacSpi {
 
     @Override
     protected int engineGetMacLength() {
+        if (macType == MacType.WC_AES_GMAC) {
+            return this.gmacTagLen;
+        }
         return this.digestSize;
     }
 

--- a/src/main/java/com/wolfssl/wolfcrypt/AesCts.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/AesCts.java
@@ -65,6 +65,7 @@ public class AesCts extends NativeStruct {
     /* Native JNI methods, internally reach back and grab/use pointer from
      * NativeStruct.java. */
     private native long mallocNativeStruct_internal() throws OutOfMemoryError;
+    private native void native_free();
     private native void native_set_key_internal(byte[] key, byte[] iv,
         int opmode);
     private native int native_update_internal(int opmode, byte[] input,
@@ -371,13 +372,20 @@ public class AesCts extends NativeStruct {
 
     /**
      * Release native AES-CTS structure.
-     * Object cannot be used again after calling this method.
+     * Object may be re-initialized and used again after release by
+     * calling setKey().
      */
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (stateLock) {
             if (state != WolfCryptState.RELEASED) {
-                super.releaseNativeStruct();
+                synchronized (pointerLock) {
+                    /* Only zeroize when a native struct exists */
+                    if (getNativeStruct() != NativeStruct.NULL) {
+                        native_free();
+                    }
+                    super.releaseNativeStruct();
+                }
                 state = WolfCryptState.RELEASED;
             }
         }

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -213,6 +213,18 @@ public class Hmac extends NativeStruct {
     }
 
     /**
+     * Release native Hmac structure.
+     * Synchronized on this object so a concurrent release cannot free
+     * the native struct while another synchronized method is using it.
+     */
+    @Override
+    public synchronized void releaseNativeStruct() {
+        synchronized (pointerLock) {
+            super.releaseNativeStruct();
+        }
+    }
+
+    /**
      * Perform HMAC update operation
      *
      * @param data single input data byte to update HMAC with

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMacTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptMacTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.GCMParameterSpec;
 
@@ -2090,6 +2091,63 @@ public class WolfCryptMacTest {
         byte[] computedTag = mac.doFinal();
 
         assertArrayEquals(expectedTag, computedTag);
+    }
+
+    @Test
+    public void testAesGmacShortTagLength()
+        throws InvalidKeyException, NoSuchAlgorithmException,
+               NoSuchProviderException, InvalidAlgorithmParameterException,
+               ShortBufferException {
+
+        if (!enabledAlgos.contains("AESGMAC")) {
+            return;
+        }
+
+        byte[] key = new byte[] {
+            (byte)0x89, (byte)0xc9, (byte)0x49, (byte)0xe9,
+            (byte)0xc8, (byte)0x04, (byte)0xaf, (byte)0x01,
+            (byte)0x4d, (byte)0x56, (byte)0x04, (byte)0xb3,
+            (byte)0x94, (byte)0x59, (byte)0xf2, (byte)0xc8
+        };
+
+        byte[] iv = new byte[] {
+            (byte)0xd1, (byte)0xb1, (byte)0x04, (byte)0xc8,
+            (byte)0x15, (byte)0xbf, (byte)0x1e, (byte)0x94,
+            (byte)0xe2, (byte)0x8c, (byte)0x8f, (byte)0x16
+        };
+
+        byte[] authIn = new byte[] {
+            (byte)0x82, (byte)0xad, (byte)0xcd, (byte)0x63,
+            (byte)0x8d, (byte)0x3f, (byte)0xa9, (byte)0xd9,
+            (byte)0xf3, (byte)0xe8, (byte)0x41, (byte)0x00,
+            (byte)0xd6, (byte)0x1e, (byte)0x07, (byte)0x77
+        };
+
+        byte[] expectedTag = new byte[] {
+            (byte)0x88, (byte)0xdb, (byte)0x9d, (byte)0x62,
+            (byte)0x17, (byte)0x2e, (byte)0xd0, (byte)0x43,
+            (byte)0xaa, (byte)0x10, (byte)0xf1, (byte)0x6d,
+            (byte)0x22, (byte)0x7d, (byte)0xc4, (byte)0x1b
+        };
+
+        Mac mac = Mac.getInstance("AESGMAC", "wolfJCE");
+        SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
+
+        /* 96 bit tag, getMacLength() must match 12 byte doFinal() output */
+        mac.init(keyspec, new GCMParameterSpec(96, iv));
+        assertEquals(12, mac.getMacLength());
+
+        mac.update(authIn);
+        byte[] out = new byte[mac.getMacLength()];
+        mac.doFinal(out, 0);
+
+        /* GMAC truncates to the leftmost tag bytes */
+        assertArrayEquals(Arrays.copyOf(expectedTag, 12), out);
+
+        /* Full 128 bit tag must still report 16 */
+        mac.init(keyspec, new GCMParameterSpec(128, iv));
+        assertEquals(16, mac.getMacLength());
+        assertArrayEquals(expectedTag, mac.doFinal(authIn));
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfSSLKeyStoreTest.java
@@ -75,6 +75,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import java.util.Base64;
 
@@ -413,6 +414,31 @@ public class WolfSSLKeyStoreTest {
                 new X509EncodedKeySpec(certPub.getEncoded()));
             assertEquals("XMSS", wolfPub.getAlgorithm());
         }
+    }
+
+    @Test
+    public void testAliasWithLineBreaksRoundTrips() throws Exception {
+
+        /* Line breaks in an alias are escaped in debug log output only,
+         * the alias itself must round trip through store/load unchanged */
+        String alias = "evil\nalias\rwith\r\nline breaks";
+
+        KeyStore store = KeyStore.getInstance("WKS", "wolfJCE");
+        store.load(null, storePass.toCharArray());
+        store.setKeyEntry(alias, new SecretKeySpec(new byte[16], "AES"),
+            storePass.toCharArray(), null);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        store.store(bos, storePass.toCharArray());
+
+        KeyStore reloaded = KeyStore.getInstance("WKS", "wolfJCE");
+        reloaded.load(new ByteArrayInputStream(bos.toByteArray()),
+            storePass.toCharArray());
+
+        assertTrue("alias with line breaks must round trip unchanged",
+            reloaded.containsAlias(alias));
+        assertNotNull("key must be retrievable at original alias",
+            reloaded.getKey(alias, storePass.toCharArray()));
     }
 
     /**

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesCtsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesCtsTest.java
@@ -206,6 +206,29 @@ public class AesCtsTest {
     }
 
     @Test
+    public void releaseAndReuseShouldWork() {
+        AesCts aesCts = new AesCts();
+
+        try {
+            aesCts.setKey(KEY_128, IV, AesCts.ENCRYPT_MODE);
+            aesCts.releaseNativeStruct();
+
+            /* second release must be a safe no-op */
+            aesCts.releaseNativeStruct();
+
+            /* object must re-init cleanly after release and still work
+             * right */
+            aesCts.setKey(KEY_128, IV, AesCts.ENCRYPT_MODE);
+            byte[] ciphertext = aesCts.update(PLAINTEXT_17);
+
+            assertArrayEquals("AES-128-CTS encryption failed after re-init",
+                CIPHERTEXT_17, ciphertext);
+        } finally {
+            aesCts.releaseNativeStruct();
+        }
+    }
+
+    @Test
     public void aes128CtsEncryptDecrypt17BytesTest() {
         AesCts aesCts = new AesCts();
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/ChachaTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/ChachaTest.java
@@ -151,6 +151,28 @@ public class ChachaTest {
     }
 
     @Test
+    public void processWithEmptyInputShouldReturnEmptyArray() {
+        Chacha chacha = new Chacha();
+
+        try {
+            chacha.setKey(KEY);
+            chacha.setIV(IV);
+
+            /* Empty input is a no-op that must return an empty array,
+             * not throw */
+            byte[] empty = chacha.process(new byte[0]);
+            assertNotNull(empty);
+            assertEquals(0, empty.length);
+
+            /* Keystream position must be unchanged by the empty call */
+            byte[] cipher = chacha.process(INPUT);
+            assertArrayEquals(EXPECTED, cipher);
+        } finally {
+            chacha.releaseNativeStruct();
+        }
+    }
+
+    @Test
     public void checkChachaVectors() {
 
         int i = 0;

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
@@ -224,6 +225,37 @@ public class EccTest {
         alice2.importPrivate(alice.exportPrivate(), alice.exportX963());
 
         assertTrue(alice2.verify(hash, signature));
+    }
+
+    @Test
+    public void signWithFreedRngShouldThrow() {
+        Ecc alice = new Ecc();
+        Rng callerRng = new Rng();
+        callerRng.init();
+
+        alice.makeKey(callerRng, 32);
+        byte[] hash =
+            "Everyone gets Friday off.".getBytes(StandardCharsets.UTF_8);
+
+        /* A freed Rng makes native signing fail after the native signature
+         * buffer is allocated, exercising error cleanup */
+        callerRng.free();
+
+        try {
+            alice.sign(hash, callerRng);
+            fail("Ecc.sign() should throw with a freed Rng");
+        } catch (WolfCryptException e) {
+            /* test must throw */
+        }
+
+        /* Object must still sign correctly after the failed attempt */
+        callerRng.init();
+        byte[] signature = alice.sign(hash, callerRng);
+        assertTrue(alice.verify(hash, signature));
+
+        callerRng.free();
+        callerRng.releaseNativeStruct();
+        alice.releaseNativeStruct();
     }
 
     @Test

--- a/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/EccTest.java
@@ -442,6 +442,57 @@ public class EccTest {
     }
 
     @Test
+    public void eccImportPublicRawVerifiesSignature() {
+
+        /* secp256r1 key pair, x and y are the public point coordinates
+         * from the pubKey used in signatureShouldMatchDecodingKeys */
+        byte[] prvKey = Util.h2b("30770201010420F8CF92"
+                + "6BBD1E28F1A8ABA1234F3274188850AD7EC7EC92"
+                + "F88F974DAF568965C7A00A06082A8648CE3D0301"
+                + "07A1440342000455BFF40F44509A3DCE9BB7F0C5"
+                + "4DF5707BD4EC248E1980EC5A4CA22403622C9BDA"
+                + "EFA2351243847616C6569506CC01A9BDF6751A42"
+                + "F7BDA9B236225FC75D7FB4");
+
+        byte[] x = Util.h2b("55BFF40F44509A3DCE9BB7"
+                + "F0C54DF5707BD4EC248E1980EC5A4CA22403622C9B");
+        byte[] y = Util.h2b("DAEFA2351243847616C656"
+                + "9506CC01A9BDF6751A42F7BDA9B236225FC75D7FB4");
+
+        byte[] hash =
+            "Everyone gets Friday off. ecc p".getBytes(StandardCharsets.UTF_8);
+
+        Ecc alice = new Ecc();
+        Ecc bob = new Ecc();
+
+        try {
+            alice.privateKeyDecode(prvKey);
+
+            byte[] signature = null;
+            synchronized (rngLock) {
+                signature = alice.sign(hash, rng);
+            }
+
+            bob.importPublicRaw(x, y, "secp256r1");
+            assertTrue(bob.verify(hash, signature));
+
+            /* coordinate size not matching curve must be rejected */
+            Ecc shortX = new Ecc();
+            try {
+                shortX.importPublicRaw(Arrays.copyOf(x, 16), y, "secp256r1");
+                fail("importPublicRaw with short x coordinate should fail");
+            } catch (WolfCryptException e) {
+                /* expected */
+            } finally {
+                shortX.releaseNativeStruct();
+            }
+        } finally {
+            alice.releaseNativeStruct();
+            bob.releaseNativeStruct();
+        }
+    }
+
+    @Test
     public void getEccCurveNameFromSpec()
         throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
 


### PR DESCRIPTION
This PR includes 11 Fenrir fixes:

  - **F-4437**: Skip output allocation for zero length ChaCha process input, returning an empty array
  - **F-5401**: Free signature buffer on ECC sign_hash error paths
  - **F-5988**: Return the configured GMAC tag length from engineGetMacLength()
  - **F-5989**: Track found curves separately from max index in wc_ecc_get_all_curve_names()
  - **F-6155**: Remove redundant wc_ecc_init() calls from the ECC raw import wrappers
  - **F-3562**: Zeroize the AES-CTS key schedule and IV in releaseNativeStruct() before the native struct is freed
  - **F-3762 / F-5036**: Zeroize the cleartext unwrapped key buffer in WolfCryptCipher.engineUnwrap() after Key is reconstructed
  - **F-3998**: Zeroize abandoned DH shared secret buffers in WolfCryptKeyAgreement.engineGenerateSecret()
  - **F-4362**: Escape CR and LF in wolfJCE debug log messages
  - **F-4364**: Override releaseNativeStruct() in Hmac