### PR TITLE
Fixes for key material zeroization across JCE and JNI, PBKDF input validation

### DIFF
--- a/jni/jni_jce_wolfsslkeystore.c
+++ b/jni/jni_jce_wolfsslkeystore.c
@@ -25,7 +25,9 @@
     #include <wolfssl/options.h>
 #endif
 
+#include <wolfssl/version.h>
 #include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #include <com_wolfssl_provider_jce_WolfSSLKeyStore.h>
 #include <wolfcrypt_jni_error.h>
 
@@ -40,6 +42,7 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
     int ret = WOLFSSL_SUCCESS;
     int certDerSz = 0;
     int keyDerSz = 0;
+    jboolean keyDerIsCopy = JNI_FALSE;
     byte* certDer = NULL;
     byte* keyDer = NULL;
     byte* pkcs8KeyDer = NULL;
@@ -57,7 +60,8 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
     certDer = (byte*)(*env)->GetByteArrayElements(env, certDerArr, NULL);
     certDerSz = (*env)->GetArrayLength(env, certDerArr);
 
-    keyDer = (byte*)(*env)->GetByteArrayElements(env, pkcs8KeyDerArr, NULL);
+    keyDer = (byte*)(*env)->GetByteArrayElements(env, pkcs8KeyDerArr,
+        &keyDerIsCopy);
     keyDerSz = (*env)->GetArrayLength(env, pkcs8KeyDerArr);
     /* Keep original keyDer pointer for free later, wolfSSL_d2i_PKCS8_PKEY
      * will change/advance the pointer. */
