### PR TITLE
Hardening for AES-CCM sizing/nonce, DH params, PBKDF2 translate, CertPathBuilder floor

### DIFF
--- a/jni/jni_wolfssl_x509_store_ctx.c
+++ b/jni/jni_wolfssl_x509_store_ctx.c
@@ -41,13 +41,11 @@
 #include <wolfcrypt_jni_debug.h>
 
 /* Check if CertPathBuilder feature is available.
- * CertPathBuilder requires wolfSSL >= 5.8.0 for proper X509_STORE chain
- * building support. Older versions have issues with reference counting
- * and chain building. */
+ * CertPathBuilder requires wolfSSL >= 5.9.2. Older versions have issues
+ * with reference counting and chain building. */
 static int isCertPathBuilderAvailable(void)
 {
-#if defined(OPENSSL_EXTRA) && \
-    (LIBWOLFSSL_VERSION_HEX >= 0x05008000)
+#if defined(OPENSSL_EXTRA) && (LIBWOLFSSL_VERSION_HEX >= 0x05009002)
     return 1;
 #else
     return 0;
@@ -137,7 +135,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_wolfcrypt_WolfSSLX509StoreCtx_wolfSSL_1
     (void)jcl;
 
     if (!isCertPathBuilderAvailable()) {
-        LogStr("CertPathBuilder requires wolfSSL >= 5.8.0\n");
+        LogStr("CertPathBuilder requires wolfSSL >= 5.9.2\n");
         return 0;
     }
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -150,8 +150,18 @@ public class WolfCryptCipher extends CipherSpi {
     private AlgorithmParameterSpec storedSpec = null;
     private byte[] iv = null;
 
+    /* Default AEAD (AES-GCM/CCM) tag length in bytes (128 bits) */
+    private static final int AEAD_DEFAULT_TAG_LEN_SZ = 16;
+
     /* AES-GCM/CCM tag length (bytes), default to 128 bits */
-    private int gcmTagLen = 16;
+    private int gcmTagLen = AEAD_DEFAULT_TAG_LEN_SZ;
+
+    /* Native AES-CCM nonce length bounds (bytes) */
+    private static final int CCM_NONCE_MIN_SZ = 7;
+    private static final int CCM_NONCE_MAX_SZ = 13;
+
+    /* Nonce length generated for parameterless AES-CCM init (bytes). */
+    private static final int CCM_NONCE_GEN_SZ = 12;
 
     /* AAD data for AES-GCM/CCM, accumulated via engineUpdateAAD() */
     private ByteArrayOutputStream aadStream = null;
@@ -940,7 +950,15 @@ public class WolfCryptCipher extends CipherSpi {
 
         /* store IV, or generate random IV if not available */
         if (spec == null) {
-            this.iv = new byte[this.blockSize];
+            /* No parameters given, reset AEAD tag length to the default so
+             * shorter tag length from a previous init() is not reused */
+            this.gcmTagLen = AEAD_DEFAULT_TAG_LEN_SZ;
+
+            if (cipherMode == CipherMode.WC_CCM) {
+                this.iv = new byte[CCM_NONCE_GEN_SZ];
+            } else {
+                this.iv = new byte[this.blockSize];
+            }
 
             if (random != null) {
                 random.nextBytes(this.iv);
@@ -991,10 +1009,11 @@ public class WolfCryptCipher extends CipherSpi {
                         "AES-CCM nonce is null or 0 length");
                 }
 
-                /* CCM nonce length validation (7-15 bytes typical) */
-                if (ccmSpec.getIV().length < 7 || ccmSpec.getIV().length > 15) {
+                if (ccmSpec.getIV().length < CCM_NONCE_MIN_SZ ||
+                    ccmSpec.getIV().length > CCM_NONCE_MAX_SZ) {
                     throw new InvalidAlgorithmParameterException(
-                        "CCM nonce length must be 7-15 bytes, got: " +
+                        "CCM nonce length must be " + CCM_NONCE_MIN_SZ + "-" +
+                        CCM_NONCE_MAX_SZ + " bytes, got: " +
                         ccmSpec.getIV().length);
                 }
 
@@ -1909,9 +1928,10 @@ public class WolfCryptCipher extends CipherSpi {
                 /* Create appropriate ParameterSpec with the current IV to avoid
                  * generating a new random IV during reset */
                 AlgorithmParameterSpec currentIvSpec;
-                if (cipherMode == CipherMode.WC_GCM) {
-                    /* For GCM mode, create GCMParameterSpec with current
-                     * IV and tag length */
+                if (cipherMode == CipherMode.WC_GCM ||
+                    cipherMode == CipherMode.WC_CCM) {
+                    /* AES-GCM and AES-CCM both expect a GCMParameterSpec
+                     * carrying the current IV and tag length */
                     currentIvSpec = new GCMParameterSpec(
                         this.gcmTagLen * 8, this.iv.clone());
                 } else {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptCipher.java
@@ -716,8 +716,9 @@ public class WolfCryptCipher extends CipherSpi {
         switch (this.cipherType) {
             case WC_AES:
                 if (paddingType == PaddingType.WC_NONE) {
-                    if (cipherMode == CipherMode.WC_GCM) {
-                        /* In AES-GCM mode we append the authentication tag
+                    if (cipherMode == CipherMode.WC_GCM ||
+                        cipherMode == CipherMode.WC_CCM) {
+                        /* In AES-GCM or AES-CCM mode we append the auth tag
                          * to the end of ciphertext, When decrypting, output
                          * size will have it taken off. */
                         if (this.direction == OpMode.WC_ENCRYPT) {

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptDhParameters.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptDhParameters.java
@@ -66,16 +66,22 @@ public class WolfCryptDhParameters extends AlgorithmParametersSpi {
 
         int idx = 0;
         int seqLen = 0;
+        int seqEnd = 0;
         int pLen = 0;
         int gLen = 0;
+        int lLen = 0;
         byte[] pBytes = null;
         byte[] gBytes = null;
+        byte[] lBytes = null;
+        BigInteger lValue = null;
 
         /* Parse DER-encoded DH parameters. Doing basic DER parsing here
          * since wolfCrypt does not have DER parsing support for this
-         * encoded parameters format.
+         * encoded parameters format. The SEQUENCE must span the entire
+         * input, any trailing data is rejected.
          *
-         * Format: SEQUENCE { prime INTEGER, generator INTEGER } */
+         * Format: SEQUENCE { prime INTEGER, generator INTEGER,
+         *                    privateValueLength INTEGER OPTIONAL } */
         try {
             /* Check SEQUENCE tag */
             if (params[idx++] != 0x30) {
@@ -90,7 +96,13 @@ public class WolfCryptDhParameters extends AlgorithmParametersSpi {
                 throw new IOException(
                     "Invalid DH parameters: bad SEQUENCE length: " + seqLen);
             }
-            int seqEnd = idx + seqLen;
+            seqEnd = idx + seqLen;
+
+            /* SEQUENCE must span the entire input, reject any trailing data */
+            if (seqEnd != params.length) {
+                throw new IOException(
+                    "Invalid DH parameters: trailing data after SEQUENCE");
+            }
 
             /* Decode prime (p) INTEGER */
             if (idx >= seqEnd || params[idx++] != 0x02) {
@@ -124,8 +136,40 @@ public class WolfCryptDhParameters extends AlgorithmParametersSpi {
             idx += gLen;
             this.g = new BigInteger(1, gBytes);
 
-            /* Private value length not encoded in standard DH params */
-            this.l = 0;
+            /* Decode optional private-value length (l) INTEGER, if present. */
+            if (idx < seqEnd) {
+                if (params[idx++] != 0x02) {
+                    throw new IOException(
+                        "Invalid DH parameters: expected INTEGER tag for l");
+                }
+                lLen = WolfCryptASN1Util.getDERLength(params, idx);
+                idx += WolfCryptASN1Util.getDERLengthSize(params, idx);
+                if (lLen <= 0 || lLen > (seqEnd - idx)) {
+                    throw new IOException(
+                        "Invalid DH parameters: bad length for l: " + lLen);
+                }
+                lBytes = new byte[lLen];
+                System.arraycopy(params, idx, lBytes, 0, lLen);
+                idx += lLen;
+                lValue = new BigInteger(1, lBytes);
+                this.l = lValue.intValue();
+                /* Reject a value that does not fit in a Java int */
+                if (!BigInteger.valueOf(this.l).equals(lValue)) {
+                    throw new IOException(
+                        "Invalid DH parameters: private value length too big");
+                }
+            }
+            else {
+                /* Private value length is optional and absent */
+                this.l = 0;
+            }
+
+            /* Reject any trailing data inside the SEQUENCE */
+            if (idx != seqEnd) {
+                throw new IOException(
+                    "Invalid DH parameters: unexpected trailing data " +
+                    "in SEQUENCE");
+            }
 
         } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
             throw new IOException("Invalid DH parameters encoding: " +
@@ -194,7 +238,8 @@ public class WolfCryptDhParameters extends AlgorithmParametersSpi {
             byte[] pBytes = this.p.toByteArray();
             byte[] gBytes = this.g.toByteArray();
 
-            /* Encode as ASN.1 SEQUENCE { prime, generator } */
+            /* Encode as ASN.1 SEQUENCE { prime, generator,
+             * privateValueLength OPTIONAL } */
             ByteArrayOutputStream seq = new ByteArrayOutputStream();
 
             /* Encode p as INTEGER */
@@ -206,6 +251,12 @@ public class WolfCryptDhParameters extends AlgorithmParametersSpi {
             seq.write(0x02); /* INTEGER tag */
             seq.write(WolfCryptASN1Util.encodeDERLength(gBytes.length));
             seq.write(gBytes);
+
+            /* Encode optional private-value length (l) as the third INTEGER */
+            if (this.l > 0) {
+                seq.write(WolfCryptASN1Util.encodeDERInteger(
+                    BigInteger.valueOf(this.l)));
+            }
 
             byte[] seqBytes = seq.toByteArray();
 

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptProvider.java
@@ -947,7 +947,7 @@ public final class WolfCryptProvider extends Provider {
         put("CertPathValidator.PKIX",
                 "com.wolfssl.provider.jce.WolfCryptPKIXCertPathValidator");
 
-        /* CertPathBuilder requires wolfSSL 5.8.0 or later */
+        /* CertPathBuilder requires wolfSSL 5.9.2 or later */
         if (WolfSSLX509StoreCtx.isSupported()) {
             put("CertPathBuilder.PKIX",
                     "com.wolfssl.provider.jce.WolfCryptPKIXCertPathBuilder");

--- a/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
+++ b/src/main/java/com/wolfssl/provider/jce/WolfCryptSecretKeyFactory.java
@@ -655,9 +655,12 @@ public class WolfCryptSecretKeyFactory extends SecretKeyFactorySpi {
 
         if (key != null) {
 
-            if (!isAlgorithmSupported(key.getAlgorithm())) {
-                throw new InvalidKeyException(
-                    "SecretKey algorithm not supported: " + key.getAlgorithm());
+            /* Require the source key algorithm to match this factory. */
+            String keyAlgo = key.getAlgorithm();
+            if (keyAlgo == null || !keyAlgo.equalsIgnoreCase(this.typeString)) {
+                throw new InvalidKeyException("PBEKey algorithm " + keyAlgo +
+                    " does not match this SecretKeyFactory algorithm " +
+                    this.typeString);
             }
 
             try {

--- a/src/main/java/com/wolfssl/wolfcrypt/WolfSSLX509StoreCtx.java
+++ b/src/main/java/com/wolfssl/wolfcrypt/WolfSSLX509StoreCtx.java
@@ -69,8 +69,8 @@ public class WolfSSLX509StoreCtx implements AutoCloseable {
     /**
      * Check if CertPathBuilder functionality is supported.
      *
-     * CertPathBuilder requires wolfSSL version 5.8.0 or later for proper
-     * X509_STORE chain building support.
+     * CertPathBuilder requires wolfSSL version 5.9.2 or later. Earlier
+     * versions have X509_STORE chain building issues.
      *
      * @return true if CertPathBuilder is supported, false otherwise
      */
@@ -119,11 +119,11 @@ public class WolfSSLX509StoreCtx implements AutoCloseable {
     /**
      * Create new WolfSSLX509StoreCtx object.
      *
-     * Requires wolfSSL version 5.8.0 or later for proper X509_STORE
+     * Requires wolfSSL version 5.9.2 or later for proper X509_STORE
      * chain building support.
      *
      * @throws WolfCryptException if unable to create native X509_STORE,
-     *         or if wolfSSL version is too old (requires 5.8.0+)
+     *         or if wolfSSL version is too old (requires 5.9.2+)
      */
     public WolfSSLX509StoreCtx() throws WolfCryptException {
 
@@ -131,7 +131,7 @@ public class WolfSSLX509StoreCtx implements AutoCloseable {
         if (storePtr == 0) {
             throw new WolfCryptException(
                 "Failed to create native WOLFSSL_X509_STORE. " +
-                "CertPathBuilder requires wolfSSL 5.8.0 or later.");
+                "CertPathBuilder requires wolfSSL 5.9.2 or later.");
         }
         this.active = true;
     }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptAlgorithmParametersTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.Description;
 import org.junit.Test;
 import org.junit.BeforeClass;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.Security;
@@ -642,10 +643,10 @@ public class WolfCryptAlgorithmParametersTest {
             return;
         }
 
-        /* Test multiple round trips: spec -> params -> encoded ->
-         * params -> spec.
-         * NOTE: The 'l' parameter is not preserved through encoding/decoding
-         * since standard DH ASN.1 encoding only includes p and g. */
+        /* Test multiple round trips: spec->params->encoded->params->spec.
+         * This spec has no private-value length, so only p and g are encoded.
+         * Preservation of a nonzero 'l' is covered by
+         * testDHParametersEncodingPreservesL. */
         BigInteger p = new BigInteger(
             "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
             "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
@@ -690,6 +691,201 @@ public class WolfCryptAlgorithmParametersTest {
 
         /* Verify encodings are identical */
         assertTrue(Arrays.equals(encoded1, encoded2));
+    }
+
+    @Test
+    public void testDHParametersEncodingPreservesL()
+        throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        BigInteger p = new BigInteger(
+            "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
+            "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
+            "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
+            "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED" +
+            "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D" +
+            "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F" +
+            "83655D23DCA3AD961C62F356208552BB9ED529077096966D" +
+            "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B" +
+            "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9" +
+            "DE2BCBF6955817183995497CEA956AE515D2261898FA0510" +
+            "15728E5A8AACAA68FFFFFFFFFFFFFFFF", 16);
+        BigInteger g = BigInteger.valueOf(2);
+        int l = 256;
+
+        /* A nonzero private-value length must survive encode->decode as the
+         * optional third PKCS#3 INTEGER, otherwise the params change on
+         * round trip. */
+        DHParameterSpec spec = new DHParameterSpec(p, g, l);
+
+        AlgorithmParameters params1 =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        params1.init(spec);
+        byte[] encoded = params1.getEncoded();
+
+        AlgorithmParameters params2 =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        params2.init(encoded);
+
+        DHParameterSpec decodedSpec =
+            params2.getParameterSpec(DHParameterSpec.class);
+        assertEquals(p, decodedSpec.getP());
+        assertEquals(g, decodedSpec.getG());
+        assertEquals(l, decodedSpec.getL());
+
+        /* Re-encoding the decoded parameters must reproduce identical DER */
+        assertTrue(Arrays.equals(encoded, params2.getEncoded()));
+
+        /* A spec with l == 0 must not emit the optional INTEGER, so it stays
+         * shorter than the same p and g with a nonzero l */
+        AlgorithmParameters paramsNoL =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        paramsNoL.init(new DHParameterSpec(p, g));
+        assertTrue("Encoding with l should be longer than without",
+            encoded.length > paramsNoL.getEncoded().length);
+    }
+
+    @Test
+    public void testDHParametersInitRejectsTrailingData()
+        throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        BigInteger p = new BigInteger(
+            "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
+            "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
+            "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
+            "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED" +
+            "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D" +
+            "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F" +
+            "83655D23DCA3AD961C62F356208552BB9ED529077096966D" +
+            "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B" +
+            "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9" +
+            "DE2BCBF6955817183995497CEA956AE515D2261898FA0510" +
+            "15728E5A8AACAA68FFFFFFFFFFFFFFFF", 16);
+        BigInteger g = BigInteger.valueOf(2);
+
+        AlgorithmParameters params1 =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        params1.init(new DHParameterSpec(p, g));
+        byte[] encoded = params1.getEncoded();
+
+        /* Append a trailing byte after the declared SEQUENCE */
+        byte[] withTrailing = Arrays.copyOf(encoded, encoded.length + 1);
+
+        AlgorithmParameters params2 =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        try {
+            params2.init(withTrailing);
+            fail("AlgorithmParameters.init should reject trailing data " +
+                 "after the DH SEQUENCE");
+        } catch (IOException e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testDHParametersInitRejectsNonIntegerThirdElement()
+        throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        /* SEQUENCE { INTEGER 5, INTEGER 2, OCTET STRING } - the optional
+         * third element must be an INTEGER (0x02), an OCTET STRING (0x04)
+         * tag must be rejected */
+        byte[] der = new byte[] {
+            0x30, 0x09,
+            0x02, 0x01, 0x05,
+            0x02, 0x01, 0x02,
+            0x04, 0x01, 0x08
+        };
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        try {
+            params.init(der);
+            fail("init should reject a non-INTEGER third element");
+        } catch (IOException e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testDHParametersInitRejectsOversizedPrivateValueLength()
+        throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        /* SEQUENCE { INTEGER 5, INTEGER 2, INTEGER (32-byte value) }. A
+         * 32-byte third INTEGER does not fit in a Java int, so it must be
+         * rejected rather than silently truncated. */
+        ByteArrayOutputStream contents = new ByteArrayOutputStream();
+        contents.write(new byte[] { 0x02, 0x01, 0x05 }); /* p = 5 */
+        contents.write(new byte[] { 0x02, 0x01, 0x02 }); /* g = 2 */
+        contents.write(0x02);                            /* INTEGER tag */
+        contents.write(0x20);                            /* length 32 */
+        byte[] big = new byte[32];
+        Arrays.fill(big, (byte) 0x01);
+        contents.write(big);
+
+        byte[] body = contents.toByteArray();
+        ByteArrayOutputStream der = new ByteArrayOutputStream();
+        der.write(0x30);
+        der.write(body.length);
+        der.write(body);
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        try {
+            params.init(der.toByteArray());
+            fail("init should reject a private-value length that overflows " +
+                 "a Java int");
+        } catch (IOException e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testDHParametersInitRejectsFourthElement()
+        throws Exception {
+
+        /* skip test if DH is not compiled in native wolfSSL */
+        if (!FeatureDetect.DhEnabled()) {
+            return;
+        }
+
+        /* SEQUENCE { INTEGER 5, INTEGER 2, INTEGER 8, INTEGER 9 }. PKCS#3
+         * defines at most three elements, so a fourth element is trailing
+         * data inside the SEQUENCE and must be rejected. */
+        byte[] der = new byte[] {
+            0x30, 0x0C,
+            0x02, 0x01, 0x05,
+            0x02, 0x01, 0x02,
+            0x02, 0x01, 0x08,
+            0x02, 0x01, 0x09
+        };
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("DH", "wolfJCE");
+        try {
+            params.init(der);
+            fail("init should reject a fourth element inside the SEQUENCE");
+        } catch (IOException e) {
+            /* expected */
+        }
     }
 
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -6148,31 +6148,139 @@ public class WolfCryptCipherTest {
                            e.getMessage().contains("nonce length"));
             }
 
-            /* Test nonce too long (16 bytes) */
-            byte[] longNonce = new byte[Aes.BLOCK_SIZE];
-            GCMParameterSpec longSpec = new GCMParameterSpec(128, longNonce);
+            /* Test nonce too long. The native layer only accepts a 7-13 byte
+             * nonce, so 14 through 17 byte nonces must be rejected at init
+             * rather than deferring the failure to doFinal(). */
+            for (int len = 14; len <= 17; len++) {
+                byte[] longNonce = new byte[len];
+                GCMParameterSpec longSpec =
+                    new GCMParameterSpec(128, longNonce);
 
-            try {
-                cipher.init(Cipher.ENCRYPT_MODE, keySpec, longSpec);
-                fail("Should reject nonce longer than 15 bytes");
-            } catch (InvalidAlgorithmParameterException e) {
-                assertTrue("Error message should mention nonce length",
-                           e.getMessage().contains("nonce length"));
+                try {
+                    cipher.init(Cipher.ENCRYPT_MODE, keySpec, longSpec);
+                    fail("Should reject nonce longer than 13 bytes, got " +
+                        len);
+                } catch (InvalidAlgorithmParameterException e) {
+                    assertTrue("Error message should mention nonce length",
+                        e.getMessage().contains("nonce length"));
+                }
             }
 
-            /* Test valid nonce lengths (7-15 bytes) */
-            for (int len = 7; len <= (Aes.BLOCK_SIZE - 1); len++) {
+            /* Test valid nonce lengths (7-13 bytes) */
+            for (int len = 7; len <= 13; len++) {
                 byte[] validNonce = new byte[len];
                 GCMParameterSpec validSpec =
                     new GCMParameterSpec(128, validNonce);
 
-                /* Should not throw exception */
+                /* Should not throw exception at init, and encryption should
+                 * succeed instead of failing at doFinal() */
                 cipher.init(Cipher.ENCRYPT_MODE, keySpec, validSpec);
+                cipher.doFinal("CCM nonce length test".getBytes());
             }
 
         } catch (Exception e) {
             fail("Unexpected exception in nonce length validation: " +
                 e.getMessage());
+        }
+    }
+
+    /**
+     * Verify parameterless AES-CCM init generates a native-acceptable nonce.
+     * A blockSize (16) byte nonce would be rejected by the native layer, so
+     * encryption must succeed at doFinal() and the reset path must rebuild a
+     * GCMParameterSpec for the generated nonce.
+     */
+    @Test
+    public void testAesCcmParameterlessInit() throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/CCM/NoPadding")) {
+            /* algorithm not enabled */
+            return;
+        }
+
+        byte[] keyBytes = {
+            (byte)0x2b, (byte)0x7e, (byte)0x15, (byte)0x16,
+            (byte)0x28, (byte)0xae, (byte)0xd2, (byte)0xa6,
+            (byte)0xab, (byte)0xf7, (byte)0x15, (byte)0x88,
+            (byte)0x09, (byte)0xcf, (byte)0x4f, (byte)0x3c
+        };
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
+        byte[] plaintext = "CCM parameterless init test".getBytes();
+
+        /* Parameterless init generates a random nonce internally. This must
+         * be a valid CCM length so doFinal() succeeds instead of failing in
+         * the native layer. */
+        Cipher enc = Cipher.getInstance("AES/CCM/NoPadding", jceProvider);
+        enc.init(Cipher.ENCRYPT_MODE, key);
+        byte[] ciphertext = enc.doFinal(plaintext);
+
+        byte[] nonce = enc.getIV();
+        assertNotNull("CCM should expose a generated nonce", nonce);
+        assertTrue("Generated CCM nonce must be within 7-13 bytes, got " +
+            nonce.length, nonce.length >= 7 && nonce.length <= 13);
+
+        /* Roundtrip with the generated nonce. The first doFinal() above
+         * already exercised the auto-reset that runs at the end of an AEAD
+         * final, which for parameterless CCM must rebuild a GCMParameterSpec
+         * rather than an IvParameterSpec (wolfCryptSetIV() rejects the latter
+         * for CCM). If that reset path were broken the first doFinal() would
+         * have thrown, so no second encryption under the same nonce is done
+         * here. */
+        Cipher dec = Cipher.getInstance("AES/CCM/NoPadding", jceProvider);
+        dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+        assertArrayEquals("CCM parameterless roundtrip should match plaintext",
+            plaintext, dec.doFinal(ciphertext));
+    }
+
+    /**
+     * Verify parameterless AEAD init resets the tag length to the 128-bit
+     * default rather than carrying over a shorter tag length set by a previous
+     * init() on the same Cipher object.
+     */
+    @Test
+    public void testAesAeadParameterlessInitResetsTagLength()
+        throws Exception {
+
+        byte[] keyBytes = new byte[16];
+        java.util.Arrays.fill(keyBytes, (byte) 0x01);
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
+
+        byte[] nonce = new byte[12];
+        java.util.Arrays.fill(nonce, (byte) 0x02);
+        byte[] plaintext = new byte[10];
+
+        if (enabledJCEAlgos.contains("AES/CCM/NoPadding")) {
+            Cipher ccm = Cipher.getInstance("AES/CCM/NoPadding", jceProvider);
+
+            /* First init with a 64-bit (8-byte) tag */
+            ccm.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(64, nonce));
+            assertEquals("Short tag should be in effect after explicit init",
+                10 + 8, ccm.getOutputSize(10));
+
+            /* Re-init parameterless, tag length must reset to 16 bytes */
+            ccm.init(Cipher.ENCRYPT_MODE, key);
+            assertEquals("Parameterless init should reset CCM tag to 16 bytes",
+                10 + 16, ccm.getOutputSize(10));
+            byte[] ct = ccm.doFinal(plaintext);
+            assertEquals("Parameterless CCM should produce a 16-byte tag",
+                plaintext.length + 16, ct.length);
+        }
+
+        if (enabledJCEAlgos.contains("AES/GCM/NoPadding")) {
+            Cipher gcm = Cipher.getInstance("AES/GCM/NoPadding", jceProvider);
+
+            /* First init with a 64-bit (8-byte) tag */
+            gcm.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(64, nonce));
+            assertEquals("Short tag should be in effect after explicit init",
+                10 + 8, gcm.getOutputSize(10));
+
+            /* Re-init parameterless, tag length must reset to 16 bytes */
+            gcm.init(Cipher.ENCRYPT_MODE, key);
+            assertEquals("Parameterless init should reset GCM tag to 16 bytes",
+                10 + 16, gcm.getOutputSize(10));
+            byte[] ct = gcm.doFinal(plaintext);
+            assertEquals("Parameterless GCM should produce a 16-byte tag",
+                plaintext.length + 16, ct.length);
         }
     }
 

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptCipherTest.java
@@ -2939,6 +2939,91 @@ public class WolfCryptCipherTest {
     }
 
     /**
+     * Test Cipher("AES/CCM/NoPadding") getOutputSize() method for various
+     * use cases. AES-CCM appends the auth tag on encryption and strips it on
+     * decryption (same as AES-GCM), so getOutputSize() must account for tag
+     * in both directions.
+     */
+    @Test
+    public void testAesCcmGetOutputSize() throws Exception {
+
+        if (!enabledJCEAlgos.contains("AES/CCM/NoPadding")) {
+            /* skip if AES-CCM is not enabled */
+            return;
+        }
+
+        final int TAG_LENGTH_BYTES = 16;  /* Default tag length */
+        final int KEY_LENGTH_BYTES = 16;  /* 128-bit AES key */
+        final int NONCE_LENGTH_BYTES = 12;
+
+        /* Fill key and nonce with non-zero values */
+        byte[] keyBytes = new byte[KEY_LENGTH_BYTES];
+        java.util.Arrays.fill(keyBytes, (byte) 0x01);
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
+
+        byte[] nonce = new byte[NONCE_LENGTH_BYTES];
+        java.util.Arrays.fill(nonce, (byte) 0x02);
+        GCMParameterSpec spec = new GCMParameterSpec(TAG_LENGTH_BYTES * 8,
+            nonce);
+
+        Cipher cipher = Cipher.getInstance("AES/CCM/NoPadding", jceProvider);
+
+        /* Test ENCRYPT with zero-length input */
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+        assertEquals("Output size for zero-length input should be tag length",
+            TAG_LENGTH_BYTES, cipher.getOutputSize(0));
+
+        /* Test ENCRYPT with small input */
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+        assertEquals("Output size should be input length plus tag length",
+            10 + TAG_LENGTH_BYTES, cipher.getOutputSize(10));
+
+        /* Test ENCRYPT with block boundary input */
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+        assertEquals("Output size should be input length plus tag length " +
+            "at block boundary", 16 + TAG_LENGTH_BYTES,
+            cipher.getOutputSize(16));
+
+        /* Test DECRYPT with tag included */
+        cipher.init(Cipher.DECRYPT_MODE, key, spec);
+        assertEquals("Output size for decryption should be input length " +
+            "minus tag length", 10,
+            cipher.getOutputSize(10 + TAG_LENGTH_BYTES));
+
+        /* Test ENCRYPT after partial update */
+        byte[] partialInput = new byte[5];
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+        cipher.update(partialInput); /* Process some data */
+        assertEquals("Output size after update should account for remaining " +
+            "input plus tag", 16 + TAG_LENGTH_BYTES, cipher.getOutputSize(11));
+
+        /* Test with a non-default (64-bit) tag length to confirm the tag
+         * accounting uses the requested tag size in both directions */
+        final int SHORT_TAG_BYTES = 8;
+        GCMParameterSpec shortTagSpec =
+            new GCMParameterSpec(SHORT_TAG_BYTES * 8, nonce);
+
+        cipher.init(Cipher.ENCRYPT_MODE, key, shortTagSpec);
+        assertEquals("Output size should be input length plus 8-byte tag",
+            10 + SHORT_TAG_BYTES, cipher.getOutputSize(10));
+
+        cipher.init(Cipher.DECRYPT_MODE, key, shortTagSpec);
+        assertEquals("Output size for decryption should be input length " +
+            "minus 8-byte tag", 10,
+            cipher.getOutputSize(10 + SHORT_TAG_BYTES));
+
+        /* Test getOutputSize() before initialization, expect exception */
+        Cipher uninitializedCipher =
+            Cipher.getInstance("AES/CCM/NoPadding", jceProvider);
+        try {
+            uninitializedCipher.getOutputSize(10);
+            fail("Expected IllegalStateException for uninitialized cipher");
+        } catch (IllegalStateException e) {
+            /* Expected exception */
+        }
+    }
+
+    /**
      * Verify that getOutputSize() in DECRYPT mode does not add pad bytes.
      */
     @Test

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathBuilderTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptPKIXCertPathBuilderTest.java
@@ -348,7 +348,7 @@ public class WolfCryptPKIXCertPathBuilderTest {
     @Rule(order = Integer.MIN_VALUE)
     public TestRule testWatcher = TimedTestWatcher.create();
 
-    /* Rule to check if CertPathBuilder is supported (requires wolfSSL 5.8.0+),
+    /* Rule to check if CertPathBuilder is supported (requires wolfSSL 5.9.2+),
      * skips tests if not. */
     @Rule(order = Integer.MIN_VALUE + 1)
     public TestRule certPathBuilderSupported = new TestRule() {
@@ -357,7 +357,7 @@ public class WolfCryptPKIXCertPathBuilderTest {
             return new Statement() {
                 @Override
                 public void evaluate() throws Throwable {
-                    Assume.assumeTrue("CertPathBuilder requires wolfSSL 5.8.0+",
+                    Assume.assumeTrue("CertPathBuilder requires wolfSSL 5.9.2+",
                         WolfSSLX509StoreCtx.isSupported());
                     base.evaluate();
                 }

--- a/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
+++ b/src/test/java/com/wolfssl/provider/jce/test/WolfCryptSecretKeyFactoryTest.java
@@ -938,6 +938,59 @@ public class WolfCryptSecretKeyFactoryTest {
     }
 
     /**
+     * Test that translateKey() rejects a PBKDF2 key whose PRF algorithm does
+     * not match this SecretKeyFactory.
+     */
+    @Test
+    public void testTranslateKeyRejectsMismatchedPRF()
+        throws NoSuchAlgorithmException, InvalidKeySpecException,
+               NoSuchProviderException, InvalidKeyException {
+
+        char[] pass = "passwordpassword".toCharArray();
+        byte[] salt = {
+            (byte)0x78, (byte)0x57, (byte)0x8E, (byte)0x5a,
+            (byte)0x5d, (byte)0x63, (byte)0xcb, (byte)0x06
+        };
+        int iterations = 2048;
+        int kLen = 192;
+
+        if (!FeatureDetect.Pbkdf2Enabled() ||
+            !FeatureDetect.HmacShaEnabled() ||
+            !FeatureDetect.HmacSha256Enabled() ||
+            !algoSupported("PBKDF2WithHmacSHA1") ||
+            !algoSupported("PBKDF2WithHmacSHA256")) {
+            /* skipped */
+            Assume.assumeTrue(false);
+        }
+
+        /* Generate a PBKDF2WithHmacSHA1 key with the wolfJCE provider */
+        SecretKeyFactory sha1Factory =
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", provider);
+        PBEKeySpec spec = new PBEKeySpec(pass, salt, iterations, kLen);
+        SecretKey sha1Key = sha1Factory.generateSecret(spec);
+        assertNotNull(sha1Key);
+        assertEquals("PBKDF2WithHmacSHA1", sha1Key.getAlgorithm());
+
+        /* Translating the SHA1 key through a SHA256 factory must be rejected
+         * rather than returning a re-derived SHA256 key */
+        SecretKeyFactory sha256Factory =
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
+        try {
+            sha256Factory.translateKey(sha1Key);
+            fail("translateKey should reject a mismatched PBKDF2 PRF");
+        } catch (InvalidKeyException e) {
+            /* expected */
+        }
+
+        /* Translating through a matching SHA1 factory must still succeed */
+        SecretKeyFactory sha1Factory2 =
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", provider);
+        SecretKey translated = sha1Factory2.translateKey(sha1Key);
+        assertNotNull(translated);
+        assertEquals("PBKDF2WithHmacSHA1", translated.getAlgorithm());
+    }
+
+    /**
      * Set up one SecretKeyFactory and KeySpec, then test parallel
      * threaded calls to generateSecret.
      */


### PR DESCRIPTION
This PR includes 5 Fenrir fixes:

  - **F-12161**: account for the AES-CCM auth tag in `Cipher.engineGetOutputSize()`, matching AES-GCM
  - **F-12162**: enforce the native 7-13 byte AES-CCM nonce limit at `init()`, generate a valid parameterless nonce, and reset AEAD tag length to the 128-bit default
  - **F-12163**: encode and decode the optional PKCS#3 DH `privateValueLength`, and reject trailing data
  - **F-12164**: reject a mismatched PRF in PBKDF2 `translateKey()` instead of silently re-deriving the key
  - **F-12188**: require wolfSSL 5.9.2 or later for the native X509 `CertPathBuilder` verifier