### PR TITLE
Fixes across debug logging, key zeroization, and native input handling

### DIFF
--- a/jni/include/com_wolfssl_wolfcrypt_Chacha.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Chacha.h
@@ -41,6 +41,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setKey
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
   (JNIEnv *, jobject, jbyteArray);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_Chacha
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_native_1free
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/include/com_wolfssl_wolfcrypt_Hmac.h
+++ b/jni/include/com_wolfssl_wolfcrypt_Hmac.h
@@ -153,6 +153,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_Hmac_getCodeSha3_1512
 JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Hmac_mallocNativeStruct
   (JNIEnv *, jobject);
 
+/*
+ * Class:     com_wolfssl_wolfcrypt_Hmac
+ * Method:    native_free
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_native_1free
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/jni_aes.c
+++ b/jni/jni_aes.c
@@ -145,10 +145,12 @@ Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__I_3BII_3BI(
         LogStr("wc_AesCbcDecrypt(aes=%p, out, in, inSz) = %d\n", aes, ret);
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output, ret);
@@ -223,10 +225,12 @@ Java_com_wolfssl_wolfcrypt_Aes_native_1update_1internal__ILjava_nio_ByteBuffer_2
         ret = length;
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 #else
     throwNotCompiledInException(env);
     ret = NOT_COMPILED_IN;

--- a/jni/jni_aesccm.c
+++ b/jni/jni_aesccm.c
@@ -204,12 +204,17 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesCcm_wc_1AesCcmEncrypt
 
     /* Allocate new buffer to hold ciphertext */
     if (ret == 0) {
-        out = (byte*)XMALLOC(inLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        word32 outSz = inLen;
+        if (outSz == 0) {
+            /* AAD-only case, allocate 1 byte to avoid XMALLOC(0) */
+            outSz = 1;
+        }
+        out = (byte*)XMALLOC(outSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out == NULL) {
             ret = MEMORY_E;
         }
         else {
-            XMEMSET(out, 0, inLen);
+            XMEMSET(out, 0, outSz);
         }
     }
 
@@ -336,12 +341,17 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesCcm_wc_1AesCcmDecrypt
     }
 
     if (ret == 0) {
-        out = (byte*)XMALLOC(inLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        word32 outSz = inLen;
+        if (outSz == 0) {
+            /* AAD-only case, allocate 1 byte to avoid XMALLOC(0) */
+            outSz = 1;
+        }
+        out = (byte*)XMALLOC(outSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out == NULL) {
             ret = MEMORY_E;
         }
         else {
-            XMEMSET(out, 0, inLen);
+            XMEMSET(out, 0, outSz);
         }
     }
 

--- a/jni/jni_aescmac.c
+++ b/jni/jni_aescmac.c
@@ -197,8 +197,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCmac_wc_1CmacUpdate___3BII(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_CmacUpdate(cmac=%p, data, length) = %d\n", cmac, ret);
-    LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
-    LogHex((byte*) data, offset, length);
+    if (data != NULL) {
+        LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
+        LogHex((byte*) data, offset, length);
+    }
 
     releaseByteArray(env, data_object, data, JNI_ABORT);
 #else
@@ -236,8 +238,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCmac_wc_1CmacUpdate__Ljava_
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_CmacUpdate(cmac=%p, data, length) = %d\n", cmac, ret);
-    LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
-    LogHex((byte*) data, offset, length);
+    if (data != NULL) {
+        LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
+        LogHex((byte*) data, offset, length);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/jni/jni_aesctr.c
+++ b/jni/jni_aesctr.c
@@ -146,10 +146,12 @@ Java_com_wolfssl_wolfcrypt_AesCtr_native_1update_1internal___3BII_3BI(
         LogStr("wc_AesCtrEncrypt(aes=%p, out, in, inSz) = %d\n", aes, ret);
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output, ret);
@@ -218,10 +220,12 @@ Java_com_wolfssl_wolfcrypt_AesCtr_native_1update_1internal__Ljava_nio_ByteBuffer
         ret = length;
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output);
-    LogHex((byte*) output, 0, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/jni/jni_aescts.c
+++ b/jni/jni_aescts.c
@@ -116,6 +116,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1set_1key_1inter
     byte* key = NULL;
     byte* iv  = NULL;
     word32 keySz = 0;
+    word32 ivSz  = 0;
 
     ctx = (AesCtsCtx*) getNativeStruct(env, this);
     if ((*env)->ExceptionOccurred(env)) {
@@ -126,8 +127,12 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1set_1key_1inter
     key = getByteArray(env, key_object);
     iv  = getByteArray(env, iv_object);
     keySz = getByteArrayLength(env, key_object);
+    ivSz  = getByteArrayLength(env, iv_object);
 
     if (ctx == NULL || key == NULL || iv == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else if (ivSz != AES_BLOCK_SIZE) {
         ret = BAD_FUNC_ARG;
     }
 

--- a/jni/jni_aescts.c
+++ b/jni/jni_aescts.c
@@ -259,10 +259,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_wolfcrypt_AesCts_native_1update_1interna
             ctx, opmode, length, ret);
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output,

--- a/jni/jni_aesecb.c
+++ b/jni/jni_aesecb.c
@@ -151,10 +151,12 @@ Java_com_wolfssl_wolfcrypt_AesEcb_native_1update_1internal__I_3BII_3BI(
         LogStr("wc_AesEcbDecrypt(aes=%p, out, in, inSz) = %d\n", aes, ret);
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output, ret);
@@ -232,10 +234,12 @@ Java_com_wolfssl_wolfcrypt_AesEcb_native_1update_1internal__ILjava_nio_ByteBuffe
         ret = length;
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 #else
     throwNotCompiledInException(env);
     ret = NOT_COMPILED_IN;

--- a/jni/jni_aesgcm.c
+++ b/jni/jni_aesgcm.c
@@ -211,12 +211,17 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesGcmEncrypt
 
     /* Allocate new buffer to hold ciphertext */
     if (ret == 0) {
-        out = (byte*)XMALLOC(inLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        word32 outSz = inLen;
+        if (outSz == 0) {
+            /* AAD-only case, allocate 1 byte to avoid XMALLOC(0) */
+            outSz = 1;
+        }
+        out = (byte*)XMALLOC(outSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out == NULL) {
             ret = MEMORY_E;
         }
         else {
-            XMEMSET(out, 0, inLen);
+            XMEMSET(out, 0, outSz);
         }
     }
 
@@ -362,12 +367,17 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_wolfcrypt_AesGcm_wc_1AesGcmDecrypt
     }
 
     if (ret == 0) {
-        out = (byte*)XMALLOC(inLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        word32 outSz = inLen;
+        if (outSz == 0) {
+            /* AAD-only case, allocate 1 byte to avoid XMALLOC(0) */
+            outSz = 1;
+        }
+        out = (byte*)XMALLOC(outSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out == NULL) {
             ret = MEMORY_E;
         }
         else {
-            XMEMSET(out, 0, inLen);
+            XMEMSET(out, 0, outSz);
         }
     }
 

--- a/jni/jni_aesofb.c
+++ b/jni/jni_aesofb.c
@@ -159,10 +159,12 @@ Java_com_wolfssl_wolfcrypt_AesOfb_native_1update_1internal__I_3BII_3BI(
 #endif
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output, ret);
@@ -246,10 +248,12 @@ Java_com_wolfssl_wolfcrypt_AesOfb_native_1update_1internal__ILjava_nio_ByteBuffe
         ret = length;
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 #else
     throwNotCompiledInException(env);
     ret = NOT_COMPILED_IN;

--- a/jni/jni_chacha.c
+++ b/jni/jni_chacha.c
@@ -65,6 +65,32 @@ Java_com_wolfssl_wolfcrypt_Chacha_mallocNativeStruct(
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_native_1free
+    (JNIEnv* env, jobject this)
+{
+#ifdef HAVE_CHACHA
+    ChaCha* chacha = (ChaCha*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free ChaCha %p\n", chacha);
+
+    if (chacha) {
+        /* Zeroize ChaCha key/state, NativeStruct.xfree() frees memory */
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(chacha, sizeof(ChaCha));
+    #else
+        XMEMSET(chacha, 0, sizeof(ChaCha));
+    #endif
+    }
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Chacha_wc_1Chacha_1setIV
   (JNIEnv* env, jobject this, jbyteArray iv_object)
 {

--- a/jni/jni_des3.c
+++ b/jni/jni_des3.c
@@ -144,10 +144,12 @@ Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__I_3BII_3BI(
         LogStr("wc_Des3CbcDecrypt(des=%p, out, in, inSz) = %d\n", des, ret);
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 
     releaseByteArray(env, input_object, input, JNI_ABORT);
     releaseByteArray(env, output_object, output, ret);
@@ -221,10 +223,12 @@ Java_com_wolfssl_wolfcrypt_Des3_native_1update_1internal__ILjava_nio_ByteBuffer_
         ret = length;
     }
 
-    LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
-    LogHex((byte*) input, offset, length);
-    LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
-    LogHex((byte*) output, outputOffset, length);
+    if (input != NULL && output != NULL) {
+        LogStr("input[%u]: [%p]\n", (word32)length, input + offset);
+        LogHex((byte*) input, offset, length);
+        LogStr("output[%u]: [%p]\n", (word32)length, output + outputOffset);
+        LogHex((byte*) output, outputOffset, length);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -148,6 +148,34 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_Hmac_mallocNativeStruct
 #endif
 }
 
+JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_native_1free
+    (JNIEnv* env, jobject this)
+{
+#ifndef NO_HMAC
+    Hmac* hmac = (Hmac*) getNativeStruct(env, this);
+    if ((*env)->ExceptionOccurred(env)) {
+        /* getNativeStruct may throw exception, prevent throwing another */
+        return;
+    }
+
+    LogStr("free Hmac %p\n", hmac);
+
+    if (hmac) {
+        /* Free device/async/inner-hash resources, then zeroize key-derived
+         * ipad/opad. NativeStruct.xfree() frees the memory. */
+        wc_HmacFree(hmac);
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(hmac, sizeof(Hmac));
+    #else
+        XMEMSET(hmac, 0, sizeof(Hmac));
+    #endif
+    }
+#else
+    throwNotCompiledInException(env);
+#endif
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacSetKey
     (JNIEnv* env, jobject this, jint type, jbyteArray key_object)
 {

--- a/jni/jni_hmac.c
+++ b/jni/jni_hmac.c
@@ -287,8 +287,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacUpdate___3BII
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_HmacUpdate(hmac=%p, data, length) = %d\n", hmac, ret);
-    LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
-    LogHex((byte*) data, offset, length);
+    if (data != NULL) {
+        LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
+        LogHex((byte*) data, offset, length);
+    }
 
     releaseByteArray(env, data_object, data, JNI_ABORT);
 #else
@@ -326,8 +328,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Hmac_wc_1HmacUpdate__Ljava_nio
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_HmacUpdate(hmac=%p, data, length) = %d\n", hmac, ret);
-    LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
-    LogHex((byte*) data, offset, length);
+    if (data != NULL) {
+        LogStr("data[%u]: [%p]\n", (word32)length, data + offset);
+        LogHex((byte*) data, offset, length);
+    }
 #else
     throwNotCompiledInException(env);
 #endif

--- a/jni/jni_md5.c
+++ b/jni/jni_md5.c
@@ -163,8 +163,8 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1update_1internal__Ljava_nio_ByteBuffer_2I
 
     LogStr("wc_Md5Update(md5=%p, data, len)\n", md5);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     throwNotCompiledInException(env);
@@ -240,8 +240,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
     }
 
     LogStr("wc_Md5Final(md5=%p, hash)\n", md5);
-    LogStr("hash[%u]: [%p]\n", (word32)MD5_DIGEST_SIZE, hash);
-    LogHex(hash, 0, MD5_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)MD5_DIGEST_SIZE, hash + position);
+        LogHex(hash, position, MD5_DIGEST_SIZE);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -274,8 +276,10 @@ Java_com_wolfssl_wolfcrypt_Md5_native_1final_1internal___3B(
     }
 
     LogStr("wc_Md5Final(md5=%p, hash)\n", md5);
-    LogStr("hash[%u]: [%p]\n", (word32)MD5_DIGEST_SIZE, hash);
-    LogHex(hash, 0, MD5_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)MD5_DIGEST_SIZE, hash);
+        LogHex(hash, 0, MD5_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, 0);
 #else

--- a/jni/jni_rng.c
+++ b/jni/jni_rng.c
@@ -148,8 +148,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Rng_rngGenerateBlock__Ljava_ni
     }
 
     LogStr("wc_RNG_GenerateBlock(rng=%p, buffer, size) = %d\n", rng, ret);
-    LogStr("output[%u]: [%p]\n", (word32)size, buffer);
-    LogHex(buffer, 0, size);
+    if (buffer != NULL) {
+        LogStr("output[%u]: [%p]\n", (word32)size, buffer + position);
+        LogHex(buffer, position, size);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -189,8 +191,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Rng_rngGenerateBlock___3BII(
     }
 
     LogStr("wc_RNG_GenerateBlock(rng=%p, buffer, length) = %d\n", rng, ret);
-    LogStr("output[%u]: [%p]\n", (word32)length, buffer);
-    LogHex(buffer, 0, length);
+    if (buffer != NULL) {
+        LogStr("output[%u]: [%p]\n", (word32)length, buffer + offset);
+        LogHex(buffer, offset, length);
+    }
 
     releaseByteArray(env, buffer_buffer, buffer, ret);
 #else

--- a/jni/jni_rsa.c
+++ b/jni/jni_rsa.c
@@ -742,6 +742,10 @@ Java_com_wolfssl_wolfcrypt_Rsa_wc_1RsaSetRNG(
     else {
         return JNI_TRUE;
     }
+#else
+    (void)env;
+    (void)this;
+    (void)rng_object;
 #endif
 
 #else

--- a/jni/jni_sha.c
+++ b/jni/jni_sha.c
@@ -291,8 +291,8 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal__Ljava_nio_ByteBuffer_2I
 
     LogStr("wc_ShaUpdate(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     throwNotCompiledInException(env);
@@ -331,7 +331,7 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1update_1internal___3BII(
 
     LogStr("wc_ShaUpdate_fips(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + offset);
         LogHex(data, offset, len);
     }
 
@@ -366,8 +366,10 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal__Ljava_nio_ByteBuffer_2I(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_ShaFinal(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash + position);
+        LogHex(hash, position, SHA_DIGEST_SIZE);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -398,8 +400,10 @@ Java_com_wolfssl_wolfcrypt_Sha_native_1final_1internal___3B(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_ShaFinal(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA_DIGEST_SIZE, hash);
+        LogHex(hash, 0, SHA_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, ret);
 #else
@@ -504,8 +508,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha224_native_1update_1interna
 
     LogStr("wc_Sha224Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     (void)env;
@@ -592,8 +596,11 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha224_native_1final_1internal
     }
 
     LogStr("wc_Sha224Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA224_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA224_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA224_DIGEST_SIZE,
+            hash + position);
+        LogHex(hash, position, SHA224_DIGEST_SIZE);
+    }
 #else
     (void)env;
     (void)this;
@@ -631,8 +638,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha224_native_1final_1internal
     }
 
     LogStr("wc_Sha224Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA224_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA224_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA224_DIGEST_SIZE, hash);
+        LogHex(hash, 0, SHA224_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, ret);
 #else
@@ -734,8 +743,8 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal__Ljava_nio_ByteBuffer
 
     LogStr("wc_Sha256Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     throwNotCompiledInException(env);
@@ -776,8 +785,8 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1update_1internal___3BII(
 
     LogStr("wc_Sha256Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + offset);
+        LogHex(data, offset, len);
     }
 
     releaseByteArray(env, data_buffer, data, JNI_ABORT);
@@ -811,8 +820,11 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal__Ljava_nio_ByteBuffer_
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha256Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA256_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE,
+            hash + position);
+        LogHex(hash, position, SHA256_DIGEST_SIZE);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -843,8 +855,10 @@ Java_com_wolfssl_wolfcrypt_Sha256_native_1final_1internal___3B(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha256Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA256_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA256_DIGEST_SIZE, hash);
+        LogHex(hash, 0, SHA256_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, ret);
 #else
@@ -941,8 +955,8 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1update_1internal__Ljava_nio_ByteBuffer
 
     LogStr("wc_Sha384Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     throwNotCompiledInException(env);
@@ -1017,8 +1031,11 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal__Ljava_nio_ByteBuffer_
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha384Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA384_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE,
+            hash + position);
+        LogHex(hash, position, SHA384_DIGEST_SIZE);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -1049,8 +1066,10 @@ Java_com_wolfssl_wolfcrypt_Sha384_native_1final_1internal___3B(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha384Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA384_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA384_DIGEST_SIZE, hash);
+        LogHex(hash, 0, SHA384_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, ret);
 #else
@@ -1147,8 +1166,8 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1update_1internal__Ljava_nio_ByteBuffer
 
     LogStr("wc_Sha512Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + position);
+        LogHex(data, position, len);
     }
 #else
     throwNotCompiledInException(env);
@@ -1224,8 +1243,11 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal__Ljava_nio_ByteBuffer_
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha512Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA512_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE,
+            hash + position);
+        LogHex(hash, position, SHA512_DIGEST_SIZE);
+    }
 #else
     throwNotCompiledInException(env);
 #endif
@@ -1256,8 +1278,10 @@ Java_com_wolfssl_wolfcrypt_Sha512_native_1final_1internal___3B(
         throwWolfCryptExceptionFromError(env, ret);
 
     LogStr("wc_Sha512Final(sha=%p, hash) = %d\n", sha, ret);
-    LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE, hash);
-    LogHex(hash, 0, SHA512_DIGEST_SIZE);
+    if (hash != NULL) {
+        LogStr("hash[%u]: [%p]\n", (word32)SHA512_DIGEST_SIZE, hash);
+        LogHex(hash, 0, SHA512_DIGEST_SIZE);
+    }
 
     releaseByteArray(env, hash_buffer, hash, ret);
 #else
@@ -1438,8 +1462,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha3_native_1update_1internal_
 
     LogStr("wc_Sha3_Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
-        LogHex(data, 0, len);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + offset);
+        LogHex(data, offset, len);
     }
 #else
     (void)env;
@@ -1501,7 +1525,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_wolfcrypt_Sha3_native_1update_1internal_
 
     LogStr("wc_Sha3_Update(sha=%p, data, len) = %d\n", sha, ret);
     if (ret == 0) {
-        LogStr("data[%u]: [%p]\n", (word32)len, data);
+        LogStr("data[%u]: [%p]\n", (word32)len, data + offset);
         LogHex(data, offset, len);
     }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptMessageDigestSha3.java
@@ -138,7 +138,7 @@ public class WolfCryptMessageDigestSha3
     }
 
     /**
-     * wolfJCE SHA1wECDSA message digest class
+     * wolfJCE SHA3-224 message digest class
      */
     public static final class wcSHA3_224 extends WolfCryptMessageDigestSha3 {
         /**

--- a/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Chacha.java
@@ -57,14 +57,17 @@ public class Chacha extends NativeStruct {
     private native byte[] wc_Chacha_process(byte in[]);
     private native void wc_Chacha_setKey(byte[] Key);
     private native void wc_Chacha_setIV(byte[] IV);
+    private native void native_free();
 
     @Override
     public synchronized void releaseNativeStruct() {
-        /* No native ChaCha free API, so just release NativeStruct */
         synchronized (stateLock) {
             if ((state != WolfCryptState.UNINITIALIZED) &&
                 (state != WolfCryptState.RELEASED)) {
-                super.releaseNativeStruct();
+                synchronized (pointerLock) {
+                    native_free();
+                    super.releaseNativeStruct();
+                }
                 state = WolfCryptState.RELEASED;
             }
         }

--- a/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/Hmac.java
@@ -126,6 +126,8 @@ public class Hmac extends NativeStruct {
      */
     protected native long mallocNativeStruct() throws OutOfMemoryError;
 
+    private native void native_free();
+
     /**
      * Check if type is -1, if so that type is not compiled in at native
      * wolfSSL level.
@@ -220,6 +222,9 @@ public class Hmac extends NativeStruct {
     @Override
     public synchronized void releaseNativeStruct() {
         synchronized (pointerLock) {
+            if (getNativeStruct() != NativeStruct.NULL) {
+                native_free();
+            }
             super.releaseNativeStruct();
         }
     }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptUtilTest.java
@@ -508,7 +508,8 @@ public class WolfCryptUtilTest {
     }
 
     /**
-     * Test converting WKS to WKS (should return same InputStream)
+     * Test converting WKS to a newly serialized WKS InputStream while
+     * preserving all entries
      */
     @Test
     public void testConvertWksToWks() throws Exception {

--- a/src/test/java/com/wolfssl/wolfcrypt/test/AesCtsTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/AesCtsTest.java
@@ -123,6 +123,20 @@ public class AesCtsTest {
             /* test must throw */
         }
 
+        try {
+            aesCts.setKey(KEY_128, new byte[8], AesCts.ENCRYPT_MODE);
+            fail("iv shorter than one AES block should be rejected.");
+        } catch (WolfCryptException e) {
+            /* test must throw */
+        }
+
+        try {
+            aesCts.setKey(KEY_128, new byte[24], AesCts.ENCRYPT_MODE);
+            fail("iv longer than one AES block should be rejected.");
+        } catch (WolfCryptException e) {
+            /* test must throw */
+        }
+
         aesCts.setKey(KEY_128, IV, AesCts.ENCRYPT_MODE);
         aesCts.releaseNativeStruct();
 

--- a/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
+++ b/src/test/java/com/wolfssl/wolfcrypt/test/HmacTest.java
@@ -71,6 +71,43 @@ public class HmacTest {
     }
 
     @Test
+    public void hmacReleaseLifecycle() {
+        byte[] key = new byte[32];
+        byte[] data = new byte[64];
+
+        try {
+            /* Release before any setKey() must be a safe no-op */
+            Hmac unused = new Hmac();
+            unused.releaseNativeStruct();
+
+            /* Release after use, then re-key and produce the same MAC */
+            Hmac hmac = new Hmac();
+            hmac.setKey(Hmac.SHA256, key);
+            hmac.update(data);
+            byte[] mac1 = hmac.doFinal();
+
+            hmac.releaseNativeStruct();
+
+            hmac.setKey(Hmac.SHA256, key);
+            hmac.update(data);
+            byte[] mac2 = hmac.doFinal();
+            assertArrayEquals("MAC after release and re-key must match",
+                mac1, mac2);
+
+            /* Double release must not crash */
+            hmac.releaseNativeStruct();
+            hmac.releaseNativeStruct();
+        } catch (WolfCryptException e) {
+            if (e.getError() == WolfCryptError.NOT_COMPILED_IN) {
+                System.out.println("Hmac release test skipped: " +
+                    e.getError());
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Test
     public void shaHmacShouldMatch() {
         String[] keyVector = new String[] {
                 "fd42f5044e3f70825102017f8521",


### PR DESCRIPTION
This PR includes ten Fenrir fixes:

  - **F-3563**: Zeroize Hmac/ChaCha native structs on release.
  - **F-3769**: Log the written output region in the AesCtr ByteBuffer update debug output.
  - **F-3996**: Require an IV of exactly one AES block in AesCts key setup, rejecting short and long IVs.
  - **F-6156**: Avoid XMALLOC(0) on the AAD-only AES-GCM/CCM paths by allocating at least one byte.
  - **F-9327**: Correct the wcSHA3_224 class javadoc label from SHA1wECDSA to SHA3-224.
  - **F-9328**: Fix the stale testConvertWksToWks comment that claimed stream identity.
  - **F-9997**: Add an explicit non-blinding arm to the wc_RsaSetRNG JNI wrapper.
  - **F-11207**: Log the processed region in the MD5 ByteBuffer update/final debug output.
  - **F-11208**: Log the processed region in the SHA ByteBuffer update/final debug output.
  - **F-11209**: Log the generated region in the RNG debug output.