@@ -118,8 +122,16 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_provider_jce_WolfSSLKeyStore_X509Che
                                          (jbyte*)certDer, JNI_ABORT);
     }
     if (keyDer != NULL) {
+        if (keyDerIsCopy == JNI_TRUE) {
+        #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+            !defined(WOLFSSL_NO_FORCE_ZERO)
+            wc_ForceZero(keyDer, keyDerSz);
+        #else
+            XMEMSET(keyDer, 0, keyDerSz);
+        #endif
+        }
         (*env)->ReleaseByteArrayElements(env, pkcs8KeyDerArr,
-                                         (jbyte*)keyDer, JNI_ABORT);
+            (jbyte*)keyDer, JNI_ABORT);
     }
 
     if (ret == WOLFSSL_SUCCESS) {

--- a/jni/jni_pwdbased.c
+++ b/jni/jni_pwdbased.c
@@ -52,7 +52,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Pwdbased_wc_1PKCS12_1PBK
     jbyteArray result = NULL;
     (void)jcl;
 
-    if (env == NULL || kLen == 0) {
+    if (env == NULL || kLen <= 0) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
         return NULL;
     }
@@ -147,7 +147,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_Pwdbased_wc_1PBKDF2
     jbyteArray result = NULL;
     (void)jcl;
 
-    if (env == NULL || kLen == 0) {
+    if (env == NULL || kLen <= 0) {
         throwWolfCryptExceptionFromError(env, BAD_FUNC_ARG);
         return NULL;
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -2025,15 +2025,20 @@ public class WolfCryptCipher extends CipherSpi {
             return 0;
         }
 
-        if (output.length - outputOffset < tmpOut.length) {
-            throw new ShortBufferException(
-                "Output buffer too small, need " + tmpOut.length +
-                " bytes, got " + (output.length - outputOffset));
+        try {
+            if (output.length - outputOffset < tmpOut.length) {
+                throw new ShortBufferException(
+                    "Output buffer too small, need " + tmpOut.length +
+                    " bytes, got " + (output.length - outputOffset));
+            }
+
+            System.arraycopy(tmpOut, 0, output, outputOffset, tmpOut.length);
+
+            return tmpOut.length;
+        } finally {
+            /* Zeroize intermediate copy, holds plaintext when decrypting */
+            zeroArray(tmpOut);
         }
-
-        System.arraycopy(tmpOut, 0, output, outputOffset, tmpOut.length);
-
-        return tmpOut.length;
     }
 
     private void zeroArray(byte[] in) {
@@ -2098,15 +2103,20 @@ public class WolfCryptCipher extends CipherSpi {
 
         tmpOut = wolfCryptFinal(input, inputOffset, inputLen);
 
-        if (output.length - outputOffset < tmpOut.length) {
-            throw new ShortBufferException(
-                "Output buffer too small, need " + tmpOut.length +
-                " bytes, got " + (output.length - outputOffset));
+        try {
+            if (output.length - outputOffset < tmpOut.length) {
+                throw new ShortBufferException(
+                    "Output buffer too small, need " + tmpOut.length +
+                    " bytes, got " + (output.length - outputOffset));
+            }
+
+            System.arraycopy(tmpOut, 0, output, outputOffset, tmpOut.length);
+
+            return tmpOut.length;
+
+        } finally {
+            zeroArray(tmpOut);
         }
-
-        System.arraycopy(tmpOut, 0, output, outputOffset, tmpOut.length);
-
-        return tmpOut.length;
     }
 
     @Override

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -1493,41 +1493,48 @@ public class WolfCryptCipher extends CipherSpi {
         /* keep remaining non-block size input buffered */
         bufferedConsume(bytesToProcess);
 
-        /* process tmpIn[] */
-        switch (this.cipherType) {
+        try {
+            /* process tmpIn[] */
+            switch (this.cipherType) {
 
-            /* Only CBC/ECB/CTR/OFB mode reaches this point currently,
-             * GCM/CCM/CTS cache all data internally above until final call */
-            case WC_AES:
-                if (cipherMode == CipherMode.WC_ECB) {
-                    output = this.aesEcb.update(tmpIn, 0, tmpIn.length);
+                /* Only CBC/ECB/CTR/OFB mode reaches this point currently,
+                 * GCM/CCM/CTS cache all data internally above until final
+                 * call */
+                case WC_AES:
+                    if (cipherMode == CipherMode.WC_ECB) {
+                        output = this.aesEcb.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else if (cipherMode == CipherMode.WC_CTR) {
+                        output = this.aesCtr.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else if (cipherMode == CipherMode.WC_OFB) {
+                        output = this.aesOfb.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else {
+                        byte[] full = this.aes.update(tmpIn, 0, tmpIn.length);
+                        /* truncate, zeroize untruncated copy */
+                        output = Arrays.copyOfRange(full, 0, tmpIn.length);
+                        zeroArray(full);
+                    }
+
+                    break;
+
+                case WC_DES3: {
+                    byte[] full = this.des3.update(tmpIn, 0, tmpIn.length);
+                    /* truncate, zeroize untruncated copy */
+                    output = Arrays.copyOfRange(full, 0, tmpIn.length);
+                    zeroArray(full);
+
+                    break;
                 }
-                else if (cipherMode == CipherMode.WC_CTR) {
-                    output = this.aesCtr.update(tmpIn, 0, tmpIn.length);
-                }
-                else if (cipherMode == CipherMode.WC_OFB) {
-                    output = this.aesOfb.update(tmpIn, 0, tmpIn.length);
-                }
-                else {
-                    output = this.aes.update(tmpIn, 0, tmpIn.length);
 
-                    /* truncate */
-                    output = Arrays.copyOfRange(output, 0, tmpIn.length);
-                }
-
-                break;
-
-            case WC_DES3:
-                output = this.des3.update(tmpIn, 0, tmpIn.length);
-
-                /* truncate */
-                output = Arrays.copyOfRange(output, 0, tmpIn.length);
-
-                break;
-
-            default:
-                throw new RuntimeException("Unsupported algorithm type");
-        };
+                default:
+                    throw new RuntimeException("Unsupported algorithm type");
+            };
+        } finally {
+            /* Zero internal input plaintext copy */
+            zeroArray(tmpIn);
+        }
 
         if (output == null) {
             /* For interop compatibility, return empty byte array */
@@ -1615,246 +1622,275 @@ public class WolfCryptCipher extends CipherSpi {
             }
         }
 
-        /* add padding if encrypting and PKCS5 padding is used. PKCS#5 padding
-         * is treated the same as PKCS#7 padding here, using each algorithm's
-         * specific block size. CCM, CTR, CTS, and OFB modes do not use
-         * padding */
-        if (this.direction == OpMode.WC_ENCRYPT &&
-            this.paddingType == PaddingType.WC_PKCS5 &&
-            cipherMode != CipherMode.WC_CCM &&
-            cipherMode != CipherMode.WC_CTR &&
-            cipherMode != CipherMode.WC_CTS &&
-            cipherMode != CipherMode.WC_OFB) {
-            if (this.cipherType == CipherType.WC_AES) {
-                tmpIn = Aes.padPKCS7(tmpIn, Aes.BLOCK_SIZE);
-            } else if (this.cipherType == CipherType.WC_DES3) {
-                tmpIn = Des3.padPKCS7(tmpIn, Des3.BLOCK_SIZE);
-            }
-        }
-
         /* Flatten accumulated AAD to a single array for GCM/CCM calls below */
         byte[] aad = (this.aadStream != null) ?
             this.aadStream.toByteArray() : null;
 
-        switch (this.cipherType) {
+        try {
+            /* Add padding if encrypting and PKCS5 padding is used, PKCS#5
+             * padding is treated the same as PKCS#7 padding here, using
+             * each algorithm's specific block size. CCM, CTR, CTS, and OFB
+             * modes do not use padding */
+            if (this.direction == OpMode.WC_ENCRYPT &&
+                this.paddingType == PaddingType.WC_PKCS5 &&
+                cipherMode != CipherMode.WC_CCM &&
+                cipherMode != CipherMode.WC_CTR &&
+                cipherMode != CipherMode.WC_CTS &&
+                cipherMode != CipherMode.WC_OFB) {
+                if (this.cipherType == CipherType.WC_AES) {
+                    byte[] padded = Aes.padPKCS7(tmpIn, Aes.BLOCK_SIZE);
+                    /* Zeroize plaintext copy orphaned by padding */
+                    zeroArray(tmpIn);
+                    tmpIn = padded;
+                } else if (this.cipherType == CipherType.WC_DES3) {
+                    byte[] padded = Des3.padPKCS7(tmpIn, Des3.BLOCK_SIZE);
+                    /* Zeroize plaintext copy orphaned by padding */
+                    zeroArray(tmpIn);
+                    tmpIn = padded;
+                }
+            }
 
-            case WC_AES:
-                if (cipherMode == CipherMode.WC_GCM) {
-                    if (this.direction == OpMode.WC_ENCRYPT) {
+            switch (this.cipherType) {
 
-                        /* A second encryption without re-init would reuse
-                         * the same key and IV (GCM nonce reuse) */
-                        if (this.gcmEncryptNeedsReinit) {
-                            throw new IllegalStateException(
-                                "Must use either different key or iv for " +
-                                "GCM encryption");
-                        }
+                case WC_AES:
+                    if (cipherMode == CipherMode.WC_GCM) {
+                        if (this.direction == OpMode.WC_ENCRYPT) {
 
-                        byte[] tag = new byte[this.gcmTagLen];
-                        tmpOut = this.aesGcm.encrypt(tmpIn, this.iv, tag,
-                                    aad);
-
-                        this.gcmEncryptNeedsReinit = true;
-
-                        /* Concatenate auth tag to end of ciphertext */
-                        byte[] totalOut = new byte[tmpOut.length + tag.length];
-                        System.arraycopy(tmpOut, 0, totalOut, 0, tmpOut.length);
-                        System.arraycopy(tag, 0, totalOut, tmpOut.length,
-                                         tag.length);
-                        tmpOut = totalOut;
-                    }
-                    else {
-                        /* Case where input is only the authentication tag,
-                         * zero-length plaintext */
-                        if (tmpIn.length < this.gcmTagLen) {
-                            throw new AEADBadTagException(
-                                "Input too short for GCM tag, got " +
-                                tmpIn.length + " bytes, need at least " +
-                                this.gcmTagLen);
-                        }
-
-                        /* Get auth tag from end of ciphertext */
-                        byte[] tag = Arrays.copyOfRange(tmpIn,
-                                        tmpIn.length - this.gcmTagLen,
-                                        tmpIn.length);
-
-                        /* Shrink ciphertext array down to not include tag */
-                        tmpIn = Arrays.copyOfRange(tmpIn, 0,
-                                    tmpIn.length - this.gcmTagLen);
-
-                        try {
-                            tmpOut = this.aesGcm.decrypt(tmpIn, this.iv,
-                                tag, aad);
-
-                        } catch (WolfCryptException e) {
-                            /* Convert to AEADBadTagException */
-                            if (e.getCode() ==
-                                WolfCryptError.AES_GCM_AUTH_E.getCode()) {
-                                /* Authentication check fail */
-                                throw new AEADBadTagException(e.getMessage());
+                            /* A second encryption without re-init would reuse
+                             * the same key and IV (GCM nonce reuse) */
+                            if (this.gcmEncryptNeedsReinit) {
+                                throw new IllegalStateException(
+                                    "Must use either different key or iv for " +
+                                    "GCM encryption");
                             }
-                            throw e;
+
+                            byte[] tag = new byte[this.gcmTagLen];
+                            tmpOut = this.aesGcm.encrypt(tmpIn, this.iv, tag,
+                                        aad);
+
+                            this.gcmEncryptNeedsReinit = true;
+
+                            /* Concatenate auth tag to end of ciphertext */
+                            byte[] totalOut =
+                                new byte[tmpOut.length + tag.length];
+                            System.arraycopy(tmpOut, 0, totalOut, 0,
+                                tmpOut.length);
+                            System.arraycopy(tag, 0, totalOut, tmpOut.length,
+                                             tag.length);
+                            tmpOut = totalOut;
+                        }
+                        else {
+                            /* Case where input is only the authentication tag,
+                             * zero-length plaintext */
+                            if (tmpIn.length < this.gcmTagLen) {
+                                throw new AEADBadTagException(
+                                    "Input too short for GCM tag, got " +
+                                    tmpIn.length + " bytes, need at least " +
+                                    this.gcmTagLen);
+                            }
+
+                            /* Get auth tag from end of ciphertext */
+                            byte[] tag = Arrays.copyOfRange(tmpIn,
+                                            tmpIn.length - this.gcmTagLen,
+                                            tmpIn.length);
+
+                            /* Shrink ciphertext array to not include tag */
+                            tmpIn = Arrays.copyOfRange(tmpIn, 0,
+                                        tmpIn.length - this.gcmTagLen);
+
+                            try {
+                                tmpOut = this.aesGcm.decrypt(tmpIn, this.iv,
+                                    tag, aad);
+
+                            } catch (WolfCryptException e) {
+                                /* Convert to AEADBadTagException */
+                                if (e.getCode() ==
+                                    WolfCryptError.AES_GCM_AUTH_E.getCode()) {
+                                    /* Authentication check fail */
+                                    throw new AEADBadTagException(
+                                        e.getMessage());
+                                }
+                                throw e;
+                            }
                         }
                     }
-                }
-                else if (cipherMode == CipherMode.WC_CCM) {
-                    if (this.direction == OpMode.WC_ENCRYPT) {
-                        byte[] tag = new byte[this.gcmTagLen];
-                        tmpOut = this.aesCcm.encrypt(tmpIn, this.iv, tag,
-                                    aad);
+                    else if (cipherMode == CipherMode.WC_CCM) {
+                        if (this.direction == OpMode.WC_ENCRYPT) {
+                            byte[] tag = new byte[this.gcmTagLen];
+                            tmpOut = this.aesCcm.encrypt(tmpIn, this.iv, tag,
+                                        aad);
 
-                        /* Concatenate auth tag to end of ciphertext */
-                        byte[] totalOut = new byte[tmpOut.length + tag.length];
-                        System.arraycopy(tmpOut, 0, totalOut, 0, tmpOut.length);
-                        System.arraycopy(tag, 0, totalOut, tmpOut.length,
-                                         tag.length);
-                        tmpOut = totalOut;
+                            /* Concatenate auth tag to end of ciphertext */
+                            byte[] totalOut =
+                                new byte[tmpOut.length + tag.length];
+                            System.arraycopy(tmpOut, 0, totalOut, 0,
+                                tmpOut.length);
+                            System.arraycopy(tag, 0, totalOut, tmpOut.length,
+                                             tag.length);
+                            tmpOut = totalOut;
+                        }
+                        else {
+                            /* Case where input is only the authentication tag,
+                             * zero-length plaintext */
+                            if (tmpIn.length < this.gcmTagLen) {
+                                throw new AEADBadTagException(
+                                    "Input too short for CCM tag, got " +
+                                    tmpIn.length + " bytes, need at least " +
+                                    this.gcmTagLen);
+                            }
+
+                            /* Get auth tag from end of ciphertext */
+                            byte[] tag = Arrays.copyOfRange(tmpIn,
+                                            tmpIn.length - this.gcmTagLen,
+                                            tmpIn.length);
+
+                            /* Shrink ciphertext array to not include tag */
+                            tmpIn = Arrays.copyOfRange(tmpIn, 0,
+                                        tmpIn.length - this.gcmTagLen);
+
+                            tmpOut = this.aesCcm.decrypt(tmpIn, this.iv, tag,
+                                        aad);
+                        }
+                    }
+                    else if (cipherMode == CipherMode.WC_ECB) {
+                        tmpOut = this.aesEcb.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else if (cipherMode == CipherMode.WC_CTR) {
+                        tmpOut = this.aesCtr.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else if (cipherMode == CipherMode.WC_CTS) {
+                        tmpOut = this.aesCts.update(tmpIn, 0, tmpIn.length);
+                    }
+                    else if (cipherMode == CipherMode.WC_OFB) {
+                        tmpOut = this.aesOfb.update(tmpIn, 0, tmpIn.length);
                     }
                     else {
-                        /* Case where input is only the authentication tag,
-                         * zero-length plaintext */
-                        if (tmpIn.length < this.gcmTagLen) {
-                            throw new AEADBadTagException(
-                                "Input too short for CCM tag, got " +
-                                tmpIn.length + " bytes, need at least " +
-                                this.gcmTagLen);
-                        }
-
-                        /* Get auth tag from end of ciphertext */
-                        byte[] tag = Arrays.copyOfRange(tmpIn,
-                                        tmpIn.length - this.gcmTagLen,
-                                        tmpIn.length);
-
-                        /* Shrink ciphertext array down to not include tag */
-                        tmpIn = Arrays.copyOfRange(tmpIn, 0,
-                                    tmpIn.length - this.gcmTagLen);
-
-                        tmpOut = this.aesCcm.decrypt(tmpIn, this.iv, tag,
-                                    aad);
+                        byte[] full = this.aes.update(tmpIn, 0, tmpIn.length);
+                        tmpOut = Arrays.copyOfRange(full, 0, tmpIn.length);
+                        zeroArray(full);
                     }
-                }
-                else if (cipherMode == CipherMode.WC_ECB) {
-                    tmpOut = this.aesEcb.update(tmpIn, 0, tmpIn.length);
-                }
-                else if (cipherMode == CipherMode.WC_CTR) {
-                    tmpOut = this.aesCtr.update(tmpIn, 0, tmpIn.length);
-                }
-                else if (cipherMode == CipherMode.WC_CTS) {
-                    tmpOut = this.aesCts.update(tmpIn, 0, tmpIn.length);
-                }
-                else if (cipherMode == CipherMode.WC_OFB) {
-                    tmpOut = this.aesOfb.update(tmpIn, 0, tmpIn.length);
-                }
-                else {
-                    tmpOut = this.aes.update(tmpIn, 0, tmpIn.length);
 
-                    /* truncate */
-                    tmpOut = Arrays.copyOfRange(tmpOut, 0, tmpIn.length);
-                }
-
-                /* strip PKCS#5/PKCS#7 padding if required,
-                 * CCM, CTR, CTS, and OFB modes do not use padding */
-                if (tmpOut != null && tmpOut.length > 0) {
-                    if (this.direction == OpMode.WC_DECRYPT &&
-                        this.paddingType == PaddingType.WC_PKCS5 &&
-                        cipherMode != CipherMode.WC_CCM &&
-                        cipherMode != CipherMode.WC_CTR &&
-                        cipherMode != CipherMode.WC_CTS &&
-                        cipherMode != CipherMode.WC_OFB) {
-                        try {
-                            tmpOut = Aes.unPadPKCS7(tmpOut, Aes.BLOCK_SIZE);
-                        } catch (WolfCryptException e) {
-                            throw new BadPaddingException("Decryption error");
+                    /* strip PKCS#5/PKCS#7 padding if required,
+                     * CCM, CTR, CTS, and OFB modes do not use padding */
+                    if (tmpOut != null && tmpOut.length > 0) {
+                        if (this.direction == OpMode.WC_DECRYPT &&
+                            this.paddingType == PaddingType.WC_PKCS5 &&
+                            cipherMode != CipherMode.WC_CCM &&
+                            cipherMode != CipherMode.WC_CTR &&
+                            cipherMode != CipherMode.WC_CTS &&
+                            cipherMode != CipherMode.WC_OFB) {
+                            try {
+                                byte[] padded = tmpOut;
+                                tmpOut = Aes.unPadPKCS7(padded, Aes.BLOCK_SIZE);
+                                zeroArray(padded);
+                            } catch (WolfCryptException e) {
+                                zeroArray(tmpOut);
+                                throw new BadPaddingException(
+                                    "Decryption error");
+                            }
                         }
                     }
-                }
 
-                break;
+                    break;
 
-            case WC_DES3:
-                tmpOut = this.des3.update(tmpIn, 0, tmpIn.length);
+                case WC_DES3: {
+                    byte[] fullDes = this.des3.update(tmpIn, 0, tmpIn.length);
+                    tmpOut = Arrays.copyOfRange(fullDes, 0, tmpIn.length);
+                    zeroArray(fullDes);
 
-                /* truncate */
-                tmpOut = Arrays.copyOfRange(tmpOut, 0, tmpIn.length);
-
-                /* strip PKCS#5/PKCS#7 padding if required */
-                if (tmpOut != null && tmpOut.length > 0) {
-                    if (this.direction == OpMode.WC_DECRYPT &&
-                        this.paddingType == PaddingType.WC_PKCS5) {
-                        try {
-                            tmpOut = Des3.unPadPKCS7(tmpOut, Des3.BLOCK_SIZE);
-                        } catch (WolfCryptException e) {
-                            throw new BadPaddingException("Decryption error");
+                    /* strip PKCS#5/PKCS#7 padding if required */
+                    if (tmpOut != null && tmpOut.length > 0) {
+                        if (this.direction == OpMode.WC_DECRYPT &&
+                            this.paddingType == PaddingType.WC_PKCS5) {
+                            try {
+                                byte[] padded = tmpOut;
+                                tmpOut = Des3.unPadPKCS7(padded,
+                                    Des3.BLOCK_SIZE);
+                                zeroArray(padded);
+                            } catch (WolfCryptException e) {
+                                zeroArray(tmpOut);
+                                throw new BadPaddingException(
+                                    "Decryption error");
+                            }
                         }
                     }
+
+                    break;
                 }
 
-                break;
+                case WC_RSA:
 
-            case WC_RSA:
+                    if (this.paddingType == PaddingType.WC_OAEP_SHA256 ||
+                        this.paddingType == PaddingType.WC_OAEP_SHA1) {
+                        /* OAEP only supports public key encrypt and
+                         * private key decrypt */
+                        if (this.direction == OpMode.WC_ENCRYPT) {
+                            if (this.rsaKeyType == RsaKeyType.WC_RSA_PRIVATE) {
+                                throw new IllegalStateException(
+                                    "OAEP padding requires public key for " +
+                                    "encryption");
+                            }
 
-                if (this.paddingType == PaddingType.WC_OAEP_SHA256 ||
-                    this.paddingType == PaddingType.WC_OAEP_SHA1) {
-                    /* OAEP only supports public key encrypt, private decrypt */
-                    if (this.direction == OpMode.WC_ENCRYPT) {
-                        if (this.rsaKeyType == RsaKeyType.WC_RSA_PRIVATE) {
-                            throw new IllegalStateException(
-                                "OAEP padding requires public key for " +
-                                "encryption");
-                        }
-
-                        tmpOut = this.rsa.encryptOaep(tmpIn, this.rng,
-                            this.oaepHashType, this.oaepMgf);
-
-                    } else {
-                        if (this.rsaKeyType == RsaKeyType.WC_RSA_PUBLIC) {
-                            throw new IllegalStateException(
-                                "OAEP padding requires private key for " +
-                                "decryption");
-                        }
-
-                        try {
-                            tmpIn = leftPadRSACiphertext(tmpIn,
-                                this.rsa.getEncryptSize());
-
-                            tmpOut = this.rsa.decryptOaep(tmpIn,
+                            tmpOut = this.rsa.encryptOaep(tmpIn, this.rng,
                                 this.oaepHashType, this.oaepMgf);
 
-                        } catch (WolfCryptException e) {
-                            throw new BadPaddingException("Decryption error");
-                        }
-                    }
-                } else {
-                    /* PKCS#1 v1.5 padding */
-                    if (this.direction == OpMode.WC_ENCRYPT) {
-
-                        if (this.rsaKeyType == RsaKeyType.WC_RSA_PRIVATE) {
-                            tmpOut = this.rsa.sign(tmpIn, this.rng);
-
                         } else {
-                            tmpOut = this.rsa.encrypt(tmpIn, this.rng);
-                        }
+                            if (this.rsaKeyType == RsaKeyType.WC_RSA_PUBLIC) {
+                                throw new IllegalStateException(
+                                    "OAEP padding requires private key for " +
+                                    "decryption");
+                            }
 
+                            try {
+                                tmpIn = leftPadRSACiphertext(tmpIn,
+                                    this.rsa.getEncryptSize());
+
+                                tmpOut = this.rsa.decryptOaep(tmpIn,
+                                    this.oaepHashType, this.oaepMgf);
+
+                            } catch (WolfCryptException e) {
+                                throw new BadPaddingException(
+                                    "Decryption error");
+                            }
+                        }
                     } else {
-                        try {
-                            tmpIn = leftPadRSACiphertext(tmpIn,
-                                this.rsa.getEncryptSize());
+                        /* PKCS#1 v1.5 padding */
+                        if (this.direction == OpMode.WC_ENCRYPT) {
 
                             if (this.rsaKeyType == RsaKeyType.WC_RSA_PRIVATE) {
-                                tmpOut = this.rsa.decrypt(tmpIn);
+                                tmpOut = this.rsa.sign(tmpIn, this.rng);
+
                             } else {
-                                tmpOut = this.rsa.verify(tmpIn);
+                                tmpOut = this.rsa.encrypt(tmpIn, this.rng);
                             }
-                        } catch (WolfCryptException e) {
-                            throw new BadPaddingException("Decryption error");
+
+                        } else {
+                            try {
+                                tmpIn = leftPadRSACiphertext(tmpIn,
+                                    this.rsa.getEncryptSize());
+
+                                if (this.rsaKeyType ==
+                                        RsaKeyType.WC_RSA_PRIVATE) {
+                                    tmpOut = this.rsa.decrypt(tmpIn);
+                                } else {
+                                    tmpOut = this.rsa.verify(tmpIn);
+                                }
+                            } catch (WolfCryptException e) {
+                                throw new BadPaddingException(
+                                    "Decryption error");
+                            }
                         }
                     }
-                }
-                break;
+                    break;
 
-            default:
-                throw new RuntimeException("Unsupported algorithm type");
-        };
+                default:
+                    throw new RuntimeException("Unsupported algorithm type");
+            };
+
+        } finally {
+            /* Zeroize the internal input copy for both directions */
+            zeroArray(tmpIn);
+        }
 
         /* reset state, user doesn't need to call init again before use */
         try {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptECKeyFactory.java
@@ -263,6 +263,9 @@ public class WolfCryptECKeyFactory extends KeyFactorySpi {
             if (ecc != null) {
                 ecc.releaseNativeStruct();
             }
+            if (pkcs8Der != null) {
+                Arrays.fill(pkcs8Der, (byte)0);
+            }
             if (privDer != null) {
                 Arrays.fill(privDer, (byte)0);
             }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptKeyGenerator.java
@@ -37,6 +37,7 @@ import java.security.NoSuchProviderException;
 import java.security.InvalidParameterException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.Arrays;
 
 /**
  * wolfCrypt JCE KeyGenerator implementation.
@@ -251,6 +252,7 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
     protected SecretKey engineGenerateKey() {
 
         byte[] keyArr = null;
+        SecretKey result = null;
 
         try {
             if (this.random == null) {
@@ -261,26 +263,36 @@ public class WolfCryptKeyGenerator extends KeyGeneratorSpi {
             return null;
         }
 
-        keyArr = new byte[(this.keySizeBits + 7) / 8];
-        this.random.nextBytes(keyArr);
+        try {
+            keyArr = new byte[(this.keySizeBits + 7) / 8];
+            this.random.nextBytes(keyArr);
 
-        log("Generating key: " + keyArr.length + " bytes");
+            log("Generating key: " + keyArr.length + " bytes");
 
-        switch (this.algoType) {
-            case WC_AES:
-            case WC_HMAC_SHA1:
-            case WC_HMAC_SHA224:
-            case WC_HMAC_SHA256:
-            case WC_HMAC_SHA384:
-            case WC_HMAC_SHA512:
-            case WC_HMAC_SHA3_224:
-            case WC_HMAC_SHA3_256:
-            case WC_HMAC_SHA3_384:
-            case WC_HMAC_SHA3_512:
-                return new SecretKeySpec(keyArr, this.algString);
-            default:
-                return null;
+            switch (this.algoType) {
+                case WC_AES:
+                case WC_HMAC_SHA1:
+                case WC_HMAC_SHA224:
+                case WC_HMAC_SHA256:
+                case WC_HMAC_SHA384:
+                case WC_HMAC_SHA512:
+                case WC_HMAC_SHA3_224:
+                case WC_HMAC_SHA3_256:
+                case WC_HMAC_SHA3_384:
+                case WC_HMAC_SHA3_512:
+                    /* SecretKeySpec clones the key bytes */
+                    result = new SecretKeySpec(keyArr, this.algString);
+                    break;
+                default:
+                    result = null;
+            }
+        } finally {
+            if (keyArr != null) {
+                Arrays.fill(keyArr, (byte)0);
+            }
         }
+
+        return result;
     }
 
     /**

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptPBEKey.java
@@ -123,7 +123,7 @@ public class WolfCryptPBEKey implements PBEKey {
      *
      * @throws IllegalStateException if object has been destroyed
      */
-    public synchronized char[] getPassword() {
+    public final synchronized char[] getPassword() {
 
         checkDestroyed();
 
@@ -141,7 +141,7 @@ public class WolfCryptPBEKey implements PBEKey {
      *
      * @throws IllegalStateException if object has been destroyed
      */
-    public synchronized byte[] getSalt() {
+    public final synchronized byte[] getSalt() {
 
         checkDestroyed();
 
@@ -197,7 +197,7 @@ public class WolfCryptPBEKey implements PBEKey {
      *
      * @throws IllegalStateException if object has been destroyed
      */
-    public synchronized byte[] getEncoded() {
+    public final synchronized byte[] getEncoded() {
 
         checkDestroyed();
 
@@ -312,8 +312,6 @@ public class WolfCryptPBEKey implements PBEKey {
             return false;
 
         } finally {
-            /* Only our own copies, the other key's accessors may return
-             * internal references and zeroizing those would destroy it */
             if (thisEncoded != null) {
                 Arrays.fill(thisEncoded, (byte)0);
             }
@@ -322,6 +320,20 @@ public class WolfCryptPBEKey implements PBEKey {
             }
             if (thisPass != null) {
                 Arrays.fill(thisPass, (char)0);
+            }
+            /* WolfCryptPBEKey accessors are final and return copies which
+             * are safe to zero, other implementations may return internal
+             * references and zeroizing would destroy the key */
+            if (pKey instanceof WolfCryptPBEKey) {
+                if (pKeyEncoded != null) {
+                    Arrays.fill(pKeyEncoded, (byte)0);
+                }
+                if (pKeySalt != null) {
+                    Arrays.fill(pKeySalt, (byte)0);
+                }
+                if (pKeyPass != null) {
+                    Arrays.fill(pKeyPass, (char)0);
+                }
             }
         }
     }

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptRSAKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptRSAKeyFactory.java
@@ -378,6 +378,9 @@ public class WolfCryptRSAKeyFactory extends KeyFactorySpi {
             if (rsa != null) {
                 rsa.releaseNativeStruct();
             }
+            if (pkcs8Der != null) {
+                Arrays.fill(pkcs8Der, (byte)0);
+            }
         }
     }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -910,114 +910,125 @@ public class WolfCryptSignature extends SignatureSpi {
         byte[] encDigest = new byte[Asn.MAX_ENCODED_SIG_SIZE];
         byte[] verify    = new byte[Asn.MAX_ENCODED_SIG_SIZE];
 
-        /* get final digest */
         try {
-            synchronized (hashLock) {
-                switch (this.digestType) {
-                    case WC_MD5:
-                        this.md5.digest(digest);
-                        break;
+            /* get final digest */
+            try {
+                synchronized (hashLock) {
+                    switch (this.digestType) {
+                        case WC_MD5:
+                            this.md5.digest(digest);
+                            break;
 
-                    case WC_SHA1:
-                        this.sha.digest(digest);
-                        break;
+                        case WC_SHA1:
+                            this.sha.digest(digest);
+                            break;
 
-                    case WC_SHA224:
-                        this.sha224.digest(digest);
-                        break;
+                        case WC_SHA224:
+                            this.sha224.digest(digest);
+                            break;
 
-                    case WC_SHA256:
-                        this.sha256.digest(digest);
-                        break;
+                        case WC_SHA256:
+                            this.sha256.digest(digest);
+                            break;
 
-                    case WC_SHA384:
-                        this.sha384.digest(digest);
-                        break;
+                        case WC_SHA384:
+                            this.sha384.digest(digest);
+                            break;
 
-                    case WC_SHA512:
-                        this.sha512.digest(digest);
-                        break;
+                        case WC_SHA512:
+                            this.sha512.digest(digest);
+                            break;
 
-                    case WC_SHA3_224:
-                    case WC_SHA3_256:
-                    case WC_SHA3_384:
-                    case WC_SHA3_512:
-                        this.sha3.digest(digest);
-                        break;
+                        case WC_SHA3_224:
+                        case WC_SHA3_256:
+                        case WC_SHA3_384:
+                        case WC_SHA3_512:
+                            this.sha3.digest(digest);
+                            break;
+                    }
                 }
+
+            } catch (ShortBufferException e) {
+                throw new SignatureException(e.getMessage());
             }
 
-        } catch (ShortBufferException e) {
-            throw new SignatureException(e.getMessage());
-        }
+            /* verify digest */
+            switch (this.keyType) {
+                case WC_RSA:
+                    if (this.paddingType == PaddingType.WC_RSA_PSS) {
+                        /* RSA-PSS verification */
+                        int mgfType = getMgfTypeFromParams();
+                        int saltLen = this.pssParams.getSaltLength();
 
-        /* verify digest */
-        switch (this.keyType) {
-            case WC_RSA:
-                if (this.paddingType == PaddingType.WC_RSA_PSS) {
-                    /* RSA-PSS verification */
-                    int mgfType = getMgfTypeFromParams();
-                    int saltLen = this.pssParams.getSaltLength();
+                        /* Convert -1 (default) to digest length */
+                        if (saltLen == -1) {
+                            saltLen = this.digestSz;
+                        }
 
-                    /* Convert -1 (default) to digest length */
-                    if (saltLen == -1) {
-                        saltLen = this.digestSz;
-                    }
+                        try {
+                            /* Use rsaPssVerifyWithDigest for pre-computed
+                             * digest verification. Pass digest as both data
+                             * and digest since we only have the final digest
+                             * here */
+                            verified = this.rsa.rsaPssVerifyWithDigest(
+                                sigBytes, digest, digest,
+                                digestTypeToHashType(this.digestType), mgfType,
+                                saltLen);
 
-                    try {
-                        /* Use rsaPssVerifyWithDigest for pre-computed digest
-                         * verification. Pass digest as both data and digest
-                         * since we only have the final digest here */
-                        verified = this.rsa.rsaPssVerifyWithDigest(
-                            sigBytes, digest, digest,
-                            digestTypeToHashType(this.digestType), mgfType,
-                            saltLen);
+                        } catch (WolfCryptException e) {
+                            verified = false;
+                        }
 
-                    } catch (WolfCryptException e) {
-                        verified = false;
-                    }
+                    } else {
+                        /* Existing PKCS#1 v1.5 verification code */
+                        encodedSz = Asn.encodeSignature(encDigest, digest,
+                                        digest.length, this.internalHashSum);
 
-                } else {
-                    /* Existing PKCS#1 v1.5 verification code */
-                    encodedSz = Asn.encodeSignature(encDigest, digest,
-                                    digest.length, this.internalHashSum);
+                        if (encodedSz < 0) {
+                            throw new SignatureException(
+                                "Failed to DER encode digest during sig " +
+                                "verify");
+                        }
 
-                    if (encodedSz < 0) {
-                        throw new SignatureException(
-                            "Failed to DER encode digest during sig verify");
-                    }
+                        try {
+                            verify = this.rsa.verify(sigBytes);
+                        } catch (WolfCryptException e) {
+                            verified = false;
+                        }
 
-                    try {
-                        verify = this.rsa.verify(sigBytes);
-                    } catch (WolfCryptException e) {
-                        verified = false;
-                    }
-
-                    /* compare expected digest to one unwrapped from verify */
-                    if ((encodedSz > encDigest.length) ||
-                        (verify.length != encodedSz)) {
-                        verified = false;
-                    }
-                    else {
-                        for (int i = 0; i < verify.length; i++) {
-                            if (verify[i] != encDigest[i]) {
-                                verified = false;
+                        /* compare expected digest to one unwrapped from
+                         * verify */
+                        if ((encodedSz > encDigest.length) ||
+                            (verify.length != encodedSz)) {
+                            verified = false;
+                        }
+                        else {
+                            for (int i = 0; i < verify.length; i++) {
+                                if (verify[i] != encDigest[i]) {
+                                    verified = false;
+                                }
                             }
                         }
                     }
-                }
 
-                break;
+                    break;
 
-            case WC_ECDSA:
+                case WC_ECDSA:
 
-                try {
-                    verified = this.ecc.verify(digest, sigBytes);
-                } catch (WolfCryptException we) {
-                    verified = false;
-                }
+                    try {
+                        verified = this.ecc.verify(digest, sigBytes);
+                    } catch (WolfCryptException we) {
+                        verified = false;
+                    }
 
-                break;
+                    break;
+            }
+
+        } finally {
+            /* Zero arrays before refs drop */
+            zeroArray(digest);
+            zeroArray(encDigest);
+            zeroArray(verify);
         }
 
         if (sigBytes != null) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSignature.java
@@ -724,95 +724,103 @@ public class WolfCryptSignature extends SignatureSpi {
         byte[] digest    = new byte[this.digestSz];
         byte[] encDigest = new byte[Asn.MAX_ENCODED_SIG_SIZE];
         byte[] signature = new byte[Asn.MAX_ENCODED_SIG_SIZE];
+        byte[] tmp       = null;
 
-        /* get final digest */
         try {
-            synchronized (hashLock) {
-                switch (this.digestType) {
-                    case WC_MD5:
-                        this.md5.digest(digest);
-                        break;
+            /* get final digest */
+            try {
+                synchronized (hashLock) {
+                    switch (this.digestType) {
+                        case WC_MD5:
+                            this.md5.digest(digest);
+                            break;
 
-                    case WC_SHA1:
-                        this.sha.digest(digest);
-                        break;
+                        case WC_SHA1:
+                            this.sha.digest(digest);
+                            break;
 
-                    case WC_SHA224:
-                        this.sha224.digest(digest);
-                        break;
+                        case WC_SHA224:
+                            this.sha224.digest(digest);
+                            break;
 
-                    case WC_SHA256:
-                        this.sha256.digest(digest);
-                        break;
+                        case WC_SHA256:
+                            this.sha256.digest(digest);
+                            break;
 
-                    case WC_SHA384:
-                        this.sha384.digest(digest);
-                        break;
+                        case WC_SHA384:
+                            this.sha384.digest(digest);
+                            break;
 
-                    case WC_SHA512:
-                        this.sha512.digest(digest);
-                        break;
+                        case WC_SHA512:
+                            this.sha512.digest(digest);
+                            break;
 
-                    case WC_SHA3_224:
-                    case WC_SHA3_256:
-                    case WC_SHA3_384:
-                    case WC_SHA3_512:
-                        this.sha3.digest(digest);
-                        break;
+                        case WC_SHA3_224:
+                        case WC_SHA3_256:
+                        case WC_SHA3_384:
+                        case WC_SHA3_512:
+                            this.sha3.digest(digest);
+                            break;
+                    }
                 }
+            } catch (ShortBufferException e) {
+                throw new SignatureException(e.getMessage());
             }
-        } catch (ShortBufferException e) {
-            throw new SignatureException(e.getMessage());
-        }
 
-        /* sign digest */
-        switch (this.keyType) {
-            case WC_RSA:
-                if (this.paddingType == PaddingType.WC_RSA_PSS) {
-                    /* RSA-PSS signature */
-                    int mgfType = getMgfTypeFromParams();
-                    int saltLen = this.pssParams.getSaltLength();
+            /* sign digest */
+            switch (this.keyType) {
+                case WC_RSA:
+                    if (this.paddingType == PaddingType.WC_RSA_PSS) {
+                        /* RSA-PSS signature */
+                        int mgfType = getMgfTypeFromParams();
+                        int saltLen = this.pssParams.getSaltLength();
 
-                    /* Convert -1 (default) to digest length */
-                    if (saltLen == -1) {
-                        saltLen = this.digestSz;
+                        /* Convert -1 (default) to digest length */
+                        if (saltLen == -1) {
+                            saltLen = this.digestSz;
+                        }
+
+                        synchronized (rngLock) {
+                            signature = this.rsa.rsaPssSign(digest,
+                                digestTypeToHashType(this.digestType),
+                                mgfType, saltLen, this.rng);
+                        }
+                    } else {
+                        /* Existing PKCS#1 v1.5 signature code */
+                        encodedSz = (int)Asn.encodeSignature(encDigest,
+                            digest, digest.length, this.internalHashSum);
+
+                        if (encodedSz < 0) {
+                            throw new SignatureException(
+                                "Failed to DER encode digest during sig gen");
+                        }
+
+                        tmp = new byte[encodedSz];
+                        System.arraycopy(encDigest, 0, tmp, 0, encodedSz);
+                        synchronized (rngLock) {
+                            signature = this.rsa.sign(tmp, this.rng);
+                        }
                     }
 
-                    synchronized (rngLock) {
-                        signature = this.rsa.rsaPssSign(digest,
-                            digestTypeToHashType(this.digestType),
-                            mgfType, saltLen, this.rng);
-                    }
-                } else {
-                    /* Existing PKCS#1 v1.5 signature code */
-                    encodedSz = (int)Asn.encodeSignature(encDigest, digest,
-                                    digest.length, this.internalHashSum);
+                    break;
 
-                    if (encodedSz < 0) {
-                        throw new SignatureException(
-                            "Failed to DER encode digest during sig gen");
-                    }
+                case WC_ECDSA:
 
-                    byte[] tmp = new byte[encodedSz];
-                    System.arraycopy(encDigest, 0, tmp, 0, encodedSz);
-                    synchronized (rngLock) {
-                        signature = this.rsa.sign(tmp, this.rng);
-                    }
-                    zeroArray(tmp);
-                }
+                    /* Ecc.sign() internally has a rngLock unlike Rsa.sign() */
+                    signature = this.ecc.sign(digest, this.rng);
 
-                break;
+                    break;
 
-            case WC_ECDSA:
+                default:
+                    throw new SignatureException(
+                        "Invalid signature algorithm type");
+            }
 
-                /* Ecc.sign() internally has a rngLock unlike Rsa.sign() */
-                signature = this.ecc.sign(digest, this.rng);
-
-                break;
-
-            default:
-                throw new SignatureException(
-                    "Invalid signature algorithm type");
+        } finally {
+            /* Zeroize message digest and DER encoding before refs drop */
+            zeroArray(digest);
+            zeroArray(encDigest);
+            zeroArray(tmp);
         }
 
         if (signature != null) {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/PwdbasedTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/PwdbasedTest.java
@@ -134,4 +134,52 @@ public class PwdbasedTest {
         assertArrayEquals("PKCS12_PBKDF modified caller password array",
             passCopy, pass);
     }
+
+    /**
+     * PBKDF2 must reject zero/negative key lengths with BAD_FUNC_ARG.
+     */
+    @Test
+    public void testPbkdf2RejectsNonPositiveKeyLength() {
+
+        Assume.assumeTrue("PBKDF2 not compiled in native wolfSSL",
+            FeatureDetect.Pbkdf2Enabled());
+
+        byte[] pass = makePassword();
+        byte[] salt = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+
+        for (int kLen : new int[] {-1, 0}) {
+            try {
+                Pwdbased.PBKDF2(pass, salt, 100, kLen,
+                    WolfCrypt.WC_HASH_TYPE_SHA256);
+                fail("PBKDF2 should reject kLen: " + kLen);
+            } catch (WolfCryptException e) {
+                assertEquals("kLen " + kLen + " must map to BAD_FUNC_ARG",
+                    WolfCryptError.BAD_FUNC_ARG, e.getError());
+            }
+        }
+    }
+
+    /**
+     * PKCS12 PBKDF must reject zero/negative key lengths with BAD_FUNC_ARG.
+     */
+    @Test
+    public void testPkcs12PbkdfRejectsNonPositiveKeyLength() {
+
+        byte[] pass = makePassword();
+        byte[] salt = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+
+        for (int kLen : new int[] {-1, 0}) {
+            try {
+                Pwdbased.PKCS12_PBKDF(pass, salt, 100, kLen,
+                    WolfCrypt.WC_HASH_TYPE_SHA256, 1);
+                fail("PKCS12_PBKDF should reject kLen: " + kLen);
+            } catch (WolfCryptException e) {
+                Assume.assumeTrue(
+                    "PKCS12 PBKDF not compiled in native wolfSSL",
+                    e.getError() != WolfCryptError.NOT_COMPILED_IN);
+                assertEquals("kLen " + kLen + " must map to BAD_FUNC_ARG",
+                    WolfCryptError.BAD_FUNC_ARG, e.getError());
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR includes 10 Fenrir fixes:

  - **F-4365**: Zeroize message digest and DER DigestInfo buffers in Signature engineSign() on all paths
  - **F-4370**: Zeroize the native copy of the PKCS#8 private key in X509CheckPrivateKey() before JNI release
  - **F-4439**: Zeroize freshly generated symmetric key bytes in KeyGenerator engineGenerateKey()
  - **F-4861**: Zeroize the PKCS8EncodedKeySpec getEncoded() copy in the EC KeyFactory private key decode path
  - **F-4862**: Zeroize digest, DER encoding, and recovered signature buffers in Signature engineVerify()
  - **F-4863**: Zeroize internal plaintext input copies in Cipher wolfCryptFinal() and wolfCryptUpdate()
  - **F-4864**: Zeroize intermediate output copies in the two arg engineDoFinal() and engineUpdate() overloads
  - **F-4865**: Zeroize peer key copies in WolfCryptPBEKey equals() when the peer is a WolfCryptPBEKey
  - **F-5035**: Zeroize the PKCS8EncodedKeySpec getEncoded() copy in the RSA KeyFactory private key decode path
  - **F-5037 / F-5038**: Reject zero and negative key lengths with BAD_FUNC_ARG in PKCS12 PBKDF and PBKDF2 wrappers