### PR TITLE
Quote shell paths in cert conversion/update scripts

### DIFF
--- a/examples/certs/systemcerts/system-cacerts-to-wks.sh
+++ b/examples/certs/systemcerts/system-cacerts-to-wks.sh
@@ -51,7 +51,11 @@ fi
 
 # ARGS: <input-keystore-name> <output-keystore-name> <in-password> <out-password> <java home>
 jks_to_wks() {
-    ${5}/bin/keytool -importkeystore -srckeystore ${1} -destkeystore ${2}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "$3" -deststorepass "$3" -deststorepass "$4" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath "$PROVIDER_PATH"
+    "${5}/bin/keytool" -importkeystore -srckeystore "${1}" \
+        -destkeystore "${2}.wks" -srcstoretype JKS -deststoretype WKS \
+        -srcstorepass "$3" -deststorepass "$4" \
+        -provider com.wolfssl.provider.jce.WolfCryptProvider \
+        --providerpath "$PROVIDER_PATH"
     if [ $? -ne 0 ]; then
         printf "Failed to convert JKS to WKS!"
         exit 1
@@ -120,7 +124,7 @@ if [ -f "$javaHome/$CACERTS_JDK9" ]; then
     if [ -f "$OUTDIR/cacerts.wks" ]; then
         rm "$OUTDIR/cacerts.wks"
     fi
-    jks_to_wks "$javaHome/$CACERTS_JDK9" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
+    jks_to_wks "$javaHome/$CACERTS_JDK9" "$OUTDIR/cacerts" "changeit" "changeitchangeit" "$javaHome"
 fi
 
 if [ -f "$javaHome/$CACERTS_JDK8" ]; then
@@ -132,10 +136,10 @@ if [ -f "$javaHome/$CACERTS_JDK8" ]; then
     if [ -f "$OUTDIR/cacerts.wks" ]; then
         rm "$OUTDIR/cacerts.wks"
     fi
-    jks_to_wks "$javaHome/$CACERTS_JDK8" "$OUTDIR/cacerts" "changeit" "changeitchangeit" $javaHome
+    jks_to_wks "$javaHome/$CACERTS_JDK8" "$OUTDIR/cacerts" "changeit" "changeitchangeit" "$javaHome"
 fi
 
-if [ -f "$javaHome/$JSSECERTS_JDK9" ]; then
+if [ -f "$javaHome/$JSSECACERTS_JDK9" ]; then
     echo "System jssecacerts found, converting from JKS to WKS:"
     echo "    FROM: $javaHome/$JSSECACERTS_JDK9"
     echo "    TO:   $OUTDIR/jssecacerts.wks"
@@ -144,10 +148,10 @@ if [ -f "$javaHome/$JSSECERTS_JDK9" ]; then
     if [ -f "$OUTDIR/jssecacerts.wks" ]; then
         rm "$OUTDIR/jssecacerts.wks"
     fi
-    jks_to_wks "$javaHome/$JSSECACERTS_JDK9" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
+    jks_to_wks "$javaHome/$JSSECACERTS_JDK9" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" "$javaHome"
 fi
 
-if [ -f "$javaHome/$JSSECERTS_JDK8" ]; then
+if [ -f "$javaHome/$JSSECACERTS_JDK8" ]; then
     echo "System jssecacerts found, converting from JKS to WKS:"
     echo "    FROM: $javaHome/$JSSECACERTS_JDK8"
     echo "    TO:   $OUTDIR/jssecacerts.wks"
@@ -156,7 +160,7 @@ if [ -f "$javaHome/$JSSECERTS_JDK8" ]; then
     if [ -f "$OUTDIR/jssecacerts.wks" ]; then
         rm "$OUTDIR/jssecacerts.wks"
     fi
-    jks_to_wks "$javaHome/$JSSECACERTS_JDK8" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" $javaHome
+    jks_to_wks "$javaHome/$JSSECACERTS_JDK8" "$OUTDIR/jssecacerts" "changeit" "changeitchangeit" "$javaHome"
 fi
 
 echo ""

--- a/examples/certs/update-certs.sh
+++ b/examples/certs/update-certs.sh
@@ -22,7 +22,11 @@ if [ -z "$1" ]; then
     printf "\tExample use ./update-certs.sh ~/wolfssl/certs\n"
     exit 1;
 fi
-CERT_LOCATION=$1
+CERT_LOCATION="$1"
+if [ ! -d "$CERT_LOCATION" ]; then
+    printf "Error: %s is not a directory\n" "$CERT_LOCATION"
+    exit 1
+fi
 
 # Copy cert files from wolfssl/certs to local examples/certs
 certList=(
@@ -115,7 +119,7 @@ slhdsaCertList=(
 for i in ${!certList[@]};
 do
     printf "Updating: ${certList[$i]}\n"
-    cp $CERT_LOCATION/${certList[$i]} ./${certList[$i]}
+    cp -- "$CERT_LOCATION/${certList[$i]}" "./${certList[$i]}"
     if [ $? -ne 0 ]; then
         printf "Failed to copy cert: ${certList[$i]}\n"
         exit 1
@@ -126,7 +130,7 @@ if [ -d "$CERT_LOCATION/mldsa" ]; then
     for i in ${!mldsaCertList[@]};
     do
         printf "Updating: ${mldsaCertList[$i]}\n"
-        cp $CERT_LOCATION/${mldsaCertList[$i]} ./${mldsaCertList[$i]}
+        cp -- "$CERT_LOCATION/${mldsaCertList[$i]}" "./${mldsaCertList[$i]}"
         if [ $? -ne 0 ]; then
             printf "Warning: skipped missing ML-DSA cert: "
             printf "${mldsaCertList[$i]}\n"
@@ -142,7 +146,7 @@ if [ -d "$CERT_LOCATION/xmss" ]; then
     for i in ${!xmssCertList[@]};
     do
         printf "Updating: ${xmssCertList[$i]}\n"
-        cp $CERT_LOCATION/${xmssCertList[$i]} ./${xmssCertList[$i]}
+        cp -- "$CERT_LOCATION/${xmssCertList[$i]}" "./${xmssCertList[$i]}"
         if [ $? -ne 0 ]; then
             printf "Warning: skipped missing XMSS cert: "
             printf "${xmssCertList[$i]}\n"
@@ -158,7 +162,7 @@ if [ -d "$CERT_LOCATION/lms" ]; then
     for i in ${!lmsCertList[@]};
     do
         printf "Updating: ${lmsCertList[$i]}\n"
-        cp $CERT_LOCATION/${lmsCertList[$i]} ./${lmsCertList[$i]}
+        cp -- "$CERT_LOCATION/${lmsCertList[$i]}" "./${lmsCertList[$i]}"
         if [ $? -ne 0 ]; then
             printf "Warning: skipped missing LMS cert: "
             printf "${lmsCertList[$i]}\n"
@@ -174,7 +178,7 @@ if [ -d "$CERT_LOCATION/slhdsa" ]; then
     for i in ${!slhdsaCertList[@]};
     do
         printf "Updating: ${slhdsaCertList[$i]}\n"
-        cp $CERT_LOCATION/${slhdsaCertList[$i]} ./${slhdsaCertList[$i]}
+        cp -- "$CERT_LOCATION/${slhdsaCertList[$i]}" "./${slhdsaCertList[$i]}"
         if [ $? -ne 0 ]; then
             printf "Warning: skipped missing SLH-DSA cert: "
             printf "${slhdsaCertList[$i]}\n"


### PR DESCRIPTION
This PR includes two Fenrir fixes:

  - **F-4000**: Quote JAVA_HOME and keystore paths in the system-cacerts-to-wks.sh keytool invocation so a path containing spaces is not word-split.
  - **F-4001**: Quote CERT_LOCATION and the cp paths in update-certs.sh and validate the certs directory before copying